### PR TITLE
CASMTRIAGE-4246: Request state of all CFS components, not some

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2022-09-28
+### Added
+- Query CFS for all components' status, not select components
+
 ## [2.0.0] - 2022-08-17
 ### Added
 - Support for Alpine3.16/python10

--- a/src/bos/operators/status.py
+++ b/src/bos/operators/status.py
@@ -71,7 +71,7 @@ class StatusOperator(BaseOperator):
         components = self.bos_client.components.get_components(enabled=True)
         component_ids = [component['id'] for component in components]
         power_states, _failed_nodes = get_power_states(component_ids)
-        cfs_states = self._get_cfs_components(','.join(component_ids))
+        cfs_states = self._get_cfs_components()
         updated_components = []
         if components:
             # Recreate these filters to pull in the latest options values
@@ -90,8 +90,14 @@ class StatusOperator(BaseOperator):
         self.bos_client.components.update_components(updated_components)
 
     @staticmethod
-    def _get_cfs_components(component_ids):
-        cfs_data = get_cfs_components(ids=component_ids)
+    def _get_cfs_components():
+        """
+        Gets all the components from CFS.
+        We used to get only the components of interest, but that caused an HTTP request
+        that was longer than uwsgi could handle when the number of nodes was very large.
+        Requesting all components means none need to be specified in the request.
+        """
+        cfs_data = get_cfs_components()
         cfs_states = {}
         for component in cfs_data:
             cfs_states[component['id']] = component


### PR DESCRIPTION
## Summary and Scope

Gets all the components from CFS. We used to get only the components of interest, but that caused an HTTP request that was longer than uwsgi could handle when the number of nodes was very large.

Requesting all components means none need to be specified in the request.

## Issues and Related PRs


* Resolves CASMTRIAGE-4246

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Shandy`

### Test description:

I restarted the BOS status operator using the new image. It no longer encounters the request too large errors that it did before. Everything is unstuck, and BOS V2 is working!

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Pretty low. BOS V2 is broken right now, and this will not make it any more broken.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

