### PR TITLE
Update v1/v2 migration to retain v1 copy of sessiontemplates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for SLES SP4
 
+### Changed
+- Remove length restriction from v1 sessiontemplate names
+- Updated v1/v2 migration of sessiontemplates to retain a v1 copy
+
 ## [1.2.6] - 2022-06-23
 ### Added
 - Initial Gitflow/Changelog conversion of BOS repository.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -437,9 +437,7 @@ components:
           type: string
           description: Name of the SessionTemplate. The length of the name is restricted to 45 characters.
           example: "cle-1.0.0"
-          # These validation parameters are restricted by Kubernetes naming conventions.
           minLength: 1
-          maxLength: 45
           pattern: "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
         description:
           type: string


### PR DESCRIPTION
## Summary and Scope

This modifies the migration script to keep a "deprecated" version v1 sessiontemplates rather than removing them entirely.
This also fixes a couple of related issues including removing the length requirement on sessiontemplate names and restoring the bypassed templateURL code for v1. 

## Issues and Related PRs

* Resolves CASMCMS-7924
* Resolves CASMCMS-8010
* Resolves CASMCMS-8080

## Testing

### Tested on:

  * Groot

### Test description:

- Removed a v2 copy of a template and re-ran the migration script so that template was re-added as both a v2 and v1_deprecated version

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

