### PR TITLE
CASMCMS-8626: API spec linting to correct minor errors, omissions, and inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     two additional fields that don't show up in any other BOS link objects.
   - Specify that the BOS v1 session ID is in UUID format.
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
+- Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
 
 ## [2.3.0] - 2023-05-10
 ### Changed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -37,6 +37,7 @@ info:
 
     ### Create a New Session
 
+
     #### GET /sessiontemplate
 
     List available session templates.
@@ -72,10 +73,9 @@ info:
     to uniquely identify a session in for the /session/{session_id}
     endpoint.
 
-
     #### GET /session/{session_id}
 
-    Get session details by session id.
+    Get session details by session ID.
 
     List all in progress and completed sessions.
 
@@ -87,9 +87,7 @@ info:
     and if *enable_cfs* is true then
     BOS will invoke CFS to configure the compute nodes.
 
-
-    All boot images specified via the session template, must be available via IMS.
-
+    All boot images specified via the session template must be available via IMS.
 
 servers:
 - url: https://api-gw-service-nmn.local/apis/bos
@@ -111,13 +109,13 @@ components:
       description: Version data
       type: object
       properties:
-        major: 
+        major:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
-        minor: 
+        minor:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
-        patch: 
+        patch:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
         links:
@@ -130,14 +128,14 @@ components:
       type: object
       properties:
         type:
-          description:
+          description: |
             Relative URI reference to the type of problem which includes human
             readable documentation.
           type: string
           format: uri
           default: "about:blank"
         title:
-          description:
+          description: |
             Short, human-readable summary of the problem, should not change by
             occurrence.
           type: string
@@ -146,12 +144,13 @@ components:
           type: integer
           example: 400
         instance:
-          description: A relative URI reference that identifies the specific
-            occurrence of the problem
+          description: |
+            A relative URI reference that identifies the specific occurrence of
+            the problem
           format: uri
           type: string
         detail:
-          description:
+          description: |
             A human-readable explanation specific to this occurrence of the
             problem. Focus on helping correct the problem, rather than giving
             debugging information.
@@ -185,7 +184,7 @@ components:
         commit:
           type: string
           description: |
-            The commit id of the configuration that you want to
+            The commit ID of the configuration that you want to
             apply to the nodes. Mutually exclusive with branch. (DEPRECATED)
         playbook:
           type: string
@@ -230,6 +229,8 @@ components:
       additionalProperties: false
     V1NodeList:
       type: array
+      description: |
+        A list of node xnames.
       items:
         type: string
         example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
@@ -367,7 +368,7 @@ components:
         type:
           type: string
           description: |
-            The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
+            The MIME type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
         etag:
           type: string
           description: |
@@ -379,9 +380,9 @@ components:
         network:
           type: string
           description: |
-            The network over which the node will boot from.
+            The network over which the node will boot.
             Choices:  NMN -- Node Management Network
-            pattern: '^(?i)nmn$'
+          pattern: '^(?i)nmn$'
         node_list:
           type: array
           items:
@@ -528,12 +529,10 @@ components:
           type: string
           description: DEPRECATED - use templateName
           example: "my-session-template"
-          format: string
         templateName:
           type: string
           description: The name of the Session Template
           example: "my-session-template"
-          format: string
         job:
           type: string
           maxLength: 64
@@ -745,7 +744,6 @@ components:
           type: string
           description: The name of the Session Template
           example: "my-session-template"
-          format: string
         limit:
           type: string
           description: >
@@ -810,7 +808,7 @@ components:
         type:
           type: string
           description: |
-            The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
+            The MIME type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
         etag:
           type: string
           description: |
@@ -888,7 +886,6 @@ components:
           type: string
           description: The name of the Session Template
           example: "my-session-template"
-          format: string
         limit:
           type: string
           description: >
@@ -1124,7 +1121,7 @@ components:
       properties:
         id:
           type: string
-          description: The component's id. e.g. xname for hardware components
+          description: The component's ID. e.g. xname for hardware components
         actual_state:
           $ref: '#/components/schemas/V2ComponentActualState'
         desired_state:
@@ -1367,7 +1364,7 @@ components:
           schema:
             $ref: '#/components/schemas/V2Session'
     V2SessionDetailsArray:
-      description: Session details
+      description: Session details array
       content:
         application/json:
           schema:
@@ -1442,7 +1439,7 @@ paths:
         - version
       x-openapi-router-controller: bos.server.controllers.base
       responses:
-        200:          
+        200:
           description: A collection of Versions
           content:
             application/json:
@@ -1457,6 +1454,7 @@ paths:
   /v1:
     get:
       summary: Get API version
+      description: Return the API version
       tags:
         - version
       x-openapi-router-controller: bos.server.controllers.v1.base
@@ -1473,8 +1471,7 @@ paths:
         - healthz
       x-openapi-router-controller: bos.server.controllers.v1.healthz
       operationId: v1_get_healthz
-      description:
-        Get bos health details.
+      description: Get BOS health details.
       responses:
         200:
           $ref: '#/components/responses/ServiceHealth'
@@ -1489,8 +1486,7 @@ paths:
         - sessiontemplate
       x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
       operationId: create_v1_sessiontemplate
-      description:
-        Create a new session template.
+      description: Create a new session template.
       requestBody:
          description: A JSON object for creating a session template
          required: true
@@ -1530,10 +1526,10 @@ paths:
         schema:
           type: string
     get:
-      summary: Get session template by id
+      summary: Get session template by ID
       description: |
-        Get session template by session_template_id.
-        The session_template_id corresponds to the *name*
+        Get session template by session template ID.
+        The session template ID corresponds to the *name*
         of the session template.
       tags:
         - sessiontemplate
