### PR TITLE
CASMCMS-8041: Correct minor spelling errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
 - Support for SLES SP4
 - Build valid unstable charts
+
+### Changed
+- Spelling corrections.
 
 ## [1.2.6] - 2022-06-23
 ### Added

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -334,7 +334,7 @@ components:
         A boot set defines a collection of nodes and the information about the
         boot artifacts and parameters to be sent to each node over the specified
         network to enable these nodes to boot. When multiple boot sets are used
-        in a session template, the boot_ordinal and shtudown_ordinal indicate
+        in a session template, the boot_ordinal and shutdown_ordinal indicate
         the order in which boot sets need to be acted upon. Boot sets sharing
         the same ordinal number will be addressed at the same time.
       type: object

--- a/src/bos/operators/utils/clients/s3.py
+++ b/src/bos/operators/utils/clients/s3.py
@@ -183,7 +183,7 @@ class S3Object:
           S3 Object
           
         Raises:
-          boto3.execptions.ClientError -- when it cannot read from S3        
+          boto3.exceptions.ClientError -- when it cannot read from S3        
         """
 
         s3 = s3_client()
@@ -222,7 +222,7 @@ class S3BootArtifacts(S3Object):
           Manifest file in JSON format
           
         Raises:
-          boto3.execptions.ClientError -- when it cannot read from S3        
+          boto3.exceptions.ClientError -- when it cannot read from S3        
         """
 
         if self._manifest_json:

--- a/src/bos/server/test/test_status_controller.py
+++ b/src/bos/server/test/test_status_controller.py
@@ -329,7 +329,7 @@ class MockResponse():
 
     @staticmethod
     def get_json():
-        return copy.deepcoy(example_boot_set)
+        return copy.deepcopy(example_boot_set)
 
 
 class MockResponse1():


### PR DESCRIPTION
## Summary and Scope

Correct spelling errors / typos in the repo. They have not caused any reported problems, but we may as well fix them. No need to make a manifest PR, though -- these can just get picked up the next time we make a release.

One of the typos was in code, but it is test code. It seems like the function in question must not have been called, as it surely would have failed.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
