### PR TITLE
CASMCMS-8085: Fix error loading old v1 session status records

### DIFF
--- a/src/bos/server/__main__.py
+++ b/src/bos/server/__main__.py
@@ -32,6 +32,18 @@ import connexion
 from bos.server import specialized_encoder
 from bos.server.controllers.v2 import options
 
+### Shim so that old pickled records still work
+# Remove when v1 is removed
+import sys
+import bos.server.controllers as controllers
+import bos.server.models as models
+
+models.v1_generic_metadata.GenericMetadata = models.v1_generic_metadata.V1GenericMetadata
+sys.modules['bos.controllers'] = controllers
+sys.modules['bos.models'] = models
+sys.modules['bos.models.generic_metadata'] = models.v1_generic_metadata
+###
+
 LOGGER = logging.getLogger('bos.__main__')
 
 


### PR DESCRIPTION
## Summary and Scope

Fixes a regression that causes v1 sessiontemplate records to not load correctly.

## Issues and Related PRs

* Resolves CASMCMS-8085

## Testing

### Tested on:

  * Fanta

### Test description:

- Found previously failing templates, and loaded them successfully with this change.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

