### PR TITLE
CASMCMS-8447: Update API spec to show that GET of session templates can return v1 or v2 templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `templateName` and `templateUuid` (although if both are specified, the latter is ignored).
   - Make the spec accurately reflect what is returned when creating a BOS v1 session and when doing a GET
     of a BOS v1 session.
+  - Indicate that GET of a session template or list of session templates can return v1 or v2 templates,
+    regardless of which endpoint is used.
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 - Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
 - Correct API spec to use valid ECMA 262 regular expression syntax, as dictated by the OpenAPI requirements.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -822,11 +822,6 @@ components:
           items:
             $ref: '#/components/schemas/Link'
       additionalProperties: false
-    V2SessionTemplateArray:
-      description: An array of session templates.
-      type: array
-      items:
-        $ref: '#/components/schemas/V2SessionTemplate'
     V2SessionTemplateValidation:
       description: |
         Message describing errors or incompleteness in a Session Template.
@@ -1363,6 +1358,14 @@ components:
           description: The default maximum number attempts per node for failed actions.
           example: 1
       additionalProperties: true
+    # Schemas that combine objects of different versions
+    SessionTemplateArray:
+      description: An array of session templates.
+      type: array
+      items:
+        anyOf:
+          - $ref: '#/components/schemas/V1SessionTemplate'
+          - $ref: '#/components/schemas/V2SessionTemplate'
   requestBodies:
     V2sessionCreateRequest:
       description: The information to create a session
@@ -1470,12 +1473,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V2SessionTemplate'
-    V2SessionTemplateDetailsArray:
-      description: Session template details
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/V2SessionTemplateArray'
     V2SessionTemplateValidation:
       description: Session template validity details
       content:
@@ -1524,6 +1521,21 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V2Options'
+    # Responses that may contain V1 or V2 objects
+    SessionTemplateDetails:
+      description: Session template details
+      content:
+        application/json:
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/V1SessionTemplate'
+              - $ref: '#/components/schemas/V2SessionTemplate'
+    SessionTemplateDetailsArray:
+      description: Session template details array
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SessionTemplateArray'
     # Errors
     AlreadyExists:
       description: The resource to be created already exists
@@ -1635,13 +1647,7 @@ paths:
       operationId: get_v1_sessiontemplates
       responses:
         200:
-          description: A collection of SessionTemplates
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/V1SessionTemplate'
+          $ref: '#/components/responses/SessionTemplateDetailsArray'
   /v1/sessiontemplate/{session_template_id}:
     parameters:
       - name: session_template_id
@@ -1662,7 +1668,7 @@ paths:
       operationId: get_v1_sessiontemplate
       responses:
         200:
-          $ref: '#/components/responses/V1SessionTemplateDetails'
+          $ref: '#/components/responses/SessionTemplateDetails'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
@@ -2078,7 +2084,7 @@ paths:
       operationId: get_v2_sessiontemplates
       responses:
         200:
-          $ref: '#/components/responses/V2SessionTemplateDetailsArray'
+          $ref: '#/components/responses/SessionTemplateDetailsArray'
   /v2/sessiontemplatesvalid/{session_template_id}:
     parameters:
       - name: session_template_id
@@ -2124,7 +2130,7 @@ paths:
       operationId: get_v2_sessiontemplate
       responses:
         200:
-          $ref: '#/components/responses/V2SessionTemplateDetails'
+          $ref: '#/components/responses/SessionTemplateDetails'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     put:


### PR DESCRIPTION
I have six related PRs out for review currently. I recommend reviewing them in this order (since they build on each other in some cases):
1. [CASMCMS-8626](https://github.com/Cray-HPE/bos/pull/133)
2. [CASMTRIAGE-5367](https://github.com/Cray-HPE/bos/pull/134)
3. [CASMCMS-8576](https://github.com/Cray-HPE/bos/pull/126)
4. [CASMCMS-8572](https://github.com/Cray-HPE/bos/pull/127)
5. [CASMCMS-8577](https://github.com/Cray-HPE/bos/pull/128)
6. [CASMCMS-8447](https://github.com/Cray-HPE/bos/pull/130) (this one)

PR #1 is into develop. Each subsequent PR is made onto the PR branch of the previous PR. That way each PR review focuses just on the changes made for that PR.

I also have a single PR into support/2.0 which includes all of these (since the changes are identical, I figured it was easier once the develop versions are approved to merge into support with a single PR): https://github.com/Cray-HPE/bos/pull/132

## Summary and Scope

The BOS API spec acts as though BOS internally distinguishes between v1 and v2 session templates. Calls to `/v1/sessiontemplate` or `/v1/sessiontemplate/{template_name}` should (per the spec) always return objects which fit the V1SessionTemplate schema. And similarly, calls to the corresponding v2 endpoints should (per the spec) always return objects which fit the V2SessionTemplate schema.

However, the reality is that all session templates are considered equal inside of BOS. Calls to `/v1/sessiontemplate` or `/v2/sessiontemplates` will both return all of the session templates on the system, whether they fit the V1 or V2 schemas. (With the exception of calls to the V2 endpoint with a tenant specified -- those will only return templates for that particular tenant, which necessarily will be V2 templates, since the V1 sessiontemplate create endpoint rejects requests where a tenant is specified).

The same thing happens if you make GET requests for a specific session template. Whether you use the v1 or v2 endpoint, you will get the template with the given name, regardless of whether it fits the V1 or V2 schema.

This PR updates the spec to reflect the fact that GET requests to these endpoints may return templates of either kind (or in the case of listing the templates, it may return an array containing one or both types).

Note that there are still some cases where endpoints return session templates that are specifically V1 or V2. For example, when a template is created (or patched in V2), the template returned will match the version of the endpoint. Or when the sessiontemplatetemplate endpoints are used, the resulting template will fit the schema of the endpoint version used. The spec already accurately reflects this, and this PR does not break that.

This PR only changes the spec to match the actual BOS behavior. It does not make any changes to BOS itself. While this behavior is not necessarily desirable, any change to it would be a breaking change that would require a major version bump. So the best we can do for now is at least make the spec reflect reality.

## Issues and Related PRs

* Resolves [CASMCMS-8447](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8447)
* Part of [CASMCMS-8559](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8559)

## Testing

I ran the updated spec through a Swagger spec validation tool. Jason also deployed and used a version of BOS including this change to test a fix for a customer problem.

## Risks and Mitigations

Low risk -- only changing the spec.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable