### PR TITLE
CASMCMS-8300: Allow BOSv2 To omit rootfs provider tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Query CFS for all components' status, not select components
 - Authenticate to CSM's artifactory
+### Changed
+- Allow users to omit rootfs=<value> so that they may specify the exact desired value in sessiontemplate parameters.
 
 ## [2.0.5] - 2022-10-14
 ### Fixed

--- a/src/bos/operators/utils/rootfs/__init__.py
+++ b/src/bos/operators/utils/rootfs/__init__.py
@@ -76,7 +76,8 @@ class RootfsProvider(object):
         if rootfs_provider_passthrough:
             fields.append(rootfs_provider_passthrough)
 
-        if fields:
+        stripped_fields = [field for field in fields if fields]
+        if stripped_fields:
             return "root={}".format(self.DELIMITER.join(fields))
         else:
             return ''

--- a/src/bos/operators/utils/rootfs/__init__.py
+++ b/src/bos/operators/utils/rootfs/__init__.py
@@ -76,7 +76,7 @@ class RootfsProvider(object):
         if rootfs_provider_passthrough:
             fields.append(rootfs_provider_passthrough)
 
-        stripped_fields = [field for field in fields if fields]
+        stripped_fields = [field for field in fields if field]
         if stripped_fields:
             return "root={}".format(self.DELIMITER.join(fields))
         else:


### PR DESCRIPTION
Omitting these tags allows sessiontemplates to provide a static root=<value> within a bootset paramters field without duplication.

## Summary and Scope

There is discrepancy between usecases for Mercury and Shasta/COS over the use of special cased fields that string together the root=<value> fields. In Shasta, this field is specialized and allows for additional calculations, however, for Mercury, these extra steps are not needed.

A recent change went in to allow this to work for COS' dracut modules to correctly parse this field, but these changes are not compatible with the way that Mercury interprets the same fields.

Solution: Because mercury (and future others) do not require preconfig or preprocessing of root filesystems, we do not require the use of rootfs_provider and rootfs_provider_passthrough fields. Instead, these users may provide their root=<value> parameters in the sessiontemplate themselves.

## Issues and Related PRs

* Resolves [CASMCMS-8300](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8300)

## Testing

Tested as part of similar changes made to BOA codebase.

### Tested on:

  * Local development environment

## Pull Request Checklist

- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

