### PR TITLE
Casmtriage 5255 support 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- 'include_disabled' option to decide whether disabled nodes should be part of a BOS session 
+
 ## [2.0.9] - 2023-1-12
 ### Fixed
 - Fixed the complete and in_progress fields for session status

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -733,6 +733,11 @@ components:
             Set to stage a session which will not immediately change the state of any components.
             The "applystaged" endpoint can be called at a later time to trigger the start of this session.
           default: false
+        include_disabled:
+          type: boolean
+          description: >
+            Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM)
+          default: false
       required: [operation, template_name]
       additionalProperties: false
     V2SessionStatus:
@@ -870,6 +875,10 @@ components:
             A comma separated list of nodes, representing the initial list of nodes
             the session should operate against.  The list will remain even if
             other sessions have taken over management of the nodes.
+        include_disabled:
+          type: boolean
+          description: >
+            Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM)
         status:
           $ref: '#/components/schemas/V2SessionStatus'
       additionalProperties: false
@@ -884,19 +893,19 @@ components:
         Detailed information on the phases of a session.
       properties:
         percent_complete:
-          type: number 
+          type: number
           description: |
             The percent of components currently in a completed/stable state
         percent_powering_on:
-          type: number 
+          type: number
           description: |
             The percent of components currently in the powering-on phase
         percent_powering_off:
-          type: number 
+          type: number
           description: |
             The percent of components currently in the powering-off phase
         percent_configuring:
-          type: number 
+          type: number
           description: |
             The percent of components currently in the configuring phase
       additionalProperties: false
@@ -935,19 +944,19 @@ components:
         phases:
           $ref: '#/components/schemas/V2SessionExtendedStatusPhases'
         percent_successful:
-          type: number 
+          type: number
           description: |
             The percent of components currently in a successful state
         percent_failed:
-          type: number 
+          type: number
           description: |
             The percent of components currently in a failed state
         percent_staged:
-          type: number 
+          type: number
           description: |
             The percent of components currently still staged for this session
         error_summary:
-          type: object 
+          type: object
           description: |
             A summary of the errors currently listed by all components
         timing:
@@ -978,7 +987,7 @@ components:
         bss_token:
           type: string
           description: >
-            A token received from the node identifying the boot artifacts. 
+            A token received from the node identifying the boot artifacts.
             For BOS use-only, users should not set this field. It will be overwritten.
         last_updated:
           type: string
@@ -1000,7 +1009,7 @@ components:
         bss_token:
           type: string
           description: >
-            A token received from BSS identifying the boot artifacts. 
+            A token received from BSS identifying the boot artifacts.
             For BOS use-only, users should not set this field. It will be overwritten.
         last_updated:
           type: string
@@ -1185,7 +1194,7 @@ components:
           description: The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically.
         disable_components_on_completion:
           type: boolean
-          description: Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes. 
+          description: Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes.
         discovery_frequency:
           type: integer
           description: How frequently the BOS discovery agent syncs new components from HSM. (in seconds)
@@ -1981,7 +1990,7 @@ paths:
         200:
           $ref: '#/components/responses/V2SessionTemplateDetails'
         400:
-          $ref: '#/components/responses/BadRequest'        
+          $ref: '#/components/responses/BadRequest'
     delete:
       summary: Delete a session template
       description: Delete a session template.

--- a/src/bos/operators/filters/base.py
+++ b/src/bos/operators/filters/base.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -59,7 +59,7 @@ class IDFilter(BaseFilter, ABC):
     """ A class for filters that take and return lists of component ids """
     def filter(self, components: List[dict]) -> List[dict]:
         component_ids = [component['id'] for component in components]
-        results = super().filter(components=component_ids)
+        results = BaseFilter.filter(self, components=component_ids)
         LOGGER.debug('{} filter found the following components: {}'.format(
             type(self).__name__,
             ','.join(results)
@@ -70,7 +70,7 @@ class IDFilter(BaseFilter, ABC):
 class DetailsFilter(BaseFilter, ABC):
     """ A class for filters that take and return lists of detailed component information """
     def filter(self, components: List[dict]) -> List[dict]:
-        results = super().filter(components=components)
+        results = BaseFilter.filter(self, components=components)
         LOGGER.debug('{} filter found the following components: {}'.format(
             type(self).__name__,
             ','.join([component.get('id', '') for component in results])

--- a/src/bos/operators/filters/filters.py
+++ b/src/bos/operators/filters/filters.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -166,7 +166,7 @@ class BootArtifactStatesMatch(LocalFilter):
         Filter out kernel parameters that dynamically change from session to session and
         should not be used for comparison.
         * spire_join_token
-        
+
         Returns:
         A parameter string without the dynamic parameters or None if the string is None
         """
@@ -187,7 +187,7 @@ class DesiredConfigurationSetInCFS(LocalFilter):
         component_ids = ','.join([component['id'] for component in components])
         cfs_components = get_cfs_components(ids=component_ids)
         self.cfs_components_dict = {component['id']: component for component in cfs_components}
-        matches = super()._filter(components)
+        matches = LocalFilter._filter(self, components)
         # Clear this, so there are no lingering side-effects of running this method.
         self.cfs_components_dict = {}
         return matches

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -107,6 +107,7 @@ def _create_session(session_create):
         'stage': session_create.stage,
         'components': '',
         'status': initial_status,
+        'include_disabled': session_create.include_disabled
     }
     return Session.from_dict(body)
 


### PR DESCRIPTION
## Summary and Scope

    Add an 'include_disabled' option to control whether nodes that are
    disabled in the Hardware State Manager (HSM) are included in a BOS
    session. This option is used for the BOS V2 sessions endpoint for
    POST requests.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5255](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

I tested this in vshasta v2 on dorian.

### Tested on:

  * `Dorian`
  * Virtual Shasta

### Test description:

I sent two shutdown requests for two nodes, 1 and 2. 
In the first request, I had node 2 disabled, and include_disabled was False. Node 2 was not part of the session.
In the second request, I had node 2 disabled, and include_disabled was True. Node 2 was part of the session.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? No
- Was downgrade tested? If not, why? No
- Were new tests (or test issues/Jiras) created for this change? No, but they should have been except for lack of time.

## Risks and Mitigations
Low.

_Are there known issues with these changes? Any other special considerations?_
No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

