### PR TITLE
CASMCMS-8628/CASMCMS-8631: Indicate Python version, pin Alpine version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Pin Alpine version to 3.18 in Dockerfile
 
 ## [2.0.14] - 2023-05-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Pin Alpine version to 3.18 in Dockerfile
+- Updated BOS server setup file from Python 3.6 to Python 3.11
 
 ## [2.0.14] - 2023-05-18
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 # Upstream Build Args
 ARG OPENAPI_IMAGE=openapitools/openapi-generator-cli:v6.0.1
-ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3
+ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.18
 
 # Generate Code
 FROM $OPENAPI_IMAGE as codegen

--- a/src/setup.py.in
+++ b/src/setup.py.in
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@ setup(
     packages=find_namespace_packages(),
     keywords="cray kubernetes boot orchestration",
     classifiers=[
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.11",
         "License :: Other/Proprietary License",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Systems Administration",


### PR DESCRIPTION
## Summary and Scope

For the support/2.0 branch, we don't want to unexpectedly start using a new Alpine (and possibly therefore Python) version. New patch versions is fine, but we want to avoid even new minor versions, as that is what caused a recent problem on a customer system.

This PR pins the Alpine version to 3.18 (which is the version currently being used in this branch)., 

## Testing

Make sure the build works.

## Risks and Mitigations

Low risk -- it's already using this Alpine version -- this just pins it so rebuilds will also use it.
