### PR TITLE
CASMCMS-8517: rpm noarch for bos-reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Updating `x86_64` RPM builds to type `noarch` for ARM required work CASMCMS-8517
+
 ## [2.1.1] - 2023-05-02
 ### Added
 - Multi-tenancy support for sessions, templates and components

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -140,7 +140,7 @@ pipeline {
         stage("SLES15SP2 RPM Publish") {
             steps {
                 script {
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: env.PUBLISH_SP2, arch: "x86_64", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP2, arch: "noarch", isStable: env.IS_STABLE)
                     publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP2, arch: "src", isStable: env.IS_STABLE)
 	             }
                 sh "make rpm_build_clean"
@@ -165,7 +165,7 @@ pipeline {
         stage("SLES15SP3 RPM Publish") {
             steps {
                 script {
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: env.PUBLISH_SP3, arch: "x86_64", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP3, arch: "noarch", isStable: env.IS_STABLE)
                     publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP3, arch: "src", isStable: env.IS_STABLE)
 	            }
                 sh "make rpm_build_clean"
@@ -189,7 +189,7 @@ pipeline {
         stage("SLES15SP4 RPM Publish") {
             steps {
                 script {
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: env.PUBLISH_SP4, arch: "x86_64", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP4, arch: "noarch", isStable: env.IS_STABLE)
                     publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP4, arch: "src", isStable: env.IS_STABLE)
                 }
                 sh "make rpm_build_clean"

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 BUILD_METADATA ?= "1~development~$(shell git rev-parse --short HEAD)"
 
 # We copy the built RPMs to these directories to simplify publishing them
-RPM_IMAGE_DIR ?= dist/rpmbuild/RPMS/x86_64
+RPM_IMAGE_DIR ?= dist/rpmbuild/RPMS/noarch
 SRC_RPM_IMAGE_DIR ?= dist/rpmbuild/SRPMS
 
 # bos-reporter RPM variables
@@ -112,7 +112,7 @@ rptr_rpm_build_source:
 
 rptr_rpm_build:
 		BUILD_METADATA=$(BUILD_METADATA) rpmbuild -ba $(RPTR_SPEC_FILE) --define "_topdir $(RPTR_BUILD_DIR)"
-		cp $(RPTR_BUILD_DIR)/RPMS/x86_64/*.rpm $(RPM_IMAGE_DIR)
+		cp $(RPTR_BUILD_DIR)/RPMS/noarch/*.rpm $(RPM_IMAGE_DIR)
 
 rpm_build_clean:
 		rm -rf $(RPM_IMAGE_DIR)/*

--- a/bos-reporter.spec.in
+++ b/bos-reporter.spec.in
@@ -28,6 +28,7 @@ Group: System/Management
 Version: @RPM_VERSION@
 Release: @RPM_RELEASE@
 Source: %{name}-@RPM_VERSION@-@RPM_RELEASE@.tar.bz2
+BuildArch: noarch
 Vendor: HPE
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires: python-rpm-macros


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Change the bos-reporter rpm to be designated as `noarch`. This is required for the aarch64 support and to remove the redundant x86_64 rpm.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8517](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8517)
* Merge with `https://github.com/Cray-HPE/csm/pull/2158`

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

