### PR TITLE
Backport API spec fixes into support/2.0 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Updated API spec so that it accurately describes the actual implementation:
   - Specify that a GET to `/v1/session` returns a list of session IDs, not sessions.
+  - Specify that creating a BOS v1 session requires `operation` to be specified and one or both of
+    `templateName` and `templateUuid` (although if both are specified, the latter is ignored).
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 - Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
 - Correct API spec to use valid ECMA 262 regular expression syntax, as dictated by the OpenAPI requirements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `templateName` and `templateUuid` (although if both are specified, the latter is ignored).
   - Make the spec accurately reflect what is returned when creating a BOS v1 session and when doing a GET
     of a BOS v1 session.
+  - Indicate that GET of a session template or list of session templates can return v1 or v2 templates,
+    regardless of which endpoint is used.
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 - Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
 - Correct API spec to use valid ECMA 262 regular expression syntax, as dictated by the OpenAPI requirements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Specify that a GET to `/v1/session` returns a list of session IDs, not sessions.
   - Specify that creating a BOS v1 session requires `operation` to be specified and one or both of
     `templateName` and `templateUuid` (although if both are specified, the latter is ignored).
+  - Make the spec accurately reflect what is returned when creating a BOS v1 session and when doing a GET
+    of a BOS v1 session.
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 - Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
 - Correct API spec to use valid ECMA 262 regular expression syntax, as dictated by the OpenAPI requirements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
+- Updated API spec so that it accurately describes the actual implementation:
+  - Specify that a GET to `/v1/session` returns a list of session IDs, not sessions.
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 - Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
 - Correct API spec to use valid ECMA 262 regular expression syntax, as dictated by the OpenAPI requirements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
+- Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
 
 ## [2.0.13] - 2023-05-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Return valid BOS v2 session template on GET request to `/v2/sessiontemplatetemplate`.
 - Formatting and language linting of API spec to correct minor errors, omissions, and inconsistencies.
+- Correct API spec to use valid ECMA 262 regular expression syntax, as dictated by the OpenAPI requirements.
 
 ## [2.0.13] - 2023-05-15
 ### Fixed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -500,7 +500,65 @@ components:
       additionalProperties: false
     V1Session:
       description: |
-        A Session object
+        A Session object specified by templateName
+
+        ## Link Relationships
+
+        * self : The session object
+      type: object
+      properties:
+        operation:
+          type: string
+          description: >
+            A Session represents an operation on a SessionTemplate.
+            The creation of a session effectively results in the creation
+            of a Kubernetes Boot Orchestration Agent (BOA) job to perform the
+            duties required to complete the operation.
+
+            Operation -- An operation to perform on nodes in this session.
+
+                Boot         Boot nodes that are off.
+
+                Configure    Reconfigure the nodes using the Configuration Framework
+                             Service (CFS).
+
+                Reboot       Gracefully power down nodes that are on and then power
+                             them back up.
+
+                Shutdown     Gracefully power down nodes that are on.
+
+          pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[rR][eE][bB][oO][oO][tT]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
+        templateUuid:
+          type: string
+          description: DEPRECATED - use templateName. This field is ignored if templateName is also set.
+          example: "my-session-template"
+        templateName:
+          type: string
+          description: The name of the Session Template
+          example: "my-session-template"
+        job:
+          type: string
+          maxLength: 64
+          readOnly: true
+          description: >
+            The identity of the Kubernetes job that is created to handle the session.
+          example: "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+        limit:
+          type: string
+          description: >
+            A comma-separated of nodes, groups, or roles to which the session
+            will be limited. Components are treated as OR operations unless
+            preceded by "&" for AND or "!" for NOT.
+        links:
+          type: array
+          readOnly: true
+          items:
+            $ref: '#/components/schemas/V1SessionLink'
+      required: [operation, templateName]
+      additionalProperties: false
+    V1SessionByTemplateUuid:
+      description: |
+        A Session object specified by templateUuid (DEPRECATED -- use templateName)
 
         ## Link Relationships
 
@@ -532,10 +590,6 @@ components:
           type: string
           description: DEPRECATED - use templateName
           example: "my-session-template"
-        templateName:
-          type: string
-          description: The name of the Session Template
-          example: "my-session-template"
         job:
           type: string
           maxLength: 64
@@ -554,7 +608,7 @@ components:
           readOnly: true
           items:
             $ref: '#/components/schemas/V1SessionLink'
-      required: [operation]
+      required: [operation, templateUuid]
       additionalProperties: false
     V1NodeChangeList:
       type: object
@@ -1574,7 +1628,9 @@ paths:
          content:
            application/json:
              schema:
-               $ref: '#/components/schemas/V1Session'
+               oneOf:
+                 - $ref: '#/components/schemas/V1Session'
+                 - $ref: '#/components/schemas/V1SessionByTemplateUuid'
       responses:
         201:
           $ref: '#/components/responses/V1SessionDetails'

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -816,11 +816,6 @@ components:
           items:
             $ref: '#/components/schemas/Link'
       additionalProperties: false
