### PR TITLE
CASMCMS-8585: Return valid BOS v2 session template on GET request to /v2/sessiontemplatetemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Created `V1SessionLink` definition to reflect that the `links` field for BOS v1 sessions can have
     two additional fields that don't show up in any other BOS link objects.
   - Specify that the BOS v1 session ID is in UUID format.
+- Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 
 ## [2.3.0] - 2023-05-10
 ### Changed

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -38,8 +38,7 @@ EXAMPLE_BOOT_SET = {
     "type": "your-boot-type",
     "etag": "your_boot_image_etag",
     "kernel_parameters": "your-kernel-parameters",
-    "cfs": {"configuration": "bootset_specific_cfs_override"},
-    "network": "nmn",
+    "cfs": {"configuration": "bootset-specific-cfs-override"},
     "node_list": [
         "xname1", "xname2", "xname3"],
     "path": "your-boot-path",


### PR DESCRIPTION
## Summary and Scope

A GET request to `/v2/sessiontemplatetemplate` returns a template that has a boot set with a `network` field, which is not legal in BOS v2 session templates. This PR updates the example template that is returned, removing that v1-only field. It also changes a couple of underscores to dashes (inside of string values) to match the rest of the example.

## Issues and Related PRs

* Resolves [CASMCMS-8585](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8585)
* Part of [CASMCMS-8559](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8559)

## Testing

Tested on starlord to make sure that the updated template was properly returned.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
