### PR TITLE
CASMCMS-8270: Fix v2 session status error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2022-10-05
+### Fixed
+- Fixed v2 extended status error reporting
+
 ## [2.0.1] - 2022-09-28
 ### Added
 - Query CFS for all components' status, not select components

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -286,7 +286,7 @@ def _get_v2_session_status(session_id, session=None):
             component_errors_data[component.get('error')].add(component.get('id'))
     component_errors = {}
     for error, components in component_errors_data.items():
-        component_list = ','.join(components[:MAX_COMPONENTS_IN_ERROR_DETAILS])
+        component_list = ','.join(list(components)[:MAX_COMPONENTS_IN_ERROR_DETAILS])
         if len(components) > MAX_COMPONENTS_IN_ERROR_DETAILS:
             component_list += '...'
         component_errors[error] = {'count': len(components), 'list': component_list}


### PR DESCRIPTION
## Summary and Scope

Fixes an error when reporting the components associated with an error in v2 extended session status.

## Issues and Related PRs

* Resolves CASMCMS-8270

## Testing

### Tested on:

  * Locally

### Test description:

Setup a test locally since it's difficult to reproduce with a large system to cause errors on.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

