### PR TITLE
CASMCMS-8157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated upstream build constraints
 - Support for SLES SP4
 - Build valid unstable charts
-
 ### Changed
 - Changed to use the internal HPE network.
 - Remove length restriction from v1 sessiontemplate names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated upstream build constraints
 - Support for SLES SP4
 - Build valid unstable charts
+
 ### Changed
 - Changed to use the internal HPE network.
 - Remove length restriction from v1 sessiontemplate names


### PR DESCRIPTION
## Summary and Scope

    Defined EMPTY_BOOT_ARTIFACTS by importing it.
    Without this import, the applystaged operation failed on a reboot.
    Do not check the BSS token if it is empty. This prevents spurious
    warnings.
    Add better error logging.

## Issues and Related PRs



* Resolves CASMCMS-8157

## Testing



### Tested on:

  * groot
### Test description:

On groot, I tested staging information for Node 4 and then applying that staged information. The node successfully rebooted using it. Before, it had failed to reboot.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No. 
- Was upgrade tested? If not, why? Yes.
- Was downgrade tested? If not, why? 
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