-    V2SessionTemplateArray:
-      description: An array of session templates.
-      type: array
-      items:
-        $ref: '#/components/schemas/V2SessionTemplate'
     V2SessionTemplateValidation:
       description: |
         Message describing errors or incompleteness in a Session Template.
@@ -1351,6 +1346,14 @@ components:
           description: The default maximum number attempts per node for failed actions.
           example: 1
       additionalProperties: true
+    # Schemas that combine objects of different versions
+    SessionTemplateArray:
+      description: An array of session templates.
+      type: array
+      items:
+        anyOf:
+          - $ref: '#/components/schemas/V1SessionTemplate'
+          - $ref: '#/components/schemas/V2SessionTemplate'
   requestBodies:
     V2sessionCreateRequest:
       description: The information to create a session
@@ -1458,12 +1461,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V2SessionTemplate'
-    V2SessionTemplateDetailsArray:
-      description: Session template details
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/V2SessionTemplateArray'
     V2SessionTemplateValidation:
       description: Session template validity details
       content:
@@ -1512,6 +1509,21 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V2Options'
+    # Responses that may contain V1 or V2 objects
+    SessionTemplateDetails:
+      description: Session template details
+      content:
+        application/json:
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/V1SessionTemplate'
+              - $ref: '#/components/schemas/V2SessionTemplate'
+    SessionTemplateDetailsArray:
+      description: Session template details array
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SessionTemplateArray'
     # Errors
     AlreadyExists:
       description: The resource to be created already exists
@@ -1623,13 +1635,7 @@ paths:
       operationId: get_v1_sessiontemplates
       responses:
         200:
-          description: A collection of SessionTemplates
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/V1SessionTemplate'
+          $ref: '#/components/responses/SessionTemplateDetailsArray'
   /v1/sessiontemplate/{session_template_id}:
     parameters:
       - name: session_template_id
@@ -1650,7 +1656,7 @@ paths:
       operationId: get_v1_sessiontemplate
       responses:
         200:
-          $ref: '#/components/responses/V1SessionTemplateDetails'
+          $ref: '#/components/responses/SessionTemplateDetails'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
@@ -2066,7 +2072,7 @@ paths:
       operationId: get_v2_sessiontemplates
       responses:
         200:
-          $ref: '#/components/responses/V2SessionTemplateDetailsArray'
+          $ref: '#/components/responses/SessionTemplateDetailsArray'
   /v2/sessiontemplatesvalid/{session_template_id}:
     parameters:
       - name: session_template_id
@@ -2112,7 +2118,7 @@ paths:
       operationId: get_v2_sessiontemplate
       responses:
         200:
-          $ref: '#/components/responses/V2SessionTemplateDetails'
+          $ref: '#/components/responses/SessionTemplateDetails'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     put:

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -279,6 +279,11 @@ components:
             $ref: '#/components/schemas/V1PhaseCategoryStatus'
         errors:
           $ref: '#/components/schemas/V1NodeErrorsList'
+    V1SessionId:
+      type: string
+      description: Unique BOS v1 session identifier.
+      format: uuid
+      example: "8deb0746-b18c-427c-84a8-72ec6a28642c"
     V1BootSetStatus:
       type: object
       description: |
@@ -296,9 +301,7 @@ components:
           description: Name of the Boot Set
           example: "Boot-Set"
         session:
-          type: string
-          description: Session ID
-          example: "Session-ID"
+          $ref: '#/components/schemas/V1SessionId'
         metadata:
           $ref: '#/components/schemas/V1GenericMetadata'
         phases:
@@ -329,9 +332,7 @@ components:
              type: string
            minItems: 1
         id:
-          type: string
-          description: Session ID
-          format: uuid
+          $ref: '#/components/schemas/V1SessionId'
         links:
           type: array
           items:
@@ -1582,22 +1583,22 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     get:
-      summary: List sessions
+      summary: List session IDs
       description: |
-        List all sessions, including those in progress and those complete.
+        List IDs of all sessions, including those in progress and those complete.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.session
       operationId: get_v1_sessions
       responses:
         200:
-          description: A collection of Sessions
+          description: A collection of Session IDs
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/V1Session'
+                  $ref: '#/components/schemas/V1SessionId'
   /v1/session/{session_id}:
     get:
       summary: Get session details by ID

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -111,13 +111,13 @@ components:
       properties:
         major:
           type: string
-          pattern: "^(0|[1-9][0-9]*)$"
+          pattern: '^(0|[1-9][0-9]*)$'
         minor:
           type: string
-          pattern: "^(0|[1-9][0-9]*)$"
+          pattern: '^(0|[1-9][0-9]*)$'
         patch:
           type: string
-          pattern: "^(0|[1-9][0-9]*)$"
+          pattern: '^(0|[1-9][0-9]*)$'
         links:
           type: array
           items:
