### PR TITLE
CASMCMS-8279: Increase v2 timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.4] - 2022-10-11
+### Fixed
+- Increased timeout values for v2
+
 ## [2.0.3] - 2022-10-08
 ### Fixed
 - Added a retry when the BOS power-on operator records the BSS tokens
+
 ## [2.0.2] - 2022-10-05
 ### Fixed
 - Fixed v2 extended status error reporting

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -42,9 +42,9 @@ DEFAULTS = {
     'disable_components_on_completion': True,
     'discovery_frequency': 5*60,
     'logging_level': 'INFO',
-    'max_boot_wait_time': 600,
-    'max_power_on_wait_time': 30,
-    'max_power_off_wait_time': 180,
+    'max_boot_wait_time': 1200,
+    'max_power_on_wait_time': 120,
+    'max_power_off_wait_time': 300,
     'polling_frequency': 60,
     'default_retry_policy': 3,
 }


### PR DESCRIPTION
## Summary and Scope

Increases the timeouts that v2 uses to determine when to retry and give up on nodes that are booting or powering off.  Nodes can still complete faster than this.  These values are also configurable if sites wish to decrease them.

This addresses some issues seen on Shandy while testing where nodes were not completing in time and a large portion of the system was failing to boot as a result.

## Issues and Related PRs

* Resolves CASMCMS-8279

## Testing

### Tested on:

  * Shandy

### Test description:

These values were deployed and several sessions were run.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

