### PR TITLE
CASMCMS-8163: Make v1 and v2 report db_status instead of <db kind>_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for SLES SP4
 - Build valid unstable charts
 - Migration script for migrating V1 session templates to V2's schema
+- Abstracting v1 andd v2 healthz endpoint to be database agnostic
 
 ### Changed
 - Changed to use the internal HPE network.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -102,7 +102,7 @@ components:
       description: Service health status
       type: object
       properties:
-        etcdStatus:
+        dbStatus:
           type: string
         apiStatus:
           type: string

--- a/src/bos/server/controllers/v1/healthz.py
+++ b/src/bos/server/controllers/v1/healthz.py
@@ -44,9 +44,9 @@ def v1_get_healthz():
         bec.put('health', 'ok')
         value, _ = bec.get('health')
         if value.decode('utf-8') != 'ok':
-            return Healthz(etcd_status='Failed to read from cluster',
+            return Healthz(db_status='Failed to read from cluster',
                            api_status='Not Ready'), 503
     return Healthz(
-        etcd_status='ok',
+        db_status='ok',
         api_status='ok',
     ), 200

--- a/src/bos/server/controllers/v2/healthz.py
+++ b/src/bos/server/controllers/v2/healthz.py
@@ -52,6 +52,6 @@ def get_v2_healthz():
     :rtype: Healthz
     """
     return Healthz(
-        redis_status=_get_db_status,
+        db_status=_get_db_status(),
         api_status='ok',
     ), 200


### PR DESCRIPTION
Allows both versions of the API to use the same openapi schema for status reporting in a db agnostic way.

## Issues and Related PRs
* Resolves [CASMCMS-8163](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8163)

## Testing

I built out the resultant change via our openapi, both through the pipeline and locally and examined the contents of the generated connexion model for healthz reporting. The updated image contains a model that has a db_status field instead of an etcd_status field.

Code was then deployed onto groot to ensure the healthz endpoints were functioning appropriately.

### Tested on:

  * `groot`
  * Local development environment

## Risks and Mitigations

## Pull Request Checklist
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