@@ -248,8 +248,9 @@ components:
           type: string
           description: |
             Name of the Phase Category
+            not_started, in_progress, succeeded, failed, or excluded
           example: "Succeeded"
-          pattern: '^(?i)not_started|in_progress|succeeded|failed|excluded$'
+          pattern: '^([nN][oO][tT]_[sS][tT][aA][rR][tT][eE][dD]|[iI][nN]_[pP][rR][oO][gG][rR][eE][sS][sS]|[sS][uU][cC][cC][eE][eE][dD][eE][dD]|[fF][aA][iI][lL][eE][dD]|[eE][xX][cC][lL][uU][dD][eE][dD])$'
         node_list:
           $ref: '#/components/schemas/V1NodeList'
     V1PhaseStatus:
@@ -267,8 +268,9 @@ components:
           type: string
           description: |
             Name of the Phase
+            boot, configure, or shutdown
           example: "Boot"
-          pattern: '^(?i)boot|configure|shutdown$'
+          pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
         metadata:
           $ref: '#/components/schemas/V1GenericMetadata'
         categories:
@@ -382,7 +384,7 @@ components:
           description: |
             The network over which the node will boot.
             Choices:  NMN -- Node Management Network
-          pattern: '^(?i)nmn$'
+          pattern: '^[nN][mM][nN]$'
         node_list:
           type: array
           items:
@@ -443,7 +445,7 @@ components:
           description: Name of the SessionTemplate. The length of the name is restricted to 45 characters.
           example: "cle-1.0.0"
           minLength: 1
-          pattern: "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
         description:
           type: string
           description: |
@@ -524,7 +526,7 @@ components:
 
                 Shutdown     Gracefully power down nodes that are on.
 
-          pattern: '^(?i)boot|configure|reboot|shutdown$'
+          pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[rR][eE][bB][oO][oO][tT]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
         templateUuid:
           type: string
           description: DEPRECATED - use templateName
@@ -590,13 +592,13 @@ components:
         properties:
           update_type:
             description: The type of update data
-            pattern: "NodeChangeList"
+            pattern: '^NodeChangeList$'
             type: string
           phase:
             description: |
-              The phase that this data belongs to. If  blank, it belongs to
-              the Boot Set itself, which only applies to the GenericMetadata type.
-            pattern: "(?i)shutdown|boot|configure"
+              The phase that this data belongs to (boot, shutdown, or configure). If blank,
+              it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
+            pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
             type: string
           data:
             $ref: '#/components/schemas/V1NodeChangeList'
@@ -610,13 +612,13 @@ components:
         properties:
           update_type:
             description: The type of update data
-            pattern: "NodeErrorsList"
+            pattern: '^NodeErrorsList$'
             type: string
           phase:
             description: |
-              The phase that this data belongs to. If  blank, it belongs to
-              the Boot Set itself, which only applies to the GenericMetadata type.
-            pattern: "(?i)shutdown|boot|configure"
+              The phase that this data belongs to (boot, shutdown, or configure). If blank,
+              it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
+            pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
             type: string
           data:
             $ref: '#/components/schemas/V1NodeErrorsList'
@@ -630,13 +632,13 @@ components:
         properties:
           update_type:
             description: The type of update data
-            pattern: "GenericMetadata"
+            pattern: '^GenericMetadata$'
             type: string
           phase:
             description: |
-              The phase that this data belongs to. If the phase is boot_set, it belongs to
-              the Boot Set itself, which only applies to the GenericMetadata type.
-            pattern: '(?i)shutdown|boot|configure|boot_set'
+              The phase that this data belongs to (boot, shutdown, or configure). If blank,
+              it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
+            pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
             type: string
           data:
             $ref: '#/components/schemas/V1GenericMetadata'
@@ -675,7 +677,7 @@ components:
           # These validation parameters are restricted by Kubernetes naming conventions.
           minLength: 1
           maxLength: 45
-          pattern: "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
           readOnly: true
         description:
           type: string

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -37,6 +37,7 @@ info:
 
     ### Create a New Session
 
+
     #### GET /sessiontemplate
 
     List available session templates.
@@ -72,10 +73,9 @@ info:
     to uniquely identify a session in for the /session/{session_id}
     endpoint.
 
-
     #### GET /session/{session_id}
 
-    Get session details by session id.
+    Get session details by session ID.
 
     List all in progress and completed sessions.
 
@@ -87,9 +87,7 @@ info:
     and if *enable_cfs* is true then
     BOS will invoke CFS to configure the compute nodes.
 
-
-    All boot images specified via the session template, must be available via IMS.
-
+    All boot images specified via the session template must be available via IMS.
 
 servers:
 - url: https://api-gw-service-nmn.local/apis/bos
@@ -111,13 +109,13 @@ components:
       description: Version data
       type: object
       properties:
