### PR TITLE
CASMCMS-8576: Update API spec to reflect that GET /v1/session returns list of IDs not sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Created `V1SessionLink` definition to reflect that the `links` field for BOS v1 sessions can have
     two additional fields that don't show up in any other BOS link objects.
   - Specify that the BOS v1 session ID is in UUID format.
+  - Specify that a GET to `/v1/session` returns a list of session IDs, not sessions.
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 - Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
 - Correct API spec to use valid ECMA 262 regular expression syntax, as dictated by the OpenAPI requirements.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -279,6 +279,11 @@ components:
             $ref: '#/components/schemas/V1PhaseCategoryStatus'
         errors:
           $ref: '#/components/schemas/V1NodeErrorsList'
+    V1SessionId:
+      type: string
+      description: Unique BOS v1 session identifier.
+      format: uuid
+      example: "8deb0746-b18c-427c-84a8-72ec6a28642c"
     V1BootSetStatus:
       type: object
       description: |
@@ -296,9 +301,7 @@ components:
           description: Name of the Boot Set
           example: "Boot-Set"
         session:
-          type: string
-          description: Session ID
-          example: "Session-ID"
+          $ref: '#/components/schemas/V1SessionId'
         metadata:
           $ref: '#/components/schemas/V1GenericMetadata'
         phases:
@@ -329,9 +332,7 @@ components:
              type: string
            minItems: 1
         id:
-          type: string
-          description: Session ID
-          format: uuid
+          $ref: '#/components/schemas/V1SessionId'
         links:
           type: array
           items:
@@ -1594,22 +1595,22 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     get:
-      summary: List sessions
+      summary: List session IDs
       description: |
-        List all sessions, including those in progress and those complete.
+        List IDs of all sessions, including those in progress and those complete.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.session
       operationId: get_v1_sessions
       responses:
         200:
-          description: A collection of Sessions
+          description: A collection of Session IDs
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/V1Session'
+                  $ref: '#/components/schemas/V1SessionId'
   /v1/session/{session_id}:
     get:
       summary: Get session details by ID


### PR DESCRIPTION
I have six related PRs out for review currently. I recommend reviewing them in this order (since they build on each other in some cases):
1. [CASMCMS-8626](https://github.com/Cray-HPE/bos/pull/133)
2. [CASMTRIAGE-5367](https://github.com/Cray-HPE/bos/pull/134)
3. [CASMCMS-8576](https://github.com/Cray-HPE/bos/pull/126) (this one)
4. [CASMCMS-8572](https://github.com/Cray-HPE/bos/pull/127)
5. [CASMCMS-8577](https://github.com/Cray-HPE/bos/pull/128)
6. [CASMCMS-8447](https://github.com/Cray-HPE/bos/pull/130)

PR #1 is into develop. Each subsequent PR is made onto the PR branch of the previous PR. That way each PR review focuses just on the changes made for that PR.

I also have a single PR into support/2.0 which includes all of these (since the changes are identical, I figured it was easier once the develop versions are approved to merge into support with a single PR): https://github.com/Cray-HPE/bos/pull/132

## Summary and Scope

The API spec says that GETs to `/v1/session` will return a list of sessions, but it actually just returns a list of session ID strings.

```text
>>> r = requests.get("https://api-gw-service-nmn.local/apis/bos/v1/session", headers=h)
>>> r
<Response [200]>
>>> r.json()
['90730844-094d-45a5-9b90-d661d14d9444']
```

This PR creates a new schema for v1 session ID, and then references that in the places where BOS v1 session IDs are expected (including a list of them when making a GET call to the aforementioned endpoint).

This PR only changes the spec to match the actual BOS behavior -- it does not change BOS itself.

## Issues and Related PRs

* Resolves [CASMCMS-8576](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8576)
* Part of [CASMCMS-8559](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8559)

## Testing

I ran the updated spec through a Swagger spec validation tool. Jason also deployed and used a version of BOS including this change to test a fix for a customer problem.

## Risks and Mitigations

Low risk -- only changing the spec.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
