### PR TITLE
CASMTRIAGE-4669: Fix sessions status complete and in_progress values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.9] - 2023-1-12
+### Fixed
+- Fixed the complete and in_progress fields for session status
+
 ## [2.0.7] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile


### PR DESCRIPTION
## Summary and Scope

Fixes the "complete" and "in_progress" fields for BOS v1 session status

## Issues and Related PRs

* Resolves CASMTRIAGE-4669

## Testing

### Tested on:

  * Mercury

### Test description:

Ran a session and watched the status while running and after completion.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

