### PR TITLE
CASMCMS-7355: Change name from bos-reporter to bos-state-reporter

### DIFF
--- a/bos-reporter.spec
+++ b/bos-reporter.spec
@@ -79,7 +79,7 @@ rm -rf %{buildroot}
 %endif
 
 %post
-ln -f /usr/bin/spire-agent /usr/bin/bos-reporter-spire-agent
+ln -f /usr/bin/spire-agent /usr/bin/bos-state-reporter-spire-agent
 %if 0%{?suse_version}
 %service_add_post bos-reporter.service
 %else


### PR DESCRIPTION
## Summary and Scope

The bos-reporter-spire-agent's name was changed to
bos-state-reporter-spire-agent's because that is how I named it in the
OPA and Spire policies. The names all need to match, so I changed this
one.
## Issues and Related PRs

CASMCMS-7355

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

### Tested on:
Mug

### Test description:
This has been tested on Mug, which has a CSM-1.0 installation. I altered the OPA and Spire policies to let the bos-state-reporter through, and the BOS spire-agent on the compute node was able to get a JWT.


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

