### PR TITLE
CASMCMS-7760: Use boa v1.2

### DIFF
--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,8 +80,5 @@
 
 image: cray-boa
     major: 1
-    # We are deliberately using the csm-1.1 version of boa here. This is because we are not
-    # building boa 1.2 images, since boa is going away after 1.1. Its presence here is only
-    # temporary, until the changes to bos are made to remove it.
-    minor: 1
+    minor: 2
 


### PR DESCRIPTION
## Summary and Scope

The fix for [CASMCMS-7753](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7753) is incomplete for csm-1.2. Specifically, it fixed boa v1.2, but bos v1.10 points to boa v1.1 (which does not have the fix). This PR just updates bos v1.10 to point to boa v1.2, thus picking up this fix.

## Issues and Related PRs

[CASMCMS-7753](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7753)

## Testing

I tested this on surtur and validated that it resolves the boa bug blocking the barebones boot test.

## Risks and Mitigations

There may be risks with the fix for CASMCMS-7753 -- I didn't look into the details of the fix. But since its PR got approved I assume that whatever risks it entailed were deemed acceptable. This PR just makes the fix present in csm-1.2.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

