### PR TITLE
CASMCMS-8381: Linting of language in openapi spec file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Linting of openapi spec (no content changes)
+
 ## [2.0.9] - 2023-1-12
 ### Fixed
 - Fixed the complete and in_progress fields for session status

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -60,14 +60,14 @@ info:
     A new session is launched as a result of this call.
 
     A limit can also be specified to narrow the scope of the session. The limit
-    can consist of nodes, groups or roles in a comma-separated list.
+    can consist of nodes, groups, or roles in a comma-separated list.
     Multiple groups are treated as separated by OR, unless "&" is added to
     the start of the component, in which case this becomes an AND.  Components
     can also be preceded by "!" to exclude them.
 
     Note, the response from a successful session launch contains *links*.
     Within *links*, *href* is a string that uniquely identifies the session.
-    *href* is constructed using the session template name and a generated uuid.
+    *href* is constructed using the session template name and a generated UUID.
     Use the entire *href* string as the path parameter *session_id*
     to uniquely identify a session in for the /session/{session_id}
     endpoint.
@@ -94,8 +94,8 @@ info:
 servers:
 - url: https://api-gw-service-nmn.local/apis/bos
   description: The production BOS API server through a standard API gateway
-- url: https://cray-bos/
-  description: The service as exposed through k8s DNS service mapping
+- url: https://cray-bos
+  description: The service as exposed through Kubernetes DNS service mapping
 components:
   schemas:
     Healthz:
@@ -398,7 +398,7 @@ components:
             type: string
           minItems: 1
           description: |
-            The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.
+            The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user-defined groups in SMD.
         rootfs_provider:
           type: string
           description: |
@@ -416,7 +416,7 @@ components:
       description: |
         A Session Template object represents a collection of resources and metadata.
         A session template is used to create a Session which when combined with an
-        action (i.e. boot, reconfigure, reboot, shutdown) will create a K8s BOA job
+        action (i.e. boot, reconfigure, reboot, shutdown) will create a Kubernetes BOA job
         to complete the required tasks for the operation.
 
         A Session Template can be created from a JSON structure.  It will return
@@ -489,7 +489,7 @@ components:
           description: >
             A Session represents an operation on a SessionTemplate.
             The creation of a session effectively results in the creation
-            of a K8s Boot Orchestration Agent (BOA) job to perform the
+            of a Kubernetes Boot Orchestration Agent (BOA) job to perform the
             duties required to complete the operation.
 
             Operation -- An operation to perform on nodes in this session.
@@ -520,12 +520,12 @@ components:
           maxLength: 64
           readOnly: true
           description: >
-            The identity of the k8s job that is created to handle the session.
+            The identity of the Kubernetes job that is created to handle the session.
           example: "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
         limit:
           type: string
           description: >
-            A comma separated of nodes, groups or roles to which the session
+            A comma-separated of nodes, groups, or roles to which the session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
         links:
@@ -697,7 +697,7 @@ components:
       properties:
         name:
           type: string
-          description: Name of the session. A uuid name is generated if a name is not provided.
+          description: Name of the session. A UUID name is generated if a name is not provided.
           example: "session-20190728032600"
           # These validation parameters are restricted by Kubernetes naming conventions.
           minLength: 1
@@ -724,7 +724,7 @@ components:
         limit:
           type: string
           description: >
-            A comma separated of nodes, groups or roles to which the session
+            A comma-separated of nodes, groups, or roles to which the session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
         stage:
@@ -809,7 +809,7 @@ components:
             type: string
           minItems: 1
           description: |
-            The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.
+            The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user-defined groups in SMD.
         rootfs_provider:
           type: string
           description: |
@@ -856,7 +856,7 @@ components:
         limit:
           type: string
           description: >
-            A comma separated of nodes, groups or roles to which the session
+            A comma-separated of nodes, groups, or roles to which the session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
         stage:
@@ -867,7 +867,7 @@ components:
         components:
           type: string
           description: >
-            A comma separated list of nodes, representing the initial list of nodes
+            A comma-separated list of nodes, representing the initial list of nodes
             the session should operate against.  The list will remain even if
             other sessions have taken over management of the nodes.
         status:
@@ -1124,7 +1124,7 @@ components:
       properties:
         ids:
           type: string
-          description: A comma separated list of component ids
+          description: A comma-separated list of component IDs
         session:
           type: string
           description: A session name.  All components part of this session will be patched.


### PR DESCRIPTION
## Summary and Scope

No content changes, just linting of some of the language in the text fields of the openapi spec file. The only non-language linting is removing the trailing / from one of the url fields, as this was flagged by an openapi linter as being bad practice.

## Issues and Related PRs

[Corresponding craycli PR](https://github.com/Cray-HPE/craycli/pull/67) to make the same changes in the Cray CLI, as well as a few CLI-specific BOS language fixes.

## Risks and Mitigations

Very very low risk. Just changes to language in text fields.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

