### PR TITLE
CASMCMS-7972: Update to use internal HPE network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build valid unstable charts
 
 ### Changed
+- Changed to use the internal HPE network.
 - Remove length restriction from v1 sessiontemplate names
 - Updated v1/v2 migration of sessiontemplates to retain a v1 copy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ FROM base as testing
 WORKDIR /app
 COPY docker_test_entry.sh .
 COPY test-requirements.txt .
-RUN apk add --no-cache --repository https://arti.dev.cray.com/artifactory/mirror-alpine/edge/testing/ etcd etcd-ctl
+RUN apk add --no-cache --repository https://arti.hpc.amslabs.hpecorp.net/artifactory/mirror-alpine/edge/testing/ etcd etcd-ctl
 RUN cd /app && pip3 install --no-cache-dir -r test-requirements.txt
 CMD [ "./docker_test_entry.sh" ]
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -168,10 +168,10 @@ pipeline {
 	        sh "make rpm_build_source_clean"
 	        }
 	    }
-        stage("SP4 RPM Build") {
+        stage("SLES15SP4 RPM Build") {
             agent {
                 docker {
-                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp4_build_environment:latest"
+                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp4_build_environment:latest"
                     reuseNode true
                     // Support docker in docker for clamav scan
                     args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
@@ -182,7 +182,7 @@ pipeline {
                 sh "make rptr_rpm"
                 }
             }
-        stage("SP4 RPM Publish") {
+        stage("SLES15SP4 RPM Publish") {
             steps {
                 script {
                     publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: env.PUBLISH_SP4, arch: "x86_64", isStable: env.IS_STABLE)

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -41,10 +41,10 @@
 # For arti, if type is not specified, it defaults to stable
 #
 # For source docker, the image version will be based on the information found in:
-# https://arti.dev.cray.com/artifactory/<team>-docker-<type>-local/repository.catalog
+# https://arti.hpc.amslabs.hpecorp.net/artifactory/<team>-docker-<type>-local/repository.catalog
 #
 # For source helm, the image version will be based on the information found in:
-# https://arti.dev.cray.com/artifactory/<team>-helm-<type>-local/index.yaml
+# https://arti.hpc.amslabs.hpecorp.net/artifactory/<team>-helm-<type>-local/index.yaml
 #
 ###################
 # server: algol60 #


### PR DESCRIPTION
## Summary and Scope
Changing the reference from arti.dev.cray.com to
arti.hpc.amslabs.hpecorp.net

## Issues and Related PRs



* Resolves [CASMCMS-7972]

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Local development environment


### Test description:
Everything built just fine for BOS and BOA in the pipline.

I built the BOS testing image locally. It built.

I downloaded and examined the BOS SLES15SP4 RPM. It looked fine.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

