### PR TITLE
CASMCMS-8561/CASMCMS-8575: Update Swagger spec to match actual behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a window during power-on operations which could lead to an incorrect status in larger systems
 - Updated API spec so that it accurately describes the actual implementation:
   - Updated `Version` definition to reflect actual type of `major`, `minor`, and `patch` fields.
+  - Created `V1SessionLink` definition to reflect that the `links` field for BOS v1 sessions can have
+    two additional fields that don't show up in any other BOS link objects.
 
 ### Changed
 - v1 endpoints now thrown an error when a tenant is specified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated `Version` definition to reflect actual type of `major`, `minor`, and `patch` fields.
   - Created `V1SessionLink` definition to reflect that the `links` field for BOS v1 sessions can have
     two additional fields that don't show up in any other BOS link objects.
+  - Specify that the BOS v1 session ID is in UUID format.
 
 ### Changed
 - v1 endpoints now thrown an error when a tenant is specified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Fixed a window during power-on operations which could lead to an incorrect status in larger systems
+- Updated API spec so that it accurately describes the actual implementation:
+  - Updated `Version` definition to reflect actual type of `major`, `minor`, and `patch` fields.
 
 ### Changed
 - v1 endpoints now thrown an error when a tenant is specified

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -111,12 +111,15 @@ components:
       description: Version data
       type: object
       properties:
-        major:
-          type: integer
-        minor:
-          type: integer
-        patch:
-          type: integer
+        major: 
+          type: string
+          pattern: "^(0|[1-9][0-9]*)$"
+        minor: 
+          type: string
+          pattern: "^(0|[1-9][0-9]*)$"
+        patch: 
+          type: string
+          pattern: "^(0|[1-9][0-9]*)$"
         links:
           type: array
           items:

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -328,6 +328,7 @@ components:
         id:
           type: string
           description: Session ID
+          format: uuid
         links:
           type: array
           items:

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -161,9 +161,9 @@ components:
       description: Link to other resources
       type: object
       properties:
-        rel:
-          type: string
         href:
+          type: string
+        rel:
           type: string
       additionalProperties: false
     # V1
@@ -478,6 +478,21 @@ components:
             $ref: '#/components/schemas/Link'
       required: [name]
       additionalProperties: false
+    V1SessionLink:
+      description: Link to other resources
+      type: object
+      properties:
+        href:
+          type: string
+        jobId:
+          type: string
+        rel:
+          type: string
+          enum: ['session', 'status']
+        type:
+          type: string
+          enum: ['GET']
+      additionalProperties: false
     V1Session:
       description: |
         A Session object
@@ -535,7 +550,7 @@ components:
           type: array
           readOnly: true
           items:
-            $ref: '#/components/schemas/Link'
+            $ref: '#/components/schemas/V1SessionLink'
       required: [operation]
       additionalProperties: false
     V1NodeChangeList:


### PR DESCRIPTION
## Summary and Scope

* [CASMCMS-8561](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8561): The BOS API spec says that Version objects have fields major, minor, and patch which are of type integer. However, it actually returns string representations of those integers.
* [CASMCMS-8575](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8575): The BOS API spec says that Link objects only have two possible fields -- href and rel. However, in practice additional fields are included for BOS v1 session links. This PR creates a new V1SessionLink definition that includes these additional fields.. Also updated the BOS v1 session status definition to note that the v1 session ID is in UUID format.

This PR just updates the spec to reflect these facts. It does not make any change to BOS itself -- just updates the Swagger spec to match reality.

## Issues and Related PRs

- Part of [CASMCMS-8559](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8559)

## Testing

I ran the Swagger spec through a Swagger validator, to make sure no problems were inadvertently introduced.

## Risks and Mitigations

Low risk -- this only updates the spec, not BOS itself.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
