### PR TITLE
CASMTRIAGE-5367: Update API spec to use valid ECMA 262 regular expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Specify that the BOS v1 session ID is in UUID format.
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 - Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
+- Correct API spec to use valid ECMA 262 regular expression syntax, as dictated by the OpenAPI requirements.
 
 ## [2.3.0] - 2023-05-10
 ### Changed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -111,13 +111,13 @@ components:
       properties:
         major:
           type: string
-          pattern: "^(0|[1-9][0-9]*)$"
+          pattern: '^(0|[1-9][0-9]*)$'
         minor:
           type: string
-          pattern: "^(0|[1-9][0-9]*)$"
+          pattern: '^(0|[1-9][0-9]*)$'
         patch:
           type: string
-          pattern: "^(0|[1-9][0-9]*)$"
+          pattern: '^(0|[1-9][0-9]*)$'
         links:
           type: array
           items:
@@ -248,8 +248,9 @@ components:
           type: string
           description: |
             Name of the Phase Category
+            not_started, in_progress, succeeded, failed, or excluded
           example: "Succeeded"
-          pattern: '^(?i)not_started|in_progress|succeeded|failed|excluded$'
+          pattern: '^([nN][oO][tT]_[sS][tT][aA][rR][tT][eE][dD]|[iI][nN]_[pP][rR][oO][gG][rR][eE][sS][sS]|[sS][uU][cC][cC][eE][eE][dD][eE][dD]|[fF][aA][iI][lL][eE][dD]|[eE][xX][cC][lL][uU][dD][eE][dD])$'
         node_list:
           $ref: '#/components/schemas/V1NodeList'
     V1PhaseStatus:
@@ -267,8 +268,9 @@ components:
           type: string
           description: |
             Name of the Phase
+            boot, configure, or shutdown
           example: "Boot"
-          pattern: '^(?i)boot|configure|shutdown$'
+          pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
         metadata:
           $ref: '#/components/schemas/V1GenericMetadata'
         categories:
@@ -382,7 +384,7 @@ components:
           description: |
             The network over which the node will boot.
             Choices:  NMN -- Node Management Network
-          pattern: '^(?i)nmn$'
+          pattern: '^[nN][mM][nN]$'
         node_list:
           type: array
           items:
@@ -443,7 +445,7 @@ components:
           description: Name of the SessionTemplate. The length of the name is restricted to 45 characters.
           example: "cle-1.0.0"
           minLength: 1
-          pattern: "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
         description:
           type: string
           description: |
@@ -524,7 +526,7 @@ components:
 
                 Shutdown     Gracefully power down nodes that are on.
 
-          pattern: '^(?i)boot|configure|reboot|shutdown$'
+          pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[rR][eE][bB][oO][oO][tT]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
         templateUuid:
           type: string
           description: DEPRECATED - use templateName
@@ -590,13 +592,13 @@ components:
         properties:
           update_type:
             description: The type of update data
-            pattern: "NodeChangeList"
+            pattern: '^NodeChangeList$'
             type: string
           phase:
             description: |
-              The phase that this data belongs to. If  blank, it belongs to
-              the Boot Set itself, which only applies to the GenericMetadata type.
-            pattern: "(?i)shutdown|boot|configure"
+              The phase that this data belongs to (boot, shutdown, or configure). If blank,
+              it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
+            pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
             type: string
           data:
             $ref: '#/components/schemas/V1NodeChangeList'
@@ -610,13 +612,13 @@ components:
         properties:
           update_type:
             description: The type of update data
-            pattern: "NodeErrorsList"
+            pattern: '^NodeErrorsList$'
             type: string
           phase:
             description: |
-              The phase that this data belongs to. If  blank, it belongs to
-              the Boot Set itself, which only applies to the GenericMetadata type.
-            pattern: "(?i)shutdown|boot|configure"
+              The phase that this data belongs to (boot, shutdown, or configure). If blank,
+              it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
+            pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
             type: string
           data:
             $ref: '#/components/schemas/V1NodeErrorsList'
@@ -630,13 +632,13 @@ components:
         properties:
           update_type:
             description: The type of update data
-            pattern: "GenericMetadata"
+            pattern: '^GenericMetadata$'
             type: string
           phase:
             description: |
-              The phase that this data belongs to. If the phase is boot_set, it belongs to
-              the Boot Set itself, which only applies to the GenericMetadata type.
-            pattern: '(?i)shutdown|boot|configure|boot_set'
+              The phase that this data belongs to (boot, shutdown, or configure). If blank,
+              it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
+            pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
             type: string
           data:
             $ref: '#/components/schemas/V1GenericMetadata'
@@ -675,7 +677,7 @@ components:
           # These validation parameters are restricted by Kubernetes naming conventions.
           minLength: 1
           maxLength: 45
-          pattern: "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
           readOnly: true
         tenant:
           type: string


### PR DESCRIPTION
I have six related PRs out for review currently. I recommend reviewing them in this order (since they build on each other in some cases):
1. [CASMCMS-8626](https://github.com/Cray-HPE/bos/pull/133)
2. [CASMTRIAGE-5367](https://github.com/Cray-HPE/bos/pull/134) (this one)
3. [CASMCMS-8576](https://github.com/Cray-HPE/bos/pull/126)
4. [CASMCMS-8572](https://github.com/Cray-HPE/bos/pull/127)
5. [CASMCMS-8577](https://github.com/Cray-HPE/bos/pull/128)
6. [CASMCMS-8447](https://github.com/Cray-HPE/bos/pull/130)

PR #1 is into develop. Each subsequent PR is made onto the PR branch of the previous PR. That way each PR review focuses just on the changes made for that PR.

I also have a single PR into support/2.0 which includes all of these (since the changes are identical, I figured it was easier once the develop versions are approved to merge into support with a single PR): https://github.com/Cray-HPE/bos/pull/132

## Summary and Scope

[OpenAPI specifies the following](https://swagger.io/docs/specification/data-models/data-types/) regarding `pattern` fields:

> The regular expression syntax used is from JavaScript (more specifically, [ECMA 262](https://www.ecma-international.org/ecma-262/5.1/#sec-15.10.1))

There are a number of uses of `(?i)` in the BOS spec to make a pattern case insensitive. Unfortunately, that is not valid for ECMA 262 regular expressions. (and also unfortunately, there isn't an equally concise way to accomplish that using ECMA 262)

There are also a few other cases of regular expressions in the spec where it appears that the intention is that entire pattern be matched, but because of combining `^` and `$` with `|` to join regular expressions, the `^` and `$` directives are only used for one of the patterns joined by `|`.

This PR cleans up all of the above so that the patterns are all valid ECMA 262 regular expressions, and ones which are indeed selecting exactly the desired matches.

## Issues and Related PRs

* This will resolve the issue reported in [CASMTRIAGE-5367](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5367)
* I made this PR on top of [this linting one](https://github.com/Cray-HPE/bos/pull/133) because I wanted to separate out those changes from these, for review purposes.

## Testing

I ran the updated spec through an OpenAPI validator.
I also tested the regular expressions with a variety of inputs using https://regex101.com/ (set to the appropriate regex flavor).
Jason also deployed and used a version of BOS including this change to test a fix for a customer problem.

## Risks and Mitigations

Very low risk -- all changes are to the spec.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