-        major: 
+        major:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
-        minor: 
+        minor:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
-        patch: 
+        patch:
           type: string
           pattern: "^(0|[1-9][0-9]*)$"
         links:
@@ -130,14 +128,14 @@ components:
       type: object
       properties:
         type:
-          description:
+          description: |
             Relative URI reference to the type of problem which includes human
             readable documentation.
           type: string
           format: uri
           default: "about:blank"
         title:
-          description:
+          description: |
             Short, human-readable summary of the problem, should not change by
             occurrence.
           type: string
@@ -146,12 +144,13 @@ components:
           type: integer
           example: 400
         instance:
-          description: A relative URI reference that identifies the specific
-            occurrence of the problem
+          description: |
+            A relative URI reference that identifies the specific occurrence of
+            the problem
           format: uri
           type: string
         detail:
-          description:
+          description: |
             A human-readable explanation specific to this occurrence of the
             problem. Focus on helping correct the problem, rather than giving
             debugging information.
@@ -185,7 +184,7 @@ components:
         commit:
           type: string
           description: |
-            The commit id of the configuration that you want to
+            The commit ID of the configuration that you want to
             apply to the nodes. Mutually exclusive with branch. (DEPRECATED)
         playbook:
           type: string
@@ -230,6 +229,8 @@ components:
       additionalProperties: false
     V1NodeList:
       type: array
+      description: |
+        A list of node xnames.
       items:
         type: string
         example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
@@ -367,7 +368,7 @@ components:
         type:
           type: string
           description: |
-            The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
+            The MIME type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
         etag:
           type: string
           description: |
@@ -379,9 +380,9 @@ components:
         network:
           type: string
           description: |
-            The network over which the node will boot from.
+            The network over which the node will boot.
             Choices:  NMN -- Node Management Network
-            pattern: '^(?i)nmn$'
+          pattern: '^(?i)nmn$'
         node_list:
           type: array
           items:
@@ -528,12 +529,10 @@ components:
           type: string
           description: DEPRECATED - use templateName
           example: "my-session-template"
-          format: string
         templateName:
           type: string
           description: The name of the Session Template
           example: "my-session-template"
-          format: string
         job:
           type: string
           maxLength: 64
@@ -739,7 +738,6 @@ components:
           type: string
           description: The name of the Session Template
           example: "my-session-template"
-          format: string
         limit:
           type: string
           description: >
@@ -804,7 +802,7 @@ components:
         type:
           type: string
           description: |
-            The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
+            The MIME type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
         etag:
           type: string
           description: |
@@ -876,7 +874,6 @@ components:
           type: string
           description: The name of the Session Template
           example: "my-session-template"
-          format: string
         limit:
           type: string
           description: >
@@ -1112,7 +1109,7 @@ components:
       properties:
         id:
           type: string
-          description: The component's id. e.g. xname for hardware components
+          description: The component's ID. e.g. xname for hardware components
         actual_state:
           $ref: '#/components/schemas/V2ComponentActualState'
         desired_state:
@@ -1355,7 +1352,7 @@ components:
           schema:
             $ref: '#/components/schemas/V2Session'
     V2SessionDetailsArray:
-      description: Session details
+      description: Session details array
       content:
         application/json:
           schema:
@@ -1430,7 +1427,7 @@ paths:
         - version
       x-openapi-router-controller: bos.server.controllers.base
       responses:
-        200:          
+        200:
           description: A collection of Versions
           content:
             application/json:
@@ -1445,6 +1442,7 @@ paths:
   /v1:
     get:
       summary: Get API version
+      description: Return the API version
       tags:
         - version
       x-openapi-router-controller: bos.server.controllers.v1.base
@@ -1461,8 +1459,7 @@ paths:
         - healthz
       x-openapi-router-controller: bos.server.controllers.v1.healthz
       operationId: v1_get_healthz
-      description:
-        Get bos health details.
+      description: Get BOS health details.
       responses:
         200:
           $ref: '#/components/responses/ServiceHealth'
@@ -1477,8 +1474,7 @@ paths:
         - sessiontemplate
       x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
       operationId: create_v1_sessiontemplate
-      description:
-        Create a new session template.
+      description: Create a new session template.
       requestBody:
          description: A JSON object for creating a session template
          required: true
@@ -1518,10 +1514,10 @@ paths:
         schema:
           type: string
     get:
-      summary: Get session template by id
+      summary: Get session template by ID
       description: |
-        Get session template by session_template_id.
-        The session_template_id corresponds to the *name*
+        Get session template by session template ID.
+        The session template ID corresponds to the *name*
         of the session template.
       tags:
         - sessiontemplate
@@ -1602,8 +1598,8 @@ paths:
                   $ref: '#/components/schemas/V1Session'
   /v1/session/{session_id}:
     get:
