### PR TITLE
Casmcms 7611 redis fix for 1.2

### DIFF
--- a/kubernetes/cray-bos/values.yaml.in
+++ b/kubernetes/cray-bos/values.yaml.in
@@ -13,7 +13,7 @@ boa_image:
 database:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis
-    tag: 5.0-alpine3.1
+    tag: 5.0-alpine3.12
 cray-service:
   type: Deployment
   nameOverride: cray-bos


### PR DESCRIPTION
## Fix BOS Redis DB image reference in values.yaml.in

This corrects the value used by the bos chart in order to allow for a correct reference to the associated reference image and brings parity with the chart's associated annotations.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves and updates CASMCMS-7611

### Tested on:

  * Local development environment
  * build servers
 
### Test description:

Built the associated helm chart, downloaded the contents and verified the fix is in place.
