### PR TITLE
Casmcms-8158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migration script for migrating V1 session templates to V2's schema
 - Abstracting v1 andd v2 healthz endpoint to be database agnostic
 - Add overrides for pvc storage class
+- Adds option for persisting component staged information via a new option 'clear_completed_stage'
 
 ### Changed
 - Changed to use the internal HPE network.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migration script for migrating V1 session templates to V2's schema
 - Abstracting v1 andd v2 healthz endpoint to be database agnostic
 - Add overrides for pvc storage class
-- Adds option for persisting component staged information via a new option 'clear_completed_stage'
+- Adds option for persisting component staged information via a new option 'clear_stage'
 
 ### Changed
 - Changed to use the internal HPE network.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1177,6 +1177,9 @@ components:
         cleanup_completed_session_ttl:
           type: string
           description: Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior.
+        clear_completed_stage:
+          type: boolean
+          description: Allows components staged information to be cleared when the requested staging action has finished. Defaults to false.
         component_actual_state_ttl:
           type: string
           description: The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1177,9 +1177,9 @@ components:
         cleanup_completed_session_ttl:
           type: string
           description: Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior.
-        clear_completed_stage:
+        clear_stage:
           type: boolean
-          description: Allows components staged information to be cleared when the requested staging action has finished. Defaults to false.
+          description: Allows components staged information to be cleared when the requested staging action has been started. Defaults to false.
         component_actual_state_ttl:
           type: string
           description: The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically.

--- a/src/bos/operators/utils/clients/bos/options.py
+++ b/src/bos/operators/utils/clients/bos/options.py
@@ -103,8 +103,8 @@ class Options:
         return self.get_option('cleanup_completed_session_ttl', str, '7d') # Defaults to 7 days (168 hours).
 
     @property
-    def clear_completed_stage(self):
-        return self.get_option('clear_completed_stage', bool, False)
+    def clear_stage(self):
+        return self.get_option('clear_stage', bool, False)
 
     @property
     def component_actual_state_ttl(self):

--- a/src/bos/operators/utils/clients/bos/options.py
+++ b/src/bos/operators/utils/clients/bos/options.py
@@ -103,6 +103,10 @@ class Options:
         return self.get_option('cleanup_completed_session_ttl', str, '7d') # Defaults to 7 days (168 hours).
 
     @property
+    def clear_completed_stage(self):
+        return self.get_option('clear_completed_stage', bool, False)
+
+    @property
     def component_actual_state_ttl(self):
         return self.get_option('component_actual_state_ttl', str, '4h')
 

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -302,7 +302,7 @@ def post_v2_apply_staged():
     response = {"succeeded": [], "failed": [], "ignored": []}
     # Obtain latest desired behavior for how to clear staging information
     # for all components
-    clear_staged = get_v2_options_data.get('clear_completed_stage', False)
+    clear_staged = get_v2_options_data.get('clear_stage', False)
     try:
         data = connexion.request.get_json()
         xnames = data.get("xnames", [])

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -27,6 +27,7 @@ import logging
 from bos.common.utils import get_current_timestamp
 from bos.common.values import Phase, Action, Status, EMPTY_STAGED_STATE, EMPTY_BOOT_ARTIFACTS
 from bos.server import redis_db_utils as dbutils
+from bos.server.controllers.v2.opt import get_v2_options_data
 from bos.server.dbs.boot_artifacts import get_boot_artifacts, BssTokenUnknown
 
 LOGGER = logging.getLogger('bos.server.controllers.v2.components')
@@ -299,12 +300,15 @@ def post_v2_apply_staged():
     """Used by the POST /applystaged API operation"""
     LOGGER.debug("POST /applystaged invoked post_v2_apply_staged")
     response = {"succeeded": [], "failed": [], "ignored": []}
+    # Obtain latest desired behavior for how to clear staging information
+    # for all components
+    clear_staged = get_v2_options_data.get('clear_completed_stage', False)
     try:
         data = connexion.request.get_json()
         xnames = data.get("xnames", [])
         for xname in xnames:
             try:
-                if _apply_staged(xname):
+                if _apply_staged(xname, clear_staged):
                     response["succeeded"].append(xname)
                 else:
                     response["ignored"].append(xname)
@@ -318,7 +322,7 @@ def post_v2_apply_staged():
     return response, 200
 
 
-def _apply_staged(component_id):
+def _apply_staged(component_id, clear_staged=False):
     if component_id not in DB:
         return False
     data = DB.get(component_id)
@@ -336,7 +340,8 @@ def _apply_staged(component_id):
         # For both the successful and failed cases, we want the new session to own the node
         data["session"] = staged_session_id
         data["last_action"]["action"] = Action.apply_staged
-        data["staged_state"] = EMPTY_STAGED_STATE
+        if clear_staged:
+            data["staged_state"] = EMPTY_STAGED_STATE
         _set_auto_fields(data)
         DB.put(component_id, data)
     return response

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -27,7 +27,7 @@ import logging
 from bos.common.utils import get_current_timestamp
 from bos.common.values import Phase, Action, Status, EMPTY_STAGED_STATE, EMPTY_BOOT_ARTIFACTS
 from bos.server import redis_db_utils as dbutils
-from bos.server.controllers.v2.opt import get_v2_options_data
+from bos.server.controllers.v2.options import get_v2_options_data
 from bos.server.dbs.boot_artifacts import get_boot_artifacts, BssTokenUnknown
 
 LOGGER = logging.getLogger('bos.server.controllers.v2.components')

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -302,7 +302,7 @@ def post_v2_apply_staged():
     response = {"succeeded": [], "failed": [], "ignored": []}
     # Obtain latest desired behavior for how to clear staging information
     # for all components
-    clear_staged = get_v2_options_data.get('clear_stage', False)
+    clear_staged = get_v2_options_data().get('clear_stage', False)
     try:
         data = connexion.request.get_json()
         xnames = data.get("xnames", [])

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -37,7 +37,7 @@ DB = dbutils.get_wrapper(db='options')
 OPTIONS_KEY = 'options'
 DEFAULTS = {
     'cleanup_completed_session_ttl': "7d",
-    'clear_completed_stage': False,
+    'clear_stage': False,
     'component_actual_state_ttl': "4h",
     'disable_components_on_completion': True,
     'discovery_frequency': 5*60,

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -37,6 +37,7 @@ DB = dbutils.get_wrapper(db='options')
 OPTIONS_KEY = 'options'
 DEFAULTS = {
     'cleanup_completed_session_ttl': "7d",
+    'clear_completed_stage': False,
     'component_actual_state_ttl': "4h",
     'disable_components_on_completion': True,
     'discovery_frequency': 5*60,


### PR DESCRIPTION
## Summary and Scope

Introduces new behavior and option for electively tweaking how BOS performs staging operations. The new option 'clear_stage' allows users to elect the original behavior of removing staged boot information from a given component during the apply stage operation. This new option defaults to 'False', allowing BOS to retain the staged artifact information during a nominal boot. Set this option to true to globally revert to the old behavior.

## Issues and Related PRs

* Resolves [CASMCMS-8158](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8158)
* Change will also be needed in `develop`

## Testing

Locally built and verified image; then deployed to 1.3 system.

### Tested on:

  * Tested, and reverted from`drax`
  * Local development environment

### Test description:

Verified through API that the new option was settable and retrievable through exec action into the pod (it was).
Created a staged session for shutting down a node (that was already shut down). Executed the stage and verified that desired state and staged state were then equal.

## Risks and Mitigations

We've done most of our stage testing with clearing this field. The delta here is pretty minimal, but it represents a desired behavior change that is fundamental to the staging operation.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