-      summary: Get session details by id
-      description: Get session details by session_id.
+      summary: Get session details by ID
+      description: Get session details by session ID.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.session
@@ -1614,8 +1610,8 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
-      summary: Delete session by id
-      description: Delete session by session_id.
+      summary: Delete session by ID
+      description: Delete session by session ID.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.session
@@ -1733,7 +1729,7 @@ paths:
       operationId: get_v1_session_status_by_bootset
       responses:
         200:
-          description: A list of the Phase Statuses for the Boot Set and metadata
+          description: Metadata and a list of the Phase Statuses for the Boot Set
           content:
             application/json:
               schema:
@@ -1892,6 +1888,7 @@ paths:
         - version
       x-openapi-router-controller: bos.server.controllers.v1.base
       operationId: v1_get_version
+      description: Return the API version
       responses:
         200:
           $ref: '#/components/responses/Version'
@@ -1906,6 +1903,7 @@ paths:
         - version
       x-openapi-router-controller: bos.server.controllers.v2.base
       operationId: get_v2
+      description: Return the API version
       responses:
         200:
           $ref: '#/components/responses/Version'
@@ -1919,8 +1917,8 @@ paths:
         - healthz
       x-openapi-router-controller: bos.server.controllers.v2.healthz
       operationId: get_v2_healthz
-      description:
-        Get bos health details.
+      description: |
+        Get BOS health details.
       responses:
         200:
          $ref: '#/components/responses/ServiceHealth'
@@ -1951,10 +1949,10 @@ paths:
         schema:
           type: string
     get:
-      summary: Validate the session template by id
+      summary: Validate the session template by ID
       description: |
-        Validate session template by session_template_id.
-        The session_template_id corresponds to the *name*
+        Validate session template by session template ID.
+        The session template ID corresponds to the *name*
         of the session template.
       tags:
         - v2
@@ -1975,10 +1973,10 @@ paths:
         schema:
           type: string
     get:
-      summary: Get session template by id
+      summary: Get session template by ID
       description: |
-        Get session template by session_template_id.
-        The session_template_id corresponds to the *name*
+        Get session template by session template ID.
+        The session template ID corresponds to the *name*
         of the session template.
       tags:
         - v2
@@ -1997,8 +1995,7 @@ paths:
         - sessiontemplates
       x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
       operationId: put_v2_sessiontemplate
-      description:
-        Create a new session template.
+      description: Create a new session template.
       requestBody:
          description: A JSON object for creating a session template
          required: true
@@ -2018,6 +2015,7 @@ paths:
         - sessiontemplates
       x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
       operationId: patch_v2_sessiontemplate
+      description: Update an existing session template.
       requestBody:
         description: A JSON object for updating a session template
         required: true
@@ -2118,6 +2116,9 @@ paths:
         - sessions
       x-openapi-router-controller: bos.server.controllers.v2.sessions
       operationId: delete_v2_sessions
+      description: |
+        Delete multiple sessions.  If filters are provided, only sessions matching
+        all filters will be deleted.  By default only completed sessions will be deleted.
       parameters:
         - name: min_age
           schema:
@@ -2138,9 +2139,6 @@ paths:
           in: query
           description: >-
             Return only sessions with the given status.
-      description:
-        Delete multiple sessions.  If filters are provided, only sessions matching
-        all filters will be deleted.  By default only completed sessions will be deleted.
       responses:
         204:
           $ref: '#/components/responses/ResourceDeleted'
@@ -2148,8 +2146,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
   /v2/sessions/{session_id}:
     get:
-      summary: Get session details by id
-      description: Get session details by session_id.
+      summary: Get session details by ID
+      description: Get session details by session ID.
       tags:
         - v2
         - sessions
@@ -2178,8 +2176,8 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
-      summary: Delete session by id
-      description: Delete session by session_id.
+      summary: Delete session by ID
+      description: Delete session by session ID.
       tags:
         - v2
         - sessions
@@ -2199,8 +2197,8 @@ paths:
           type: string
   /v2/sessions/{session_id}/status:
     get:
-      summary: Get session extended status information by id
-      description: Get session extended status information by id
+      summary: Get session extended status information by ID
+      description: Get session extended status information by ID
       tags:
         - v2
         - sessions
@@ -2253,7 +2251,7 @@ paths:
             type: string
           in: query
           description: >-
-            Retrieve the components with the given id
+            Retrieve the components with the given ID
             (e.g. xname for hardware components). Can be chained
             for selecting groups of components.
         - name: session
@@ -2261,13 +2259,13 @@ paths:
             type: string
           in: query
           description: >-
-            Retrieve the components with the given session id.
+            Retrieve the components with the given session ID.
         - name: staged_session
           schema:
             type: string
           in: query
           description: >-
-            Retrieve the components with the given staged session id.
+            Retrieve the components with the given staged session ID.
         - name: enabled
           schema:
             type: boolean
@@ -2390,7 +2388,7 @@ paths:
     parameters:
       - name: component_id
         in: path
-        description: Component id. e.g. xname for hardware components
+        description: Component ID. e.g. xname for hardware components
         required: true
         schema:
           type: string
