### PR TITLE
CASMCMS-8571: Ensure that DELETE requests to /v1/sessiontemplate/{session_template_id} return a meaningful status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DisasterRecovery values for the etcd chart
 ### Fixed
 - Fixed inconsistent indentation in Jenkinsfile.
+- Ensure that DELETE requests to `/v1/sessiontemplate/{session_template_id}` return a meaningful status code
 ### Removed
 - Remove obsolete non-functional test files and packaging. Remove references to same from Makefile and other build files.
 - Remove now-unused remnants of the former dynamic versioning system used in the repository.

--- a/src/bos/server/controllers/v1/sessiontemplate.py
+++ b/src/bos/server/controllers/v1/sessiontemplate.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -203,4 +203,4 @@ def delete_v1_sessiontemplate(session_template_id):
     Delete the session template by session template ID
     """
     LOGGER.debug("delete_v1_sessiontemplate by ID: %s", session_template_id)
-    delete_v2_sessiontemplate(session_template_id)
+    return delete_v2_sessiontemplate(session_template_id)


### PR DESCRIPTION
## Summary and Scope

If you attempt to delete a nonexistent session template using the v1 endpoint, it returns a 204 status code. This is because the v1 delete function calls the v2 delete function, but strips off the returned status code from it. This PR fixes that, so the status code returned by the v2 function is preserved.

Note that the API spec for BOS already indicated that 404 is a possible failure response for the v1 delete endpoint -- it just wasn't actually happening. So this is fixing the service to be in line with the spec (and common sense).

## Issues and Related PRs

- Resolves [CASMCMS-8571](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8571)

## Testing

On drax, I first verified that the bug existed:

```
>>> r = requests.get("http://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/dogfood", headers=h)
>>> r
<Response [404]>
>>> r = requests.delete("http://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/dogfood", headers=h)
>>> r
<Response [204]>
```

I then deployed the fix on drax and verified that the delete now returned 404, as expected:

```
>>> r = requests.delete("http://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/dogfood", headers=h)
>>> r
<Response [404]>
```

I also ran the cmsdev bos tests with the fix in place, to make sure no unexpected problems were reported:

```
ncn-m001:~ # cmsdev test -q bos
Starting main run, version: 1.10.8, tag: pC6ka
Starting sub-run, tag: pC6ka-bos
Ended sub-run, tag: pC6ka-bos (duration: 26.919014757s)
Ended run, tag: pC6ka (duration: 26.929570738s)
SUCCESS
```

## Risks and Mitigations

Low risk. The change is very small and easy to see what its effects are.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
