### PR TITLE
CASMCMS-7885: Increase operator resource limits to avoid throttling

### DIFF
--- a/kubernetes/cray-bos/values.yaml.in
+++ b/kubernetes/cray-bos/values.yaml.in
@@ -186,10 +186,10 @@ operatorDefaults:
       resources:
         requests:
           memory: "150Mi"
-          cpu: "200m"
+          cpu: "250m"
         limits:
           memory: "250Mi"
-          cpu: "500m"
+          cpu: "1000m"
       livenessProbe:
         exec:
           command:


### PR DESCRIPTION
## Summary and Scope

Increases the resource limit to a point where it no longer was throttling on a test machine.

## Issues and Related PRs

* Resolves CASMCMS-7885

## Testing

### Tested on:

  * Groot
 
### Test description:

Changed the limit and watched the graphs on grafana to watch for throttling

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