@@ -2443,6 +2441,7 @@ paths:
   /v2/version:
     get:
       summary: Get API version
+      description: Return the API version
       tags:
         - v2
         - version

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -196,36 +196,41 @@ components:
           description: |
             The name of configuration to be applied.
       additionalProperties: false
+    V1CompleteMetadata:
+      type: boolean
+      description: Is the object's status complete
+      example: true
+    V1ErrorCountMetadata:
+      type: integer
+      description: How many errors were encountered
+      example: 0
+    V1InProgressMetadata:
+      type: boolean
+      description: Is the object still doing something
+      example: false
+    V1StartTimeMetadata:
+      type: string
+      description: The start time
+      example: "2020-04-24T12:00"
+    V1StopTimeMetadata:
+      type: string
+      description: The stop time
+      example: "2020-04-24T12:00"
     V1GenericMetadata:
       type: object
       description: |
         The status metadata
       properties:
-        start_time:
-          type: string
-          description: |
-            The start time
-          example: "2020-04-24T12:00"
-        stop_time:
-          type: string
-          description: |
-            The stop time
-          example: "2020-04-24T12:00"
         complete:
-          type: boolean
-          description: |
-            Is the object's status complete
-          example: true
-        in_progress:
-          type: boolean
-          description: |
-            Is the object still doing something
-          example: false
+          $ref: '#/components/schemas/V1CompleteMetadata'
         error_count:
-          type: integer
-          description: |
-            How many errors were encountered
-          example: 0
+          $ref: '#/components/schemas/V1ErrorCountMetadata'
+        in_progress:
+          $ref: '#/components/schemas/V1InProgressMetadata'
+        start_time:
+          $ref: '#/components/schemas/V1StartTimeMetadata'
+        stop_time:
+          $ref: '#/components/schemas/V1StopTimeMetadata'
       additionalProperties: false
     V1NodeList:
       type: array
@@ -234,6 +239,13 @@ components:
       items:
         type: string
         example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
+    V1PhaseCategoryName:
+      type: string
+      description: |
+        Name of the Phase Category
+        not_started, in_progress, succeeded, failed, or excluded
+      example: "Succeeded"
+      pattern: '^([nN][oO][tT]_[sS][tT][aA][rR][tT][eE][dD]|[iI][nN]_[pP][rR][oO][gG][rR][eE][sS][sS]|[sS][uU][cC][cC][eE][eE][dD][eE][dD]|[fF][aA][iI][lL][eE][dD]|[eE][xX][cC][lL][uU][dD][eE][dD])$'
     V1PhaseCategoryStatus:
       type: object
       description: |
@@ -245,12 +257,7 @@ components:
 
       properties:
         name:
-          type: string
-          description: |
-            Name of the Phase Category
-            not_started, in_progress, succeeded, failed, or excluded
-          example: "Succeeded"
-          pattern: '^([nN][oO][tT]_[sS][tT][aA][rR][tT][eE][dD]|[iI][nN]_[pP][rR][oO][gG][rR][eE][sS][sS]|[sS][uU][cC][cC][eE][eE][dD][eE][dD]|[fF][aA][iI][lL][eE][dD]|[eE][xX][cC][lL][uU][dD][eE][dD])$'
+          $ref: '#/components/schemas/V1PhaseCategoryName'
         node_list:
           $ref: '#/components/schemas/V1NodeList'
     V1PhaseStatus:
@@ -483,6 +490,42 @@ components:
             $ref: '#/components/schemas/Link'
       required: [name]
       additionalProperties: false
+    V1BoaKubernetesJob:
+      type: string
+      maxLength: 64
+      readOnly: true
+      description: The identity of the Kubernetes job that is created to handle the session.
+      example: "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+    V1Operation:
+      type: string
+      description: >
+        A Session represents an operation on a SessionTemplate.
+        The creation of a session effectively results in the creation
+        of a Kubernetes Boot Orchestration Agent (BOA) job to perform the
+        duties required to complete the operation.
+
+        Operation -- An operation to perform on nodes in this session.
+
+            Boot         Boot nodes that are off.
+
+            Configure    Reconfigure the nodes using the Configuration Framework
+                         Service (CFS).
+
+            Reboot       Gracefully power down nodes that are on and then power
+                         them back up.
+
+            Shutdown     Gracefully power down nodes that are on.
+
+      pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[rR][eE][bB][oO][oO][tT]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
+      example: "boot"
+    V1TemplateName:
+       type: string
+       description: The name of the Session Template
+       example: "my-session-template"
+    V1TemplateUuid:
+      type: string
+      description: DEPRECATED - use templateName. This field is ignored if templateName is also set.
+      example: "my-session-template"
     V1SessionLink:
       description: Link to other resources
       type: object
@@ -490,7 +533,7 @@ components:
         href:
           type: string
         jobId:
