### PR TITLE
CASMCMS-8628: Update BOS server setup file from Python 3.6 to 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Updated BOS server setup file from Python 3.6 to Python 3.11
 ### Fixed
 - Fixed a window during power-on operations which could lead to an incorrect status in larger systems
 - Updated API spec so that it accurately describes the actual implementation:

--- a/src/setup.py.in
+++ b/src/setup.py.in
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@ setup(
     packages=find_namespace_packages(),
     keywords="cray kubernetes boot orchestration",
     classifiers=[
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.11",
         "License :: Other/Proprietary License",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Systems Administration",


### PR DESCRIPTION
## Summary and Scope

The BOS server is now running under Python 3.11. This PR updates the BOS server module's setup file to specify that it is made for Python 3.11.

## Issues and Related PRs

* Resolves [CASMCMS-8628](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8628)

## Testing

Make sure the build doesn't fail.

## Risks and Mitigations

Very low risk. We're already using Python 3.11.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
