### PR TITLE
Update Controller get code references to dynamically strip

### DIFF
--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -56,6 +56,8 @@ def get_v2_components(ids="", enabled=None, session=None, staged_session=None, p
                 detail=str(err))
     response = get_v2_components_data(id_list=id_list, enabled=enabled, session=session, staged_session=staged_session,
                                       phase=phase, status=status)
+    for component in response:
+        del_timestamp(component)
     return response, 200
 
 
@@ -232,6 +234,7 @@ def get_v2_component(component_id):
             detail="Component {} could not be found".format(component_id))
     component = DB.get(component_id)
     component = _set_status(component)
+    del_timestamp(component)
     return component, 200
 
 
@@ -384,7 +387,7 @@ def _populate_boot_artifacts(data):
     If there is a BSS Token present in the actual_state,
     then look up the boot artifacts and add them to the
     actual_state data.
-    
+
     If the data contains any boot artifacts and the BSS
     token, then those boot artifacts will be overwritten.
     If there are boot artifacts and no BSS token, then
@@ -407,6 +410,19 @@ def _populate_boot_artifacts(data):
             data['actual_state']['boot_artifacts'] = boot_artifacts
     return data
 
+
+def del_timestamp(data: dict): -> None
+    """
+    # The actual state boot artifacts dictionary contains a timestamp
+    # that is used for internal references only; we should strip it
+    # from any given data. The dictionary is modified in place, and
+    # no return is given.
+    """
+    try:
+        del data['actual_state']['boot_artifacts']['timestamp']
+    except KeyError:
+        pass
+    return None
 
 def _set_last_updated(data):
     timestamp = get_current_timestamp()


### PR DESCRIPTION
Component records will have timestamps deleted from them, as 'timestamp'
is not a defined property in the openapi spec.

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