-          type: string
+          $ref: '#/components/schemas/V1BoaKubernetesJob'
         rel:
           type: string
           enum: ['session', 'status']
@@ -498,7 +541,86 @@ components:
           type: string
           enum: ['GET']
       additionalProperties: false
+    V1SessionStatusUri:
+      type: string
+      description: URI to the status for this session
+      format: uri
+      example: "/v1/session/90730844-094d-45a5-9b90-d661d14d9444/status"
+    V1SessionDetails:
+      description: Details about a Session.
+      type: object
+      properties:
+        complete:
+          $ref: '#/components/schemas/V1CompleteMetadata'
+        error_count:
+          $ref: '#/components/schemas/V1ErrorCountMetadata'
+        in_progress:
+          $ref: '#/components/schemas/V1InProgressMetadata'
+        job:
+          $ref: '#/components/schemas/V1BoaKubernetesJob'
+        operation:
+          $ref: '#/components/schemas/V1Operation'
+        start_time:
+          $ref: '#/components/schemas/V1StartTimeMetadata'
+        status_link:
+          $ref: '#/components/schemas/V1SessionStatusUri'
+        stop_time:
+          $ref: '#/components/schemas/V1StopTimeMetadata'
+        templateName:
+          $ref: '#/components/schemas/V1TemplateName'
+    V1SessionDetailsByTemplateUuid:
+      description: |
+        Details about a Session using templateUuid instead of templateName.
+        DEPRECATED -- these will only exist from sessions created before templateUuid was deprecated.
+      type: object
+      properties:
+        complete:
+          $ref: '#/components/schemas/V1CompleteMetadata'
+        error_count:
+          $ref: '#/components/schemas/V1ErrorCountMetadata'
+        in_progress:
+          $ref: '#/components/schemas/V1InProgressMetadata'
+        job:
+          $ref: '#/components/schemas/V1BoaKubernetesJob'
+        operation:
+          $ref: '#/components/schemas/V1Operation'
+        start_time:
+          $ref: '#/components/schemas/V1StartTimeMetadata'
+        status_link:
+          $ref: '#/components/schemas/V1SessionStatusUri'
+        stop_time:
+          $ref: '#/components/schemas/V1StopTimeMetadata'
+        templateName:
+          $ref: '#/components/schemas/V1TemplateName'
     V1Session:
+      description: |
+        A Session object
+
+        ## Link Relationships
+
+        * self : The session object
+      type: object
+      properties:
+        operation:
+          $ref: '#/components/schemas/V1Operation'
+        templateName:
+          $ref: '#/components/schemas/V1TemplateName'
+        job:
+          $ref: '#/components/schemas/V1BoaKubernetesJob'
+        limit:
+          type: string
+          description: >
+            A comma-separated of nodes, groups, or roles to which the session
+            will be limited. Components are treated as OR operations unless
+            preceded by "&" for AND or "!" for NOT.
+        links:
+          type: array
+          readOnly: true
+          items:
+            $ref: '#/components/schemas/V1SessionLink'
+      required: [operation, templateName]
+      additionalProperties: false
+    V1SessionByTemplateName:
       description: |
         A Session object specified by templateName
 
@@ -508,41 +630,13 @@ components:
       type: object
       properties:
         operation:
-          type: string
-          description: >
-            A Session represents an operation on a SessionTemplate.
-            The creation of a session effectively results in the creation
-            of a Kubernetes Boot Orchestration Agent (BOA) job to perform the
-            duties required to complete the operation.
-
-            Operation -- An operation to perform on nodes in this session.
-
-                Boot         Boot nodes that are off.
-
-                Configure    Reconfigure the nodes using the Configuration Framework
-                             Service (CFS).
-
-                Reboot       Gracefully power down nodes that are on and then power
-                             them back up.
-
-                Shutdown     Gracefully power down nodes that are on.
-
-          pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[rR][eE][bB][oO][oO][tT]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
+          $ref: '#/components/schemas/V1Operation'
         templateUuid:
-          type: string
-          description: DEPRECATED - use templateName. This field is ignored if templateName is also set.
-          example: "my-session-template"
+          $ref: '#/components/schemas/V1TemplateUuid'
         templateName:
-          type: string
-          description: The name of the Session Template
-          example: "my-session-template"
+          $ref: '#/components/schemas/V1TemplateName'
         job:
-          type: string
-          maxLength: 64
-          readOnly: true
-          description: >
-            The identity of the Kubernetes job that is created to handle the session.
-          example: "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+          $ref: '#/components/schemas/V1BoaKubernetesJob'
         limit:
           type: string
           description: >
@@ -566,37 +660,11 @@ components:
       type: object
       properties:
         operation:
