### PR TITLE
CASMCMS-8452: Return non-tenant nodes with the ignored nodes

### DIFF
--- a/src/bos/operators/utils/rootfs/cpss3.py
+++ b/src/bos/operators/utils/rootfs/cpss3.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,8 @@ import logging
 import os
 
 from . import RootfsProvider
-from .. import PROTOCOL, ServiceNotReady, requests_retry_session
+from .. import ServiceNotReady
+from bos.common.utils import PROTOCOL, requests_retry_session
 
 LOGGER = logging.getLogger(__name__)
 SERVICE_NAME = 'cray-cps'

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -52,20 +52,16 @@ def get_v2_components(ids="", enabled=None, session=None, staged_session=None, p
             return connexion.problem(
                 status=400, title="Error parsing the ids provided.",
                 detail=str(err))
-    response = get_v2_components_data(id_list=id_list, enabled=enabled, session=session, staged_session=staged_session,
-                                      phase=phase, status=status)
     tenant = get_tenant_from_header()
-    if tenant:
-        tenant_components = get_tenant_component_set(tenant)
-        limited_response = [component for component in response if component["id"] in tenant_components]
-        response = limited_response
+    response = get_v2_components_data(id_list=id_list, enabled=enabled, session=session, staged_session=staged_session,
+                                      phase=phase, status=status, tenant=tenant)
     for component in response:
         del_timestamp(component)
     return response, 200
 
 
 def get_v2_components_data(id_list=None, enabled=None, session=None, staged_session=None,
-                           phase=None, status=None):
+                           phase=None, status=None, tenant=None):
     """Used by the GET /components API operation
 
     Allows filtering using a comma separated list of ids.
@@ -84,6 +80,10 @@ def get_v2_components_data(id_list=None, enabled=None, session=None, staged_sess
     response = [_set_status(r) for r in response if r]
     if enabled is not None or session is not None or staged_session is not None or phase is not None or status is not None:
         response = [r for r in response if _matches_filter(r, enabled, session, staged_session, phase, status)]
+    if tenant:
+        tenant_components = get_tenant_component_set(tenant)
+        limited_response = [component for component in response if component["id"] in tenant_components]
+        response = limited_response
     return response
 
 

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -286,8 +286,9 @@ def _get_v2_session_status(session_key, session=None):
     if not session:
         session = DB.get(session_key)
     session_id = session.get("name", {})
-    components = get_v2_components_data(session=session_id)
-    staged_components = get_v2_components_data(staged_session=session_id)
+    tenant_id = session.get("tenant")
+    components = get_v2_components_data(session=session_id, tenant=tenant_id)
+    staged_components = get_v2_components_data(staged_session=session_id, tenant=tenant_id)
     num_managed_components = len(components) + len(staged_components)
     if num_managed_components:
         component_phase_counts = Counter([c.get('status', {}).get('phase') for c in components])


### PR DESCRIPTION
## Summary and Scope

Fixes the apply staged endpoint so that nodes that don't belong to the tenant are returned in the "ignored" section.

Also fixes issues with multi-tenancy around session status and a recent import bug caused by code reorganization.

## Issues and Related PRs

* Resolves CASMCMS-8452

## Testing

### Tested on:

  * Mug

### Test description:

Ran through session status, staging sessions, applying staged sessions, shutdown and boot with two tenants.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

