### PR TITLE
CASMCMS-8023: Correct the way BOS Status Reporter Sleeps

### DIFF
--- a/src/bos/reporter/etc/bos-reporter.service
+++ b/src/bos/reporter/etc/bos-reporter.service
@@ -1,6 +1,6 @@
 
 [Unit]
-Description=bos-reporter reports BOS session ID that the node was booted with
+Description=bos-status-reporter reports boot session information periodically to the BOS API
 DefaultDependencies=no
 After=multi-user.target
 

--- a/src/bos/reporter/status_reporter/__main__.py
+++ b/src/bos/reporter/status_reporter/__main__.py
@@ -116,7 +116,7 @@ def main():
     component = read_identity()
     try:
         sleep_time = duration_to_timedelta(get_value_from_proc_cmdline('bos_update_frequency'))
-        sleep_time *= REPORTING_RATIO * sleep_time.total_seconds()
+        sleep_time = REPORTING_RATIO * sleep_time.total_seconds()
     except KeyError:
         sleep_time = STATE_UPDATE_FREQUENCY * REPORTING_RATIO
 
@@ -135,10 +135,11 @@ def main():
         except Exception as exp:
             LOGGER.error("An error occurred: {}".format(exp))
         if has_slept_before:
-            sleep(sleep_time.total_seconds())
+            sleep(sleep_time)
         else:
-            sleep(sleep_time.total_seconds() * random.random())
+            sleep(sleep_time * random.random())
             has_slept_before = True
+            LOGGER.info("Now periodically reporting every ~%s seconds.", sleep_time)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When a non-default value is passed in to bos-status-reporter through
/proc/cmdline, it is first parsed as a datetime.timedelta object. On
computes, BOS automatically injects this value onto /proc/cmdline. When
this happens, BOS assumes that a non-default value is to be used, so it
needs to convert this default (4h) into a period of time, in seconds,
that are required to sleep before reporting.

Unfortunately, a multiplicative set operation was being used in addition
to a conversion from datetime.timedelta to total_seconds, which
increased the overall reporting window by an additional multiplicative
factor. As a result, BOS-status-reporter was sleeping way too long to
report overall boot artifacts when this value was specified.

This mod corrects the problem and adds additional logging information to
report the actual value being used by bos-status-reporter.

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8023]

## Testing

Tested change on groot computes.
