### PR TITLE
CASMCMS-8064: Fix BOS v2 boot time option name

### DIFF
--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1192,7 +1192,7 @@ components:
         logging_level:
           type: string
           description: The logging level for all BOS services
-        max_boot_on_wait_time:
+        max_boot_wait_time:
           type: integer
           description: How long BOS will wait for a node to boot into a usable state before rebooting it again (in seconds)
         max_power_on_wait_time:


### PR DESCRIPTION
## Summary and Scope

Fixes a small naming issue

## Issues and Related PRs

* Found while working on the cli for CASMCMS-8064
