### PR TITLE
CASMCMS-7892

### DIFF
--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1138,12 +1138,13 @@ components:
         cleanup_completed_session_age:
           type: integer
           description: Delete complete sessions that are older than cleanup_completed_session_age (in seconds ago). 0 disables cleanup behavior.
+          minimum: 0
         disable_components_on_completion:
           type: boolean
           description: Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes. 
         discovery_frequency:
           type: integer
-          description: How frequently the BOS discovery agent syncs new components from HSM. (ins seconds)
+          description: How frequently the BOS discovery agent syncs new components from HSM. (in seconds)
         logging_level:
           type: string
           description: The logging level for all BOS services

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1135,10 +1135,9 @@ components:
         Options for the boot orchestration service.
       type: object
       properties:
-        cleanup_completed_session_age:
-          type: integer
-          description: Delete complete sessions that are older than cleanup_completed_session_age (in seconds ago). 0 disables cleanup behavior.
-          minimum: 0
+        cleanup_completed_session_ttl:
+          type: string
+          description: Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior.
         disable_components_on_completion:
           type: boolean
           description: Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes. 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1139,7 +1139,7 @@ components:
           type: integer
           description: Delete complete sessions that are older than cleanup_completed_session_age (in seconds ago). 0 disables cleanup behavior.
         disable_components_on_completion:
-          type: bool
+          type: boolean
           description: Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes. 
         discovery_frequency:
           type: integer

--- a/src/bos/operators/session_cleanup.py
+++ b/src/bos/operators/session_cleanup.py
@@ -94,7 +94,8 @@ class SessionCleanupOperator(BaseOperator):
                 # old age allowed; flag it for deletion.
                 sessions_to_delete.append({'name': session['name']})
         if sessions_to_delete:
-            LOGGER.info("Cleaning up %s completed session(s)." %(len(sessions_to_delete)))
+            LOGGER.info("Cleaning up completed session(s): "
+                        ', '.join(sorted([session['name'] for session in sessions_to_delete])))
             self.bos_client.sessions.delete_sessions(sessions_to_delete)
 
 if __name__ == '__main__':

--- a/src/bos/operators/session_cleanup.py
+++ b/src/bos/operators/session_cleanup.py
@@ -88,7 +88,7 @@ class SessionCleanupOperator(BaseOperator):
 
         for session in self.bos_client.sessions.get_sessions(status='complete'):
             session_end_time = load_timestamp(session['status']['end_time'])
-            print(session_end_time, self.max_age)
+            LOGGER.info(" ---> Comparison", session_end_time, self.max_age)
             if session_end_time < self.max_age:
                 # This completed session has an age "younger" than our maximum
                 # old age allowed; flag it for deletion.

--- a/src/bos/operators/session_cleanup.py
+++ b/src/bos/operators/session_cleanup.py
@@ -79,8 +79,8 @@ class SessionCleanupOperator(BaseOperator):
         sessions_to_delete = []
 
         # Obtain a new max age for deletion
-        options.update()
         self._max_age = None
+        options.update()
 
         # Exit early if configured so.
         if self.disabled:
@@ -88,6 +88,7 @@ class SessionCleanupOperator(BaseOperator):
 
         for session in self.bos_client.sessions.get_sessions(status='complete'):
             session_end_time = load_timestamp(session['status']['end_time'])
+            print(session_end_time, self.max_age)
             if session_end_time < self.max_age:
                 # This completed session has an age "younger" than our maximum
                 # old age allowed; flag it for deletion.

--- a/src/bos/operators/session_cleanup.py
+++ b/src/bos/operators/session_cleanup.py
@@ -88,7 +88,7 @@ class SessionCleanupOperator(BaseOperator):
 
         for session in self.bos_client.sessions.get_sessions(status='complete'):
             session_end_time = load_timestamp(session['status']['end_time'])
-            LOGGER.info(" ---> Comparison", session_end_time, self.max_age)
+            LOGGER.info(" ---> Comparison %s %s", session_end_time, self.max_age)
             if session_end_time < self.max_age:
                 # This completed session has an age "younger" than our maximum
                 # old age allowed; flag it for deletion.

