### PR TITLE
CASMCMS-7974: Update Alpine Docker image and dev.cray.com addresses.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 
 # Upstream Build Args
 ARG OPENAPI_IMAGE=openapitools/openapi-generator-cli:v4.1.2
-ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/docker.io/alpine:3.14
+ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3
 
 # Generate Code
 FROM $OPENAPI_IMAGE as codegen
@@ -62,16 +62,16 @@ RUN apk add --upgrade --no-cache apk-tools busybox && \
     apk add --no-cache gcc g++ python3-dev py3-pip musl-dev libffi-dev openssl-dev && \
     apk -U upgrade --no-cache && \
     pip3 install --no-cache-dir -U pip && \
-    pip3 install --no-cache-dir -r requirements.txt
-RUN cd lib && pip3 install --no-cache-dir .
+    pip3 install --no-cache-dir -r requirements.txt --ignore-installed six
+RUN cd lib && pip3 install --no-cache-dir --ignore-installed six .
 
 # Testing image
 FROM base as testing
 WORKDIR /app
 COPY docker_test_entry.sh .
 COPY test-requirements.txt .
-RUN apk add --no-cache --repository https://arti.dev.cray.com/artifactory/mirror-alpine/edge/testing/ etcd etcd-ctl
-RUN cd /app && pip3 install --no-cache-dir -r test-requirements.txt
+RUN apk add --no-cache --repository https://arti.hpc.amslabs.hpecorp.net/artifactory/mirror-alpine/edge/testing/ etcd etcd-ctl
+RUN cd /app && pip3 install --no-cache-dir --ignore-installed six -r test-requirements.txt
 CMD [ "./docker_test_entry.sh" ]
 
 # Codestyle reporting
@@ -101,7 +101,7 @@ FROM intermediate as debug
 ENV PYTHONPATH "/app/lib/server"
 WORKDIR /app
 RUN apk add --no-cache busybox-extras && \
-    pip3 install rpdb
+    pip3 install rpdb --ignore-installed six
 
 # Application image
 FROM intermediate as application

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -148,7 +148,7 @@ pipeline {
         stage("SP2 RPM Build") {
 	            agent {
 	                docker {
-	                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
+	                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
 	                    reuseNode true
 	                    // Support docker in docker for clamav scan
 	                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
@@ -175,7 +175,7 @@ pipeline {
         stage("SP3 RPM Build") {
 	            agent {
 	                docker {
-	                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
+	                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
 	                    reuseNode true
 	                    // Support docker in docker for clamav scan
 	                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
---trusted-host arti.dev.cray.com
 --trusted-host artifactory.algol60.net
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 --extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 -c constraints.txt
 -r lib/bos/server/requirements.txt

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -34,18 +34,6 @@
 #
 # The source, team, and type fields specify where on the server the image search should be done.
 #
-################
-# server: arti #
-################
-#
-# For arti, if type is not specified, it defaults to stable
-#
-# For source docker, the image version will be based on the information found in:
-# https://arti.dev.cray.com/artifactory/<team>-docker-<type>-local/repository.catalog
-#
-# For source helm, the image version will be based on the information found in:
-# https://arti.dev.cray.com/artifactory/<team>-helm-<type>-local/index.yaml
-#
 ###################
 # server: algol60 #
 ###################


### PR DESCRIPTION
## Summary and Scope

Use the correct location for Alpine Docker image. Only pin it to the
major version, so it will float and grab the highest minor and patch
versions.

At the same time, remove the reference to arti.dev.cray.com. The python modules will now get pulled directly from public repos which both protects us from hpe network domain changes and gets us a step closer to building through github action

## Issues and Related PRs
* Resolves [CASMCMS-7974](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7974)
* Resolves [CASMCMS-7972](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7972)

## Testing
STILL NEEDS TESTING

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

This is a low risk change as all it modifies is the base image the container is using and where the python modules are coming from - no code changes.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

