### PR TITLE
CASMTRIAGE-5404: Merge definitions of V1Session and V1SessionByTemplateName to avoid session creation error using templateUuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [2.0.16] - 2023-05-19
 ### Fixed
 - Merge definitions of `V1Session` and `V1SessionByTemplateName`, to avoid server error
   creating sessions using `templateUuid`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Merge definitions of `V1Session` and `V1SessionByTemplateName`, to avoid server error
+  creating sessions using `templateUuid`.
 
 ## [2.0.15] - 2023-05-18
 ### Changed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -594,34 +594,6 @@ components:
           $ref: '#/components/schemas/V1TemplateName'
     V1Session:
       description: |
-        A Session object
-
-        ## Link Relationships
-
-        * self : The session object
-      type: object
-      properties:
-        operation:
-          $ref: '#/components/schemas/V1Operation'
-        templateName:
-          $ref: '#/components/schemas/V1TemplateName'
-        job:
-          $ref: '#/components/schemas/V1BoaKubernetesJob'
-        limit:
-          type: string
-          description: >
-            A comma-separated of nodes, groups, or roles to which the session
-            will be limited. Components are treated as OR operations unless
-            preceded by "&" for AND or "!" for NOT.
-        links:
-          type: array
-          readOnly: true
-          items:
-            $ref: '#/components/schemas/V1SessionLink'
-      required: [operation, templateName]
-      additionalProperties: false
-    V1SessionByTemplateName:
-      description: |
         A Session object specified by templateName
 
         ## Link Relationships
@@ -1703,7 +1675,7 @@ paths:
            application/json:
              schema:
                oneOf:
-                 - $ref: '#/components/schemas/V1SessionByTemplateName'
+                 - $ref: '#/components/schemas/V1Session'
                  - $ref: '#/components/schemas/V1SessionByTemplateUuid'
       responses:
         201:


### PR DESCRIPTION
## Summary and Scope

It turns out that one of my API spec changes caused the problem reported in [CASMTRIAGE-5404](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5404). This is because the server code imports the automatically generated V1Session object, and my updated spec did not have the templateUuid field in that object.

The spec was internally consistent, but I overlooked this dependency inside the code itself.

The simplest fix is to put that field back into the definition in the spec. The downside is that this makes the spec slightly less accurate. It isn't wrong, it's just that my original changes were more specific about the cases when you could possible see a BOS v1 session with the templateUuid field in them. This version leaves open the possibility that any BOS session could have that field. This isn't the case, but it is the simplest way to correct this unintended problem.

For CSM 1.5, I believe there is a better way to solve this so that the spec can remain precise and we won't break the code. But I don't want to risk doing that for this patch, since it's more involved.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5404](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5404) for the CSM 1.3 and 1.4 backports.
* I will make a separate PR to fix this more satisfyingly in the develop branch.

## Testing

I loaded the patch onto Crossroads and verified that it resolved the session creation problem being seen.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
