### PR TITLE
CASMCMS-8609: Update power-on operator to pre-set the last action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fixed a window during power-on operations which could lead to an incorrect status in larger systems
+
 ### Changed
 - v1 endpoints now thrown an error when a tenant is specified
 - v2 calls to create resources now throw an error when the tenant is invalid

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -189,6 +189,26 @@ class BaseOperator(ABC):
             data.append(patch)
         self.bos_client.components.update_components(data)
 
+    def _preset_last_action(self, components: List[dict]) -> None:
+        # This is done to eliminate the window between performing an action and marking the nodes as acted
+        # e.g. nodes could be powered-on without the correct power-on last action, causing status problems
+        if not self.name:
+            return
+        data = []
+        for component in components:
+            patch = {
+                'id': component['id'],
+                'error': component['error']
+            }
+            if self.name:
+                last_action_data = {
+                    'action': self.name,
+                    'failed': False
+                }
+                patch['last_action'] = last_action_data
+            data.append(patch)
+        self.bos_client.components.update_components(data)
+
     def _update_database_for_failure(self, components: List[dict]) -> None:
         """
         Updates the BOS database for all components the operator believes have failed

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -59,6 +59,7 @@ class PowerOnOperator(BaseOperator):
         ]
 
     def _act(self, components):
+        self._preset_last_action(components)
         try:
             self._set_bss(components)
         except Exception as e:


### PR DESCRIPTION
## Summary and Scope

Updates the power-on operator to pre-set the last action so that there is no longer a window of time between calling capmc and setting the last action, which was leading to an incorrect status.

## Issues and Related PRs

* Resolves CASMCMS-8609

## Testing

### Tested on:

  * crossroads

### Test description:

Tested shutdown, boot and reboot sessions successfully.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

