### PR TITLE
CASMCMS-8539: Add disasterRecovery section for etcd operator values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Multi-tenancy support for sessions, templates and components
+- DisasterRecovery values for the etcd chart
 ### Fixed
 - Fixed inconsistent indentation in Jenkinsfile.
 ### Removed

--- a/kubernetes/cray-bos/values.yaml.in
+++ b/kubernetes/cray-bos/values.yaml.in
@@ -185,6 +185,12 @@ cray-etcd-base:
       requests:
         cpu: 10m
         memory: 64Mi
+    disasterRecovery:
+      cronjob:
+        snapshotsDir: "/snapshots/cray-bos-bitnami-etcd"
+        schedule: "0 */1 * * *"
+        historyLimit: 1
+        snapshotHistoryLimit: 24
 
 deploymentDefaults:
   service:


### PR DESCRIPTION
## Summary and Scope

Adds the disaster recovery information for etcd to the chart values

## Issues and Related PRs

* Resolves CASMCMS-8539

## Testing

* Tested by Brad Klein on Ashton

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

