### PR TITLE
CASMCMS-8572: Update API spec to reflect that creating a BOS v1 session requires operation AND templateName/templateUuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     two additional fields that don't show up in any other BOS link objects.
   - Specify that the BOS v1 session ID is in UUID format.
   - Specify that a GET to `/v1/session` returns a list of session IDs, not sessions.
+  - Specify that creating a BOS v1 session requires `operation` to be specified and one or both of
+    `templateName` and `templateUuid` (although if both are specified, the latter is ignored).
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 - Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
 - Correct API spec to use valid ECMA 262 regular expression syntax, as dictated by the OpenAPI requirements.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -500,7 +500,65 @@ components:
       additionalProperties: false
     V1Session:
       description: |
-        A Session object
+        A Session object specified by templateName
+
+        ## Link Relationships
+
+        * self : The session object
+      type: object
+      properties:
+        operation:
+          type: string
+          description: >
+            A Session represents an operation on a SessionTemplate.
+            The creation of a session effectively results in the creation
+            of a Kubernetes Boot Orchestration Agent (BOA) job to perform the
+            duties required to complete the operation.
+
+            Operation -- An operation to perform on nodes in this session.
+
+                Boot         Boot nodes that are off.
+
+                Configure    Reconfigure the nodes using the Configuration Framework
+                             Service (CFS).
+
+                Reboot       Gracefully power down nodes that are on and then power
+                             them back up.
+
+                Shutdown     Gracefully power down nodes that are on.
+
+          pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[rR][eE][bB][oO][oO][tT]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
+        templateUuid:
+          type: string
+          description: DEPRECATED - use templateName. This field is ignored if templateName is also set.
+          example: "my-session-template"
+        templateName:
+          type: string
+          description: The name of the Session Template
+          example: "my-session-template"
+        job:
+          type: string
+          maxLength: 64
+          readOnly: true
+          description: >
+            The identity of the Kubernetes job that is created to handle the session.
+          example: "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+        limit:
+          type: string
+          description: >
+            A comma-separated of nodes, groups, or roles to which the session
+            will be limited. Components are treated as OR operations unless
+            preceded by "&" for AND or "!" for NOT.
+        links:
+          type: array
+          readOnly: true
+          items:
+            $ref: '#/components/schemas/V1SessionLink'
+      required: [operation, templateName]
+      additionalProperties: false
+    V1SessionByTemplateUuid:
+      description: |
+        A Session object specified by templateUuid (DEPRECATED -- use templateName)
 
         ## Link Relationships
 
@@ -532,10 +590,6 @@ components:
           type: string
           description: DEPRECATED - use templateName
           example: "my-session-template"
-        templateName:
-          type: string
-          description: The name of the Session Template
-          example: "my-session-template"
         job:
           type: string
           maxLength: 64
@@ -554,7 +608,7 @@ components:
           readOnly: true
           items:
             $ref: '#/components/schemas/V1SessionLink'
-      required: [operation]
+      required: [operation, templateUuid]
       additionalProperties: false
     V1NodeChangeList:
       type: object
@@ -1586,7 +1640,9 @@ paths:
          content:
            application/json:
              schema:
-               $ref: '#/components/schemas/V1Session'
+               oneOf:
+                 - $ref: '#/components/schemas/V1Session'
+                 - $ref: '#/components/schemas/V1SessionByTemplateUuid'
       responses:
         201:
           $ref: '#/components/responses/V1SessionDetails'


### PR DESCRIPTION
I have six related PRs out for review currently. I recommend reviewing them in this order (since they build on each other in some cases):
1. [CASMCMS-8626](https://github.com/Cray-HPE/bos/pull/133)
2. [CASMTRIAGE-5367](https://github.com/Cray-HPE/bos/pull/134)
3. [CASMCMS-8576](https://github.com/Cray-HPE/bos/pull/126)
4. [CASMCMS-8572](https://github.com/Cray-HPE/bos/pull/127) (this one)
5. [CASMCMS-8577](https://github.com/Cray-HPE/bos/pull/128)
6. [CASMCMS-8447](https://github.com/Cray-HPE/bos/pull/130)

PR #1 is into develop. Each subsequent PR is made onto the PR branch of the previous PR. That way each PR review focuses just on the changes made for that PR.

I also have a single PR into support/2.0 which includes all of these (since the changes are identical, I figured it was easier once the develop versions are approved to merge into support with a single PR): https://github.com/Cray-HPE/bos/pull/132

## Summary and Scope

NOTE: This PR is deliberately against another dev branch, because it makes reviewing each PR easier, so you can focus just on the parts that it changes.

When creating a BOS v1 session, one must specify the desired operation and the session template to be used. The spec only specifies that the operation is required. This PR updates the spec to reflect that the template is also required.

Unfortunately, BOS v1 has two ways to specify this -- `templateUuid` (which was deprecated in CSM 1.2 but is still usable to create sessions) and `templateName`. And Swagger does not have an easy way to say one of the following arguments is required. The way to do it is to create multiple schemas for the possible inputs, and then say one of THOSE is acceptable as input to the endpoint. So that's what this PR does.

This PR also clarifies the fact that if you do specify both when creating a template, the `templateUuid` value is ignored.

## Issues and Related PRs

* Resolves [CASMCMS-8572](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8572)
* Part of [CASMCMS-8559](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8559)

## Testing

Ran the updated spec against a Swagger validation tool. Jason also deployed and used a version of BOS including this change to test a fix for a customer problem.

## Risks and Mitigations

Low risk -- only updated the spec, none of the BOS code.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