--- a/src/bos/operators/session_cleanup.py
+++ b/src/bos/operators/session_cleanup.py
@@ -24,9 +24,7 @@
 #
 import logging
 import re
-from datetime import datetime, timedelta
 
-from bos.common.utils import load_timestamp
 from bos.operators.base import BaseOperator, main
 from bos.operators.utils.clients.bos.options import options
 
@@ -38,10 +36,6 @@ class SessionCleanupOperator(BaseOperator):
     The Session Completion Operator marks sessions complete when all components
     that are part of the session have been disabled.
     """
-    def __init__(self):
-        super().__init__()
-        self._max_age = None
-
     @property
     def name(self):
         return 'SessionCleanup'

--- a/src/bos/operators/utils/clients/bos/base.py
+++ b/src/bos/operators/utils/clients/bos/base.py
@@ -112,10 +112,10 @@ class BaseBosEndpoint(object):
         return items
 
     @log_call_errors
-    def delete_items(self, data):
+    def delete_items(self, **kwargs):
         """Delete information for multiple BOS items"""
         session = requests_retry_session()
-        response = session.delete(self.base_url, json=data)
+        response = session.delete(self.base_url, params=kwargs)
         response.raise_for_status()
         if response.text:
             return json.loads(response.text)

--- a/src/bos/operators/utils/clients/bos/base.py
+++ b/src/bos/operators/utils/clients/bos/base.py
@@ -117,5 +117,7 @@ class BaseBosEndpoint(object):
         session = requests_retry_session()
         response = session.delete(self.base_url, json=data)
         response.raise_for_status()
-        items = json.loads(response.text)
-        return items
+        if response.text:
+            return json.loads(response.text)
+        else:
+            return None

--- a/src/bos/operators/utils/clients/bos/options.py
+++ b/src/bos/operators/utils/clients/bos/options.py
@@ -91,8 +91,8 @@ class Options:
         return self.get_option('disable_components_on_completion', bool, True)
 
     @property
-    def cleanup_completed_session_age(self):
-        return self.get_option('cleanup_completed_session_age', bool, 7*24*60*60) # Defaults to 1 week (604800 seconds).
+    def cleanup_completed_session_ttl(self):
+        return self.get_option('cleanup_completed_session_ttl', str, '7d') # Defaults to 7 days (168 hours).
 
 
 

--- a/src/bos/operators/utils/clients/bos/sessions.py
+++ b/src/bos/operators/utils/clients/bos/sessions.py
@@ -43,6 +43,6 @@ class SessionEndpoint(BaseBosEndpoint):
     def update_sessions(self, data):
         return self.update_items(data)
 
-    def delete_sessions(self, data):
-        return self.delete_items(data)
+    def delete_sessions(self, **kwargs):
+        return self.delete_items(**kwargs)
 

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -36,7 +36,7 @@ DB = dbutils.get_wrapper(db='options')
 # options simpler
 OPTIONS_KEY = 'options'
 DEFAULTS = {
-    'cleanup_completed_session_age': 604800,
+    'cleanup_completed_session_ttl': "7d",
     'disable_components_on_completion': True,
     'discovery_frequency': 5*60,
     'logging_level': 'INFO',


### PR DESCRIPTION
## Summary and Scope

This mod introduces a new BOS v2 operator that allows automatic cleanup of completed sessions thats are of a certain age (and older). The default for this configuration value is 7d; after 7d, completed sessions based on session status start time, are purged from BOS. Purging a completed session does not have any direct effect on associated components (desired state for nodes in a session may still be set).

## Issues and Related PRs
* Resolves [CASMCMS-7892](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7892)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * mug
  * Local development environment

### Test description:

Deployed the full set of changes and issued several dummy sessions and tested the following conditions:
- disabled (no sessions deleted)
- nominal (older sessions (in testing, 1m) being deleted
- No cull (new sessions are not deleted until they are ripe for pruning)