### PR TITLE
CASMCMS-8088: Generate valid unstable chart artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for SLES SP4
+- Build valid unstable charts
 
 ## [1.2.6] - 2022-06-23
 ### Added

--- a/kubernetes/cray-bos/Chart.yaml.in
+++ b/kubernetes/cray-bos/Chart.yaml.in
@@ -3,7 +3,7 @@ annotations:
     - name: cray-boa
       image: artifactory.algol60.net/csm-docker/stable/cray-boa:0.0.0-boa
     - name: cray-bos
-      image: artifactory.algol60.net/csm-docker/stable/cray-bos:0.0.0-bos
+      image: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-bos:0.0.0-bos
     - name: redis
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis:5.0-alpine3.12
   artifacthub.io/license: MIT

--- a/kubernetes/cray-bos/values.yaml.in
+++ b/kubernetes/cray-bos/values.yaml.in
@@ -9,7 +9,7 @@
 
 boa_image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-boa
-  tag: 0.0.0-boa 
+  tag: 0.0.0-boa
 database:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis
@@ -37,7 +37,7 @@ cray-service:
     cray-bos:
       name: cray-bos
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/cray-bos
+        repository: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-bos
         # tag defaults to chart appVersion
       ports:
       - name: http
@@ -182,7 +182,7 @@ operatorDefaults:
     operator:
       name: operator
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/cray-bos
+        repository: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-bos
       resources:
         requests:
           memory: "150Mi"

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -1,19 +1,22 @@
-#tag: version tag string to be replaced (optional -- if unspecified @VERSION@ is assumed)
-#sourcefile: file to read actual version from (optional -- if unspecified, .version is assumed)
-#targetfile: file in which to have version tags replaced
+#tag: Version tag string to be replaced (optional -- if unspecified @VERSION@ is assumed)
 #
-#Multiples of these lines are allowed. A given line is in effect until another line overrides it.
-#Example:
-#tag: @TAG1@
-#sourcefile: path/to/version1.txt
-#targetfile: my/file.py
-#targetfile: other/file.yaml
+#sourcefile: File to obtain the actual version from (optional -- if unspecified, .version is assumed)
+#            If this file is executable, it will be executed and the output will be used as the version string.
+#            Otherwise it will be read and its contents will be used as the version string, with any leading and
+#            trailing whitespace stripped. The version string is validated by the update_version.sh string to
+#            verify that they match the expected version formatting (essentially semver, with a minor exception
+#            -- see the script header for details).
+#sourcefile-novalidate: This is identical to the previous tag, except that the only validation that is
+#            done is to verify that the version string is not blank and does not contain strings which will
+#            disrupt the sed command used for the version tag replacement. Essentially, it cannot contain
+#            double quotes, forward slashes, or hash symbols. The file does still have leading and trailing
+#            whitespace stripped, however.
+#targetfile: file in which to have version tags replaced. When this line is reached, the replacement
+#            action is performed on this file.
 #
-#tag: @TAG2@
-#targetfile: a/b/c.txt
-#
-#sourcefile: v2.txt
-#targetfile: 1/2/3.txt
+#Multiples of any of these lines are allowed. A given line is in effect until another line overrides it.
+#For this purpose, the sourcefile and sourcefile-novalidate lines are considered the same (that is, they
+#override each other).
 
 # Some of the sourcefile and tag lines below are
 # superfluous, but are present for clarity
@@ -51,8 +54,14 @@ tag: 0[.]0[.]0-api
 targetfile: api/openapi.yaml
 
 # The following file does not exist in the repo as a static file
+# It is generated at build time
+sourcefile-novalidate: .stable
+tag: S-T-A-B-L-E
+targetfile: kubernetes/cray-bos/values.yaml
+targetfile: kubernetes/cray-bos/Chart.yaml
+
+# The following file does not exist in the repo as a static file
 # It is generated at build time by the runBuildPrep.sh script
 sourcefile: cray-boa.version
 tag: 0.0.0-boa 
 targetfile: kubernetes/cray-bos/values.yaml
-

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -43,7 +43,7 @@ targetfile: kubernetes/cray-bos/Chart.yaml
 sourcefile: cray-boa.version
 tag: 0.0.0-boa
 targetfile: kubernetes/cray-bos/Chart.yaml
-sourcefile: .version
+sourcefile: .docker_version
 tag: 0.0.0-bos
 targetfile: kubernetes/cray-bos/Chart.yaml
 


### PR DESCRIPTION
## Summary and Scope

Using the new ".stable" file generated alongside the usual .version files, this PR modifies the repo path for the cray-bos images in the Chart and values files. For the images not build in this repo, this PR leaves them hardcoded as stable.

## Testing

None beyond verifying that the unstable chart that was built correctly points to unstable cray-bos images.

```
$ grep stable cray-bos/Chart.yaml cray-bos/values.yaml
cray-bos/Chart.yaml:      image: artifactory.algol60.net/csm-docker/stable/cray-boa:1.2.82
cray-bos/Chart.yaml:      image: artifactory.algol60.net/csm-docker/unstable/cray-bos:2.1.0-CASMCMS-8088.1_87697b9
cray-bos/Chart.yaml:      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis:5.0-alpine3.12
cray-bos/values.yaml:  repository: artifactory.algol60.net/csm-docker/stable/cray-boa
cray-bos/values.yaml:    repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis
cray-bos/values.yaml:        repository: artifactory.algol60.net/csm-docker/unstable/cray-bos
cray-bos/values.yaml:        repository: artifactory.algol60.net/csm-docker/unstable/cray-bos
cray-bos/values.yaml:  image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.80.0
```

## Risks and Mitigations

Low risk in that we cannot pull BOS into CSM without this. Also low risk in that the changes are very limited.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

