### PR TITLE
CASMTRIAGE-5367: Rearrange (?i) option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.0.14] - 2023-05-17
+### Changed
+- Rearranged the case insensitivity option in the OpenAPI spec to conform to newer Python rules.
+
 ### Fixed
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -381,7 +381,7 @@ components:
           description: |
             The network over which the node will boot from.
             Choices:  NMN -- Node Management Network
-            pattern: '(?i)^nmn$'
+          pattern: '(?i)^nmn$'
         node_list:
           type: array
           items:

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -111,13 +111,13 @@ components:
       description: Version data
       type: object
       properties:
-        major: 
+        major:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
-        minor: 
+        minor:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
-        patch: 
+        patch:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
         links:
@@ -248,7 +248,7 @@ components:
           description: |
             Name of the Phase Category
           example: "Succeeded"
-          pattern: '^(?i)not_started|in_progress|succeeded|failed|excluded$'
+          pattern: '(?i)^not_started|in_progress|succeeded|failed|excluded$'
         node_list:
           $ref: '#/components/schemas/V1NodeList'
     V1PhaseStatus:
@@ -267,7 +267,7 @@ components:
           description: |
             Name of the Phase
           example: "Boot"
-          pattern: '^(?i)boot|configure|shutdown$'
+          pattern: '(?i)^boot|configure|shutdown$'
         metadata:
           $ref: '#/components/schemas/V1GenericMetadata'
         categories:
@@ -381,7 +381,7 @@ components:
           description: |
             The network over which the node will boot from.
             Choices:  NMN -- Node Management Network
-            pattern: '^(?i)nmn$'
+            pattern: '(?i)^nmn$'
         node_list:
           type: array
           items:
@@ -523,7 +523,7 @@ components:
 
                 Shutdown     Gracefully power down nodes that are on.
 
-          pattern: '^(?i)boot|configure|reboot|shutdown$'
+          pattern: '(?i)^boot|configure|reboot|shutdown$'
         templateUuid:
           type: string
           description: DEPRECATED - use templateName
@@ -1430,7 +1430,7 @@ paths:
         - version
       x-openapi-router-controller: bos.server.controllers.base
       responses:
-        200:          
+        200:
           description: A collection of Versions
           content:
             application/json:


### PR DESCRIPTION
## Summary and Scope

The case-insensitive option (?i) needs to appear at the beginning of the regular expression line. If it does not, later versions of Python flag this as an error.

(cherry picked from commit ed6ffe7abcf2f79bb39760f56ca2af75132d9c42)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAG-5367](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Crossroads24`

### Test description:

I uploaded and ran the new BOS image with the fix. I reran the triggering command, and it did not cause the BOS API to crash. Mission accomplished.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Low; it's broken otherwise.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