@@ -1614,8 +1610,8 @@ paths:
                   $ref: '#/components/schemas/V1Session'
   /v1/session/{session_id}:
     get:
-      summary: Get session details by id
-      description: Get session details by session_id.
+      summary: Get session details by ID
+      description: Get session details by session ID.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.session
@@ -1626,8 +1622,8 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
-      summary: Delete session by id
-      description: Delete session by session_id.
+      summary: Delete session by ID
+      description: Delete session by session ID.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.session
@@ -1745,7 +1741,7 @@ paths:
       operationId: get_v1_session_status_by_bootset
       responses:
         200:
-          description: A list of the Phase Statuses for the Boot Set and metadata
+          description: Metadata and a list of the Phase Statuses for the Boot Set
           content:
             application/json:
               schema:
@@ -1904,6 +1900,7 @@ paths:
         - version
       x-openapi-router-controller: bos.server.controllers.v1.base
       operationId: v1_get_version
+      description: Return the API version
       responses:
         200:
           $ref: '#/components/responses/Version'
@@ -1918,6 +1915,7 @@ paths:
         - version
       x-openapi-router-controller: bos.server.controllers.v2.base
       operationId: get_v2
+      description: Return the API version
       responses:
         200:
           $ref: '#/components/responses/Version'
@@ -1931,8 +1929,8 @@ paths:
         - healthz
       x-openapi-router-controller: bos.server.controllers.v2.healthz
       operationId: get_v2_healthz
-      description:
-        Get bos health details.
+      description: |
+        Get BOS health details.
       responses:
         200:
          $ref: '#/components/responses/ServiceHealth'
@@ -1963,10 +1961,10 @@ paths:
         schema:
           type: string
     get:
-      summary: Validate the session template by id
+      summary: Validate the session template by ID
       description: |
-        Validate session template by session_template_id.
-        The session_template_id corresponds to the *name*
+        Validate session template by session template ID.
+        The session template ID corresponds to the *name*
         of the session template.
       tags:
         - v2
@@ -1987,10 +1985,10 @@ paths:
         schema:
           type: string
     get:
-      summary: Get session template by id
+      summary: Get session template by ID
       description: |
-        Get session template by session_template_id.
-        The session_template_id corresponds to the *name*
+        Get session template by session template ID.
+        The session template ID corresponds to the *name*
         of the session template.
       tags:
         - v2
@@ -2009,8 +2007,7 @@ paths:
         - sessiontemplates
       x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
       operationId: put_v2_sessiontemplate
-      description:
-        Create a new session template.
+      description: Create a new session template.
       requestBody:
          description: A JSON object for creating a session template
          required: true
@@ -2030,6 +2027,7 @@ paths:
         - sessiontemplates
       x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
       operationId: patch_v2_sessiontemplate
+      description: Update an existing session template.
       requestBody:
         description: A JSON object for updating a session template
         required: true
@@ -2130,6 +2128,9 @@ paths:
         - sessions
       x-openapi-router-controller: bos.server.controllers.v2.sessions
       operationId: delete_v2_sessions
+      description: |
+        Delete multiple sessions.  If filters are provided, only sessions matching
+        all filters will be deleted.  By default only completed sessions will be deleted.
       parameters:
         - name: min_age
           schema:
@@ -2150,9 +2151,6 @@ paths:
           in: query
           description: >-
             Return only sessions with the given status.
-      description:
-        Delete multiple sessions.  If filters are provided, only sessions matching
-        all filters will be deleted.  By default only completed sessions will be deleted.
       responses:
         204:
           $ref: '#/components/responses/ResourceDeleted'
@@ -2160,8 +2158,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
   /v2/sessions/{session_id}:
     get:
-      summary: Get session details by id
-      description: Get session details by session_id.
+      summary: Get session details by ID
+      description: Get session details by session ID.
       tags:
         - v2
         - sessions
@@ -2190,8 +2188,8 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
-      summary: Delete session by id
-      description: Delete session by session_id.
+      summary: Delete session by ID
+      description: Delete session by session ID.
       tags:
         - v2
         - sessions
@@ -2211,8 +2209,8 @@ paths:
           type: string
   /v2/sessions/{session_id}/status:
     get:
-      summary: Get session extended status information by id
-      description: Get session extended status information by id
+      summary: Get session extended status information by ID
+      description: Get session extended status information by ID
       tags:
         - v2
         - sessions
@@ -2265,7 +2263,7 @@ paths:
             type: string
           in: query
           description: >-
-            Retrieve the components with the given id
+            Retrieve the components with the given ID
             (e.g. xname for hardware components). Can be chained
             for selecting groups of components.
         - name: session
@@ -2273,13 +2271,13 @@ paths:
             type: string
           in: query
           description: >-
-            Retrieve the components with the given session id.
+            Retrieve the components with the given session ID.
         - name: staged_session
           schema:
             type: string
           in: query
           description: >-
-            Retrieve the components with the given staged session id.
+            Retrieve the components with the given staged session ID.
         - name: enabled
           schema:
             type: boolean
@@ -2402,7 +2400,7 @@ paths:
     parameters:
       - name: component_id
         in: path
-        description: Component id. e.g. xname for hardware components
+        description: Component ID. e.g. xname for hardware components
         required: true
         schema:
           type: string
@@ -2455,6 +2453,7 @@ paths:
   /v2/version:
     get:
       summary: Get API version
+      description: Return the API version
       tags:
         - v2
         - version


### PR DESCRIPTION
## Summary and Scope

In my work on the BOS API spec I have found some objects and endpoints missing the description field, one field which isn't being parsed at all (because of improper indentation), some inconsistencies in the language and formatting used, and some other minor errors. This cleans it all up. No functional changes.

## Testing

I ran the spec through an OpenAPI validation tool.

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