-          type: string
-          description: >
-            A Session represents an operation on a SessionTemplate.
-            The creation of a session effectively results in the creation
-            of a Kubernetes Boot Orchestration Agent (BOA) job to perform the
-            duties required to complete the operation.
-
-            Operation -- An operation to perform on nodes in this session.
-
-                Boot         Boot nodes that are off.
-
-                Configure    Reconfigure the nodes using the Configuration Framework
-                             Service (CFS).
-
-                Reboot       Gracefully power down nodes that are on and then power
-                             them back up.
-
-                Shutdown     Gracefully power down nodes that are on.
-
-          pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[rR][eE][bB][oO][oO][tT]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
+          $ref: '#/components/schemas/V1Operation'
         templateUuid:
-          type: string
-          description: DEPRECATED - use templateName
-          example: "my-session-template"
+          $ref: '#/components/schemas/V1TemplateUuid'
         job:
-          type: string
-          maxLength: 64
-          readOnly: true
-          description: >
-            The identity of the Kubernetes job that is created to handle the session.
-          example: "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+          $ref: '#/components/schemas/V1BoaKubernetesJob'
         limit:
           type: string
           description: >
@@ -610,6 +678,13 @@ components:
             $ref: '#/components/schemas/V1SessionLink'
       required: [operation, templateUuid]
       additionalProperties: false
+    V1PhaseName:
+      type: string
+      description: |
+        The phase that this data belongs to (boot, shutdown, or configure). If blank,
+        it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
+      example: "Boot"
+      pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
     V1NodeChangeList:
       type: object
       description: |
@@ -617,14 +692,11 @@ components:
         one category to another within a phase.
       properties:
         phase:
-          type: string
-          example: "Boot"
+          $ref: '#/components/schemas/V1PhaseName'
         source:
-          type: string
-          example: "in_progress"
+          $ref: '#/components/schemas/V1PhaseCategoryName'
         destination:
-          type: string
-          example: "Succeeded"
+          $ref: '#/components/schemas/V1PhaseCategoryName'
         node_list:
           $ref: '#/components/schemas/V1NodeList'
       additionalProperties: false
@@ -650,11 +722,7 @@ components:
             pattern: '^NodeChangeList$'
             type: string
           phase:
-            description: |
-              The phase that this data belongs to (boot, shutdown, or configure). If blank,
-              it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
-            pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
-            type: string
+            $ref: '#/components/schemas/V1PhaseName'
           data:
             $ref: '#/components/schemas/V1NodeChangeList'
     V1UpdateRequestNodeErrorsList:
@@ -670,11 +738,7 @@ components:
             pattern: '^NodeErrorsList$'
             type: string
           phase:
-            description: |
-              The phase that this data belongs to (boot, shutdown, or configure). If blank,
-              it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
-            pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
-            type: string
+            $ref: '#/components/schemas/V1PhaseName'
           data:
             $ref: '#/components/schemas/V1NodeErrorsList'
     V1UpdateRequestGenericMetadata:
@@ -690,11 +754,7 @@ components:
             pattern: '^GenericMetadata$'
             type: string
           phase:
-            description: |
-              The phase that this data belongs to (boot, shutdown, or configure). If blank,
-              it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
-            pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
-            type: string
+            $ref: '#/components/schemas/V1PhaseName'
           data:
             $ref: '#/components/schemas/V1GenericMetadata'
     # V2
@@ -1365,12 +1425,20 @@ components:
     ResourceDeleted:
       description: The resource was deleted.
     # V1
+    V1Session:
+      description: Session
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V1Session'
     V1SessionDetails:
       description: Session details
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/V1Session'
+            oneOf:
+              - $ref: '#/components/schemas/V1SessionDetails'
+              - $ref: '#/components/schemas/V1SessionDetailsByTemplateUuid'
     V1SessionStatus:
       description: A list of Boot Set Statuses and metadata
       content:
@@ -1629,11 +1697,11 @@ paths:
            application/json:
              schema:
                oneOf:
-                 - $ref: '#/components/schemas/V1Session'
+                 - $ref: '#/components/schemas/V1SessionByTemplateName'
                  - $ref: '#/components/schemas/V1SessionByTemplateUuid'
       responses:
         201:
-          $ref: '#/components/responses/V1SessionDetails'
+          $ref: '#/components/responses/V1Session'
         400:
           $ref: '#/components/responses/BadRequest'
         404:


### PR DESCRIPTION
## Summary and Scope

Backports several fixes to the API spec into support/2.0 branch, both to fix a problem seen in the field and to ensure that the auto-generated API docs are more accurate.

## Issues and Related PRs

Rolls up the following PRs:
* CASMCMS-8626: https://github.com/Cray-HPE/bos/pull/133
* CASMTRIAGE-5367: https://github.com/Cray-HPE/bos/pull/134
* CASMCMS-8576: https://github.com/Cray-HPE/bos/pull/126
* CASMCMS-8572: https://github.com/Cray-HPE/bos/pull/127
* CASMCMS-8577: https://github.com/Cray-HPE/bos/pull/128
* CASMCMS-8447: https://github.com/Cray-HPE/bos/pull/130

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
