### PR TITLE
CASMCMS-8103: Fix incorrect state when rebooting with the same config

### DIFF
--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -64,7 +64,7 @@ class PowerOnOperator(BaseOperator):
         except Exception as e:
             raise Exception("An error was encountered while setting BSS information: {}".format(e)) from e
         try:
-            set_cfs(components, enabled=False)
+            set_cfs(components, enabled=False, clear_state=True)
         except Exception as e:
             raise Exception("An error was encountered while setting CFS information: {}".format(e)) from e
         component_ids = [component['id'] for component in components]


### PR DESCRIPTION
## Summary and Scope

Fixes the case where BOS will report a component is configured before it is ready when rebooting a component with the same configuration it had prior to the reboot.  This is because BOS will check that configuration is complete before the cfs-state-reporter has cleared the current configuration.

## Issues and Related PRs

* Resolves CASMCMS-8103

## Testing

### Tested on:

  * Fanta

### Test description:

Booted a node and verified that CFS was updated correctly by the power-on operator.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

