### PR TITLE
CASMTRIAGE-5367: Rearrange (?i) option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Rearranged the case insensitivity option in the OpenAPI spec to conform to newer Python rules.
+
 ### Fixed
 - Fixed a window during power-on operations which could lead to an incorrect status in larger systems
 - Updated API spec so that it accurately describes the actual implementation:
@@ -20,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v1 endpoints now thrown an error when a tenant is specified
 - v2 calls to create resources now throw an error when the tenant is invalid
 - Updated database keys to prevent collisions and added migration to the new database key format
-- 'include_disabled' option to decide whether disabled nodes should be part of a BOS session 
+- 'include_disabled' option to decide whether disabled nodes should be part of a BOS session
 - Updating `x86_64` RPM builds to type `noarch` for ARM required work CASMCMS-8517
 
 ## [2.2.0] - 2023-05-10

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -111,13 +111,13 @@ components:
       description: Version data
       type: object
       properties:
-        major: 
+        major:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
-        minor: 
+        minor:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
-        patch: 
+        patch:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
         links:
@@ -248,7 +248,7 @@ components:
           description: |
             Name of the Phase Category
           example: "Succeeded"
-          pattern: '^(?i)not_started|in_progress|succeeded|failed|excluded$'
+          pattern: '(?i)^not_started|in_progress|succeeded|failed|excluded$'
         node_list:
           $ref: '#/components/schemas/V1NodeList'
     V1PhaseStatus:
@@ -267,7 +267,7 @@ components:
           description: |
             Name of the Phase
           example: "Boot"
-          pattern: '^(?i)boot|configure|shutdown$'
+          pattern: '(?i)^boot|configure|shutdown$'
         metadata:
           $ref: '#/components/schemas/V1GenericMetadata'
         categories:
@@ -381,7 +381,7 @@ components:
           description: |
             The network over which the node will boot from.
             Choices:  NMN -- Node Management Network
-            pattern: '^(?i)nmn$'
+            pattern: '(?i)^nmn$'
         node_list:
           type: array
           items:
@@ -523,7 +523,7 @@ components:
 
                 Shutdown     Gracefully power down nodes that are on.
 
-          pattern: '^(?i)boot|configure|reboot|shutdown$'
+          pattern: '(?i)^boot|configure|reboot|shutdown$'
         templateUuid:
           type: string
           description: DEPRECATED - use templateName
@@ -1442,7 +1442,7 @@ paths:
         - version
       x-openapi-router-controller: bos.server.controllers.base
       responses:
-        200:          
+        200:
           description: A collection of Versions
           content:
             application/json:


### PR DESCRIPTION
## Summary and Scope

The case-insensitive option (?i) needs to appear at the beginning of the regular expression line. If it does not, later versions of Python flag this as an error.

(cherry picked from commit ed6ffe7abcf2f79bb39760f56ca2af75132d9c42)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAG-5367](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Crossroads24`

### Test description:

I uploaded and ran the new BOS image with the fix. I reran the triggering command, and it did not cause the BOS API to crash. Mission accomplished.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Low; it's broken otherwise.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

