### PR TITLE
Copy V1 session templates from etcd to V2's redis database

### DIFF
--- a/kubernetes/cray-bos/templates/clusterrolebinding.yaml
+++ b/kubernetes/cray-bos/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ include "cray-service.name" . }}-session-template-migration-psp"
+subjects:
+- kind: ServiceAccount
+  name: "{{ include "cray-service.name" . }}-session-template-migration"
+  namespace: "services"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: restricted-transition-net-raw-psp

--- a/kubernetes/cray-bos/templates/post-upgrade-job.yaml
+++ b/kubernetes/cray-bos/templates/post-upgrade-job.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name:  "{{ include "cray-service.name" . }}-session-template-migration"
+  labels:
+    app.kubernetes.io/managed-by: "{{ include "cray-service.name" . }}"
+    app.kubernetes.io/instance: "{{ include "cray-service.name" . }}"
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation 
+    
+
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ include "cray-service.name" . }}"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundPorts: "2379,2380,6379"
+    spec:
+      serviceAccountName: "{{ include "cray-service.name" . }}-session-template-migration"
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      
+      initContainers:
+      - name: cray-bos-wait-for-etcd
+        image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+        command:
+          - /bin/sh
+          - -c
+          - |
+            while true; do
+              JOB_CONDITION="$(kubectl get jobs -n services -l app.kubernetes.io/name=cray-bos-wait-for-etcd -o jsonpath='{.items[0].status.conditions[0].type}')"
+              JOB_CONDITION_RC=$?
+              if [ $JOB_CONDITION_RC -eq 0 ]; then
+                if [ "$JOB_CONDITION" == 'Complete' ]; then
+                  echo "Completed"
+                  break
+                fi
+                echo "Waiting for the cray-bos-wait-for-etcd job in the services namespace to complete, current condition is $(kubectl get jobs -n services -l app.kubernetes.io/name=cray-bos-wait-for-etcd -o jsonpath='{.items[0].status}')"
+                sleep 3
+              elif [ $JOB_CONDITION_RC -ne 1 ]; then
+                echo "'kubectl get jobs' failed with exit code $JOB_CONDITION_RC , failing"
+                exit 1
+              else
+                echo "'kubectl get jobs' failed with exit code $JOB_CONDITION_RC , will retry"
+              sleep 3
+              fi
+            done      
+      containers:
+      - name: v1-v2-session-template-migration  
+        image: {{ index .Values "cray-service" "containers" "cray-bos" "image" "repository" }}:{{ .Chart.AppVersion}}
+        command:
+          - python3
+          - "-m"
+          - "server.bos.v1_v2_migration"
+        env:
+        - name: PYTHONPATH
+          value: "/app/lib"

--- a/kubernetes/cray-bos/templates/role.yaml
+++ b/kubernetes/cray-bos/templates/role.yaml
@@ -21,3 +21,13 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["create", "delete", "get", "patch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ include "cray-service.name" . }}-session-template-migration"
+  namespace: services
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get","list"]

--- a/kubernetes/cray-bos/templates/rolebinding.yaml
+++ b/kubernetes/cray-bos/templates/rolebinding.yaml
@@ -24,3 +24,16 @@ subjects:
   - kind: ServiceAccount
     name: bos-service-launch-job
     namespace: services
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ include "cray-service.name" . }}-session-template-migration"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ include "cray-service.name" . }}-session-template-migration"
+subjects:
+  - kind: ServiceAccount
+    name: "{{ include "cray-service.name" . }}-session-template-migration"
+    namespace: services

--- a/kubernetes/cray-bos/templates/serviceaccount.yaml
+++ b/kubernetes/cray-bos/templates/serviceaccount.yaml
@@ -10,3 +10,9 @@ kind: ServiceAccount
 metadata:
   name: bos-service-launch-job
   namespace: services
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ include "cray-service.name" . }}-session-template-migration"
+  namespace: services

--- a/src/server/bos/v1_v2_migration.py
+++ b/src/server/bos/v1_v2_migration.py
@@ -1,0 +1,115 @@
+# Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+import json
+import logging
+import requests
+
+from server.bos.dbclient import BosEtcdClient
+from bos.operators.utils import requests_retry_session
+import server.bos.redis_db_utils as dbutils
+
+LOGGER = logging.getLogger('bos.v1_v2_migration')
+DB = dbutils.get_wrapper(db='session_templates')
+BASEKEY = "/sessionTemplate"
+
+PROTOCOL = 'http'
+SERVICE_NAME = 'cray-bos'
+ENDPOINT = "%s://%s/v2" % (PROTOCOL, SERVICE_NAME)
+
+
+def convert_v1_to_v2(v1_st):
+    """
+    Convert a v1 session template to a v2 session template.
+    Prune extraneous v1 attributes. 
+    
+    Input:
+      v1_st: A v1 session template
+    
+    Returns:
+      v2_st: A v2 session template
+    """
+    session_template_keys = ['templateUrl', 'name', 'description',
+                             'enable_cfs', 'cfs', 'partition',
+                             'boot_sets', 'links']
+    boot_set_keys = ['name', 'path', 'type', 'etag', 'kernel_parameters',
+                     'node_list', 'node_roles_groups', 'node_groups',
+                     'rootfs_provider', 'rootfs_provider_passthrough']
+
+    v2_st = {'boot_sets': {}}
+    for k, v in v1_st.items():
+        if k in session_template_keys:
+            if k != "boot_sets":
+                v2_st[k] = v
+        else:
+            LOGGER.warning("Discarding attribute: '{}' from session template: '{}'".format(k, v1_st['name']))
+
+    for boot_set, bs_values in v1_st['boot_sets'].items():
+        v2_st['boot_sets'][boot_set] = {}
+        for k, v in bs_values.items():
+            if k in boot_set_keys:
+                v2_st['boot_sets'][boot_set][k] = v
+            else:
+                LOGGER.warning("Discarding attribute: '{}' from boot set: '{}' from session template: '{}'".format(k,
+                                                                                                                  boot_set,
+                                                                                                                  v1_st['name']))
+    return v2_st
+
+
+def migrate_v1_to_v2_session_templates():
+    """
+    Read the session templates out of the V1 etcd key/value store and
+    write them into the v2 Redis database.
+    Do not overwrite existing session templates.
+    Sanitize the V1 session templates so they conform to the V2 session
+    template standards.
+    """
+    session = requests_retry_session()
+    with BosEtcdClient() as bec:
+        st_endpoint = "{}/sessiontemplates".format(ENDPOINT)
+        for session_template_byte_str, _meta in bec.get_prefix('{}/'.format(BASEKEY)):
+            v1_st = json.loads(session_template_byte_str.decode("utf-8"))
+            response = session.get("{}/{}".format(st_endpoint, v1_st['name']))
+            if response.status_code == 200:
+                LOGGER.warning("Session template: '{}' already exists. Not "
+                               "overwriting.".format(v1_st['name']))
+            elif response.status_code == 404:
+                LOGGER.info("Migrating v1 session template: '{}' to v2 "
+                            "database".format(v1_st['name']))
+                v2_st = convert_v1_to_v2(v1_st)
+                response = session.put("{}/{}".format(st_endpoint,
+                                                       v2_st['name']),
+                                                       json=v2_st)
+                if not response.ok:
+                    LOGGER.error("Session template: '{}' was not migrated due "
+                                 "to error: {}".format(v1_st['name'],
+                                                       response.reason))
+                    LOGGER.error("Error specifics: {}".format(response.text))
+            else:
+                LOGGER.error("Session template: '{}' was not migrated due "
+                                 "to error: {}".format(v1_st['name'],
+                                                       response.reason))
+                LOGGER.error("Error specifics: {}".format(response.text))
+
+
+if __name__ == "__main__":
+  migrate_v1_to_v2_session_templates()


### PR DESCRIPTION
## Summary and Scope

BOS V2 stores its session templates in a redis database. This mod
copies the existing V1 SessionTemplates from their storage in etcd to
redis. It copies them, but does not delete them from etcd. This
preserves the ability to rollback to the V1 release and retain access to
the session templates.

It contains a migration script that is run as a Helm hook on upgrade.
This migration script migrates BOS V1 session templates from the
V1 etcd database to the V2 redis database.

The V1 session templates are pruned, so that they only contain
content appropriate for a V2 session template.

Any V2 session templates that exist will not be overwritten during
migration. This allows migration to be done repeatedly without
risk of losing a V2 session template.

Because the migration job reads directly from etcd, it must wait
for those pods to be up before it runs.

## Issues and Related PRs

## Testing

### Tested on:
This was tested exhaustively on Wasp.

### Test description:
* The v1 session templates were migrated over to v2 templates. They were available in the Redis database.
* The v1 session templates did not overwrite a v2 template if one of the same name existed.
* Extraneous attributes were eliminated from the v1 session templates at both the top level and at the boot set level.

I installed via Loftsman. I saw that the Helm hook ran.

- Was upgrade tested? If not, why? Yes.

## Risks and Mitigations
Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

