### PR TITLE
Casmcms-8101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0] - 2022-08-17
 ### Added
 - Support for Alpine3.16/python10
 - Updated Build Sources
 - Updated upstream build constraints
 - Support for SLES SP4
 - Build valid unstable charts
+- Migration script for migrating V1 session templates to V2's schema
 
 ### Changed
 - Changed to use the internal HPE network.

--- a/gitInfo.txt
+++ b/gitInfo.txt
@@ -1,1 +1,0 @@
-Did you forget to run the gitInfo.sh script before the build?

--- a/kubernetes/cray-bos/Chart.yaml.in
+++ b/kubernetes/cray-bos/Chart.yaml.in
@@ -11,7 +11,7 @@ apiVersion: v2
 appVersion: 0.0.0
 dependencies:
 - name: cray-service
-  version: ^7.0.0
+  version: ^8.0.0
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
 description: "Kubernetes resources for the Boot Orchestration Service (BOS)"
 home: "https://github.com/Cray-HPE/bos"

--- a/kubernetes/cray-bos/templates/_helpers.tpl
+++ b/kubernetes/cray-bos/templates/_helpers.tpl
@@ -28,6 +28,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "cray-service.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
       annotations:
         {{- include "cray-service.pod-annotations" . | nindent 8 }}
     spec:

--- a/kubernetes/cray-bos/templates/post-upgrade-job.yaml
+++ b/kubernetes/cray-bos/templates/post-upgrade-job.yaml
@@ -47,6 +47,7 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
       annotations:
         traffic.sidecar.istio.io/excludeOutboundPorts: "2379,2380,6379"
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'        
     spec:
       serviceAccountName: "{{ include "cray-service.name" . }}-session-template-migration"
       restartPolicy: Never
@@ -87,3 +88,17 @@ spec:
           - python3
           - "-m"
           - "bos.server.v1_v2_migration"
+        env:
+        - name: APP_VERSION
+          value: 0.0.0-app-version
+        {{ range (index .Values "cray-service" "containers" "cray-bos" "ports") -}}
+        {{if eq .name "http" }}
+        - name: BOS_CONTAINER_PORT
+          value: "{{ .containerPort }}"
+        {{ end }}
+        {{- end }}
+        ports:
+        - name: http
+          containerPort: 9000
+          protocol: TCP
+          

--- a/kubernetes/cray-bos/templates/role.yaml
+++ b/kubernetes/cray-bos/templates/role.yaml
@@ -54,3 +54,6 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["get","list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","list"]

--- a/kubernetes/cray-bos/values.yaml.in
+++ b/kubernetes/cray-bos/values.yaml.in
@@ -15,6 +15,8 @@ database:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis
     tag: 5.0-alpine3.12
 cray-service:
+  podLabels:
+    app.kubernetes.io/version: 0.0.0-app-version
   type: Deployment
   nameOverride: cray-bos
   affinity:

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -65,3 +65,15 @@ targetfile: kubernetes/cray-bos/Chart.yaml
 sourcefile: cray-boa.version
 tag: 0.0.0-boa 
 targetfile: kubernetes/cray-bos/values.yaml
+
+# The following file does not exist in the repo as a static file
+# It is generated at build time by the runBuildPrep.sh script
+sourcefile: .docker_version
+tag: 0.0.0-app-version
+targetfile: kubernetes/cray-bos/values.yaml
+
+# The following file does not exist in the repo as a static file
+# It is generated at build time by the runBuildPrep.sh script
+sourcefile: .docker_version
+tag: 0.0.0-app-version
+targetfile: kubernetes/cray-bos/templates/post-upgrade-job.yaml


### PR DESCRIPTION
## Summary and Scope

Migration job should talk only to new cray-bos pods

    The migration Helm hook needs to only talk with the newly spun up
    pods. It should not talk with the pods that are spinning down
    because their V1 endpoints talk with the old etcd database. We need
    the V1 endpoints to be talking with the new redis database, so that
    the session templates are migrated to the redis database. Talking
    to the etcd DB means the session templates will be stored there, but
    will be inaccessible because the new endpoints ignore etcd. In effect,
    upon upgrade the session templates look like they disappeared instead
    of migrating to the new database.

    To ensure it is talking to the new pods, the Helm hook job needs to
    identify them by their labels. It then gets one of the new pods'
    IPs and talks only to it.

    Side note, the migration script needs to wait for Istio to be
    running before it starts otherwise it hits its retry limit
    futilely attempting to make connections. Fortunately, there is an
    Istio pod annotation that handles this situation.

    Changes:
    * Increase the version of the base chart cray-service that BOS is
    dependent upon. Do this because we want the additional pod labels
    functionality introduced through the cray-service mod that
    addressed CASMPET-5895.
    ** Note: This is a major version increase.
    * The App Version used to label the pods is the Docker version,
    which is calculated using gitversion, so the Docker version
    correlates to the released application version.
    * Add in App Version label to the cray-bos API pods and the
    operators.
    * Add the App Version to the environment variables for the migration
    job.
    * Add pods to the list of resources that the migration job can query.
    * Add an http port to the migration job pod
    ** Pass the container's port number to the migration job container via an
    enviroment variable. With this, the migration job can talk directly to
    the cray-bos container within the pod.
    * Correct the v1 to v2 endpoint.  Was using the v1 endpoint for the
    v2 session template creation.

## Issues and Related PRs


* Resolves CASMCMS-8101

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * 'gamora

### Test description:

I upgraded the Helm version which launches the Helm hook which is the migration job. I watched that the migration job created both a V2 and a V1_deprecated version of the BOS session templates that existed in the old etcd database. Further, if a session template of the same name already existed in the new redis database, the migration script did not overwrite that template. This means that if the session template exists in redis but not a V1_deprecated version, a V1_deprecated version would not be created.


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No, don't exist.
- Was upgrade tested? If not, why? Yes.
- Was downgrade tested? If not, why? Yes.
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

