### PR TITLE
CASMCMS-8275: Retry writing the BSS token to the BOS database.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3] - 2022-10-08
+### Fixed
+- Added a retry when the BOS power-on operator records the BSS tokens
 ## [2.0.2] - 2022-10-05
 ### Fixed
 - Fixed v2 extended status error reporting
 
 ## [2.0.1] - 2022-09-28
-### Added
+### Fixed
 - Query CFS for all components' status, not select components
 
 ## [2.0.0] - 2022-08-17


### PR DESCRIPTION
## Summary and Scope

Retry writing the BSS token to the BOS database. The connection to the database can be lost due to infrequent use. Retrying overcomes this difficulty.

(cherry picked from commit 442201340c2515cf03b67912c0512d5ab7bb2cda)


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMCMS-8275
## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Shandy`

### Test description:

The problem was that the power-on operator was losing its connection to the Redis database where it mapped BSS tokens to boot artifacts. This connection would be disrupted after fifteen minutes of inactivity. The remedy was to do a retry. I patched the code and restarted the BOS power-on operator. Then, I did three reboots of different nodes with fifteen minute pauses between reboots to let the connection die. The power-on operator's logs showed successful retries for the second and third reboot attempts. This proved that the connection loss situation was both encountered and remedied.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? Not, really, I patched the operator.
- Was downgrade tested? If not, why? No, because I never upgraded.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

