### PR TITLE
Casmcms 7794 csm 1.2

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -13,11 +13,15 @@ pipeline {
 
     environment {
         NAME = "cray-bos"
+        TEST_NAME = "cray-bos"
+        REPORTER_NAME = "bos-reporter"
         DESCRIPTION = "Cray Management System Boot Orchestration Service (BOS)"
         RPTR_SPEC_FILE = "bos-reporter.spec"
         TEST_SPEC_FILE = "bos-crayctldeploy-test.spec"
         IS_STABLE = getBuildIsStable()
         BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)
+        PUBLISH_SP2 = "sle-15sp2"
+        PUBLISH_SP3 = "sle-15sp3"        
     }
 
     stages {
@@ -64,13 +68,7 @@ pipeline {
             }
         }
 
-        stage("Prepare RPM Build") {
-            steps {
-                sh "make rpm_prepare"
-            }
-        }
-
-        stage("Build") {
+        stage("Build Image and Chart") {
             parallel {
                 stage('Image') {
                     environment {
@@ -94,25 +92,16 @@ pipeline {
                         sh "make chart"
                     }
                 }
-
-                stage('Reporter Rpm') {
-                    steps {
-                        sh "make rptr_rpm"
-                    }
-                }
-
-                stage('Test Rpm') {
-                    steps {
-                        sh "make test_rpm"
-                    }
-                }
-            }
-        }
+			}
+		}
 
         stage('Publish ') {
             parallel {
                 // I combine these two steps because if the image publish fails, we do not want to publish the chart
                 // referencing that image
+                // But we do publish the RPMs even if this fails. That was a practical matter of not being able to
+                // build the SP2 and SP3 rpms first (because the SP3 overwrites the SP2) and then publish them, so
+                // I just published them immediately after they are built.
                 stage('Image and Chart') {
                     environment {
                         DOCKER_VERSION = sh(returnStdout: true, script: "head -1 .docker_version").trim()
@@ -121,16 +110,85 @@ pipeline {
                         publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE)
                         publishCsmHelmCharts(component: env.NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", isStable: env.IS_STABLE)
                     }
-                }
-                
-                // Similar to the chart/image logic, if the main RPM publish fails, no reason to publish the source RPMs
-                stage('RPMs') {
-                    steps {
-                        publishCsmRpms(component: "bos", pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", arch: "x86_64", isStable: env.IS_STABLE)
-                        publishCsmRpms(component: "bos", pattern: "dist/rpmbuild/SRPMS/*.rpm", arch: "src", isStable: env.IS_STABLE)
-                    }
-                }
+                }                
             }
         }
+
+        stage("RPM Build Prepare") {
+        	steps {
+        		sh "make rpm_prepare"
+        	}
+        }
+		
+        stage("SP2 RPM Build") {
+	            agent {
+	                docker {
+	                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
+	                    reuseNode true
+	                    // Support docker in docker for clamav scan
+	                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
+	                }
+	            }
+	            steps {
+	                sh "make rptr_rpm_prepare"
+	                sh "make rptr_rpm"
+	            }
+		}
+
+        stage("SP2 RPM Publish") {
+	            steps {
+	                script {
+	                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: env.PUBLISH_SP2, arch: "x86_64", isStable: env.IS_STABLE)
+	                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP2, arch: "src", isStable: env.IS_STABLE)
+	                }
+	                sh "make rpm_build_clean"
+	                sh "make rpm_build_source_clean"
+	                
+	            }
+        }
+
+        stage("SP3 RPM Build") {
+	            agent {
+	                docker {
+	                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
+	                    reuseNode true
+	                    // Support docker in docker for clamav scan
+	                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
+	                }
+	            }
+	            steps {
+	                sh "make rptr_rpm_prepare"
+	                sh "make rptr_rpm"
+	            }
+		}
+
+        stage("SP3 RPM Publish") {
+	            steps {
+	                script {
+	                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: env.PUBLISH_SP3, arch: "x86_64", isStable: env.IS_STABLE)
+	                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP3, arch: "src", isStable: env.IS_STABLE)
+	                }
+	                sh "make rpm_build_clean"
+	                sh "make rpm_build_source_clean"
+	            }
+	     }
+		     
+		stage("Test RPM Build") {
+	        steps {
+	        	sh "make test_rpm_prepare"
+	            sh "make test_rpm"
+            }
+        }
+
+        stage("Test RPM Publish") {
+	            steps {
+	                script {
+	                    publishCsmRpms(component: env.TEST_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", arch: "x86_64", isStable: env.IS_STABLE)
+	                    publishCsmRpms(component: env.TEST_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", arch: "src", isStable: env.IS_STABLE)
+	                }
+	                sh "make rpm_build_clean"
+	                sh "make rpm_build_source_clean"
+	            }
+	     }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -85,15 +85,19 @@ lint:
 		./cms_meta_tools/scripts/runLint.sh
 
 rpm_prepare:
-		rm -rf $(RPTR_BUILD_DIR) $(TEST_BUILD_DIR)
-		mkdir -p $(RPTR_BUILD_DIR)/SPECS \
-				 $(RPTR_BUILD_DIR)/SOURCES \
-				 $(TEST_BUILD_DIR)/SPECS \
-				 $(TEST_BUILD_DIR)/SOURCES \
-				 $(RPM_IMAGE_DIR) \
+		mkdir -p $(RPM_IMAGE_DIR) \
 				 $(SRC_RPM_IMAGE_DIR)
-		cp $(RPTR_SPEC_FILE) $(RPTR_BUILD_DIR)/SPECS/
+test_rpm_prepare:
+		rm -rf $(TEST_BUILD_DIR)
+		mkdir -p $(TEST_BUILD_DIR)/SPECS \
+				 $(TEST_BUILD_DIR)/SOURCES
 		cp $(TEST_SPEC_FILE) $(TEST_BUILD_DIR)/SPECS/
+
+rptr_rpm_prepare:
+		rm -rf $(RPTR_BUILD_DIR)
+		mkdir -p $(RPTR_BUILD_DIR)/SPECS \
+				 $(RPTR_BUILD_DIR)/SOURCES
+		cp $(RPTR_SPEC_FILE) $(RPTR_BUILD_DIR)/SPECS/
 
 image:
 		docker build --pull ${DOCKER_ARGS} --tag '${NAME}:${DOCKER_VERSION}' .
@@ -125,6 +129,12 @@ test_rpm_package_source:
 			./${TEST_SPEC_FILE} \
 			./ct-tests \
 			./LICENSE
+
+rpm_build_clean:
+		rm -rf $(RPM_IMAGE_DIR)/*
+
+rpm_build_source_clean:
+		rm -rf $(SRC_RPM_IMAGE_DIR)/*
 
 test_rpm_build_source:
 		BUILD_METADATA=$(BUILD_METADATA) rpmbuild -vv -ts $(TEST_SOURCE_PATH) --define "_topdir $(TEST_BUILD_DIR)"

--- a/bos-reporter.spec.in
+++ b/bos-reporter.spec.in
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -41,6 +41,7 @@ Requires: cray-auth-utils
 %description
 Provides a systemd service and associated library that reports
 BOS' Boot Artifact ID for a node throughout its booted life.
+
 
 %{!?python3_sitelib: %define python3_sitelib %(/usr/bin/python3 -c "from distutils.sysconfig import get_python_lib ; print(get_python_lib())")}
 


### PR DESCRIPTION
## Summary and Scope

    Build the BOS rpms for the SLES15SP2 and SLES15SP3 distributions.
    The COS compute node images are SLES-based, so we need to build the
    rpm with the distribution environment.

    To prevent the accumulation of files from previous stages in the build,
    clean up the contents of the RPM build directories after publishing its
    contents. This does clean-up ahead of time, so that SLES15SP2 files are not
    included with SLES15SP3 files.

    Publish the Helm chart and Docker image ahead of the RPMs.
    This helps speed up development because developers are less interested in
    the RPM results.
## Issues and Related PRs
Resolves: CASMCMS-7802

## Testing

Build and Hela

### Tested on:
Hela

### Test description:

Test by building as well as downloading the rpms and installing them.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No, don't have any applicable.
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations
Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

