### PR TITLE
CASMCMS-8284: Fix v2 state generation for staged shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5] - 2022-10-14
+### Fixed
+- Fixed staged shutdowns for v2
+
 ## [2.0.4] - 2022-10-11
 ### Fixed
 - Increased timeout values for v2

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -32,7 +32,7 @@ from bos.operators.utils.boot_image_metadata.factory import BootImageMetaDataFac
 from bos.operators.utils.clients.bos.options import options
 from bos.operators.utils.rootfs.factory import ProviderFactory
 from bos.operators.session_completion import SessionCompletionOperator
-from bos.common.values import Action, EMPTY_ACTUAL_STATE, EMPTY_DESIRED_STATE
+from bos.common.values import Action, EMPTY_ACTUAL_STATE, EMPTY_DESIRED_STATE, EMPTY_STAGED_STATE
 
 LOGGER = logging.getLogger('bos.operators.session_setup')
 
@@ -195,7 +195,7 @@ class Session:
         stage = self.session_data.get("stage", False)
         data = {"id": component_id}
         if stage:
-            data["staged_state"] = self._generate_desired_state(boot_set)
+            data["staged_state"] = self._generate_desired_state(boot_set, staged=True)
             data["staged_state"]["session"] = self.name
         else:
             data["desired_state"] = self._generate_desired_state(boot_set)
@@ -208,10 +208,12 @@ class Session:
         data['error'] = ''
         return data
 
-    def _generate_desired_state(self, boot_set):
+    def _generate_desired_state(self, boot_set, staged=False):
         if self.operation_type == "shutdown":
-            state = EMPTY_DESIRED_STATE
-            return state
+            if staged:
+                return EMPTY_STAGED_STATE
+            else:
+                return EMPTY_DESIRED_STATE
         else:
             state = self._get_state_from_boot_set(boot_set)
             return state


### PR DESCRIPTION
## Summary and Scope

Fixes a bug where applying a staged shutdown was trying to write an empty bss token to the staged state area.

## Issues and Related PRs

* Resolves CASMCMS-8284

## Testing

### Tested on:

  * Frigg

### Test description:

Ran a staged shutdown session and confirmed the correct data was in the component after the session was started.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

