### PR TITLE
CASMCMS-8609: Update power-on operator to pre-set the last action (1.3/1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.0.12] - 2023-05-12
+### Fixed
+- Fixed a window during power-on operations which could lead to an incorrect status in larger systems
+
 ## [2.0.11] - 2023-05-10
 ### Fixed
 - Fixed inconsistent indentation in Jenkinsfile.

--- a/constraints.txt
+++ b/constraints.txt
@@ -12,7 +12,7 @@ Deprecated==1.2.13
 etcd3==0.12.0
 Flask==1.1.2
 google-auth==2.9.0
-grpcio==1.47.0
+grpcio==1.51.3
 idna==3.3
 inflection==0.5.1
 itsdangerous==2.0.1

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -59,6 +59,7 @@ class PowerOnOperator(BaseOperator):
         ]
 
     def _act(self, components):
+        self._preset_last_action(components)
         try:
             self._set_bss(components)
         except Exception as e:


### PR DESCRIPTION
## Summary and Scope

Updates the power-on operator to pre-set the last action so that there is no longer a window of time between calling capmc and setting the last action, which was leading to an incorrect status.

## Issues and Related PRs

* Resolves CASMCMS-8609

## Testing

### Tested on:

  * crossroads

### Test description:

Tested shutdown, boot and reboot sessions successfully.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

