### PR TITLE
CASMTRIAGE-5404: Avoid V1Session objects with template_uuid fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated BOS server setup file from Python 3.6 to Python 3.11
 - Updated from BOA 1.3 to 1.4
+- For POST requests to `/v1/session` that include a `templateUuid` field, convert that field to a `templateName` field (if
+  that field is not also specified) and delete the `templateUuid` field, before creating  a `V1Session` object.
 ### Fixed
 - Fixed a window during power-on operations which could lead to an incorrect status in larger systems
 - Updated API spec so that it accurately describes the actual implementation:


### PR DESCRIPTION
## Summary and Scope

Starting in CSM 1.2, it is not possible to create a BOS session such that the internal BOS session object contains the `templateUuid` field. That field is still allowed when creating templates, but it is only used if a `templateName` field is not specified, and either way the `templateUuid` field itself is not saved into the BOS database. (It is possible for BOS sessions to exist in the DB that still have `templateUuid` fields, but only if they were created prior to CSM 1.2 and never deleted).

I made two recent PRs that related to creating BOS v1 sessions:
* [CASMCMS-8577: Update the spec to accurately reflect what is returned when creating or getting a BOS v1 session](https://github.com/Cray-HPE/bos/pull/128)
* [CASMCMS-8572: Update API spec to reflect that creating a BOS v1 session requires operation AND `templateName`/`templateUuid`](https://github.com/Cray-HPE/bos/pull/127)

Among other things, these refactored and created new schemas to reflect the various forms in which BOS v1 sessions can be found. Of note for this triage ticket, I altered the `V1Session` schema to remove the `templateUuid` field, because:
1) We no longer create V1 sessions that contain that field
2) `V1Session` objects are only returned from session create operations (when you do `GET` on a session, you get a `V1SessionDetails` object).

In order to preserve the fact that you could still specify `templateUuid` when creating, I made two new schemas (`V1SessionByTemplateName` and `V1SessionByTemplateUuid`), and noted that either of these could be specified to create a new V1 session.

Removing the `templateUuid` field from `V1Session` caused an unintended regression bug (as opposed to the intentional regression bugs, I guess). Specifically, the function that creates V1 sessions takes the data it receives from the `POST` request and tries to convert it to a `V1Session` object. Then it starts to look at its `templateName` and `templateUuid` fields, deciding which to use. **When I removed the `templateUuid` field from the `V1Session` schema, it broke this logic, because if a `templateUuid` field was present, it threw an exception trying to instantiate the `V1Session` object.**

Since this bug was also in the 1.3/1.4 patches we made last week, I made the simplest fix I could for those -- I basically just added the `templateUuid` field back as a possible field in `V1Session`s. It makes the spec a little less precise, but it fixed the problem with the least invasive change, which seemed best for those branches.

For CSM 1.5, I think the better fix is to keep the API spec as-is and instead slightly modify the v1 session create function. Specifically, this PR adjusts it so that it parses the `templateName`/`templateUuid` BEFORE it instantiates it as a `V1Session` object. 

This results in identical behavior to what it was doing originally -- it allows either or both parameters to be passed, but only saves the name using the `templateName` field. And it allows the spec to be more precise in terms of what the user will get back when creating a V1 session (namely, a `V1Session` object, which is never going to have the `templateUuid` field in it, no matter what the user specified as input).

An alternative way to go about this would be to make use of the new schemas I created (`V1SessionTemplateByUuid` and `V1SessionTemplateByName`). I could modify the function to do something like this pseudo-code:

```
try:
    instantiate the session as a V1SessionByTemplateName
except error:
    if error is 'operation' field not found:
        return status indicating a required field is missing
    else if error is 'templateName' field not found:
        try:
            instantiate the session as a V1SessionByTemplateUuid
        except error:
            if error is 'templateUuid' field not found:
                return status indicating a required field is missing
            raise generic server error
    else
        raise generic server error
```

The above is nice in that it imposes the new schema more directly on the inputs. It is less nice in that it is more convoluted AND in that we would then need to add additional code to convert the `V1SessionBy...` object into a generic `V1Session` object (even though that would be quite simple). But I'm open to doing that if people think it's the purer solution from a API spec POV.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5404](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5404) for CSM 1.5+
* [PR that fixes CASMTRIAGE-5404 for CSM 1.3/1.4](https://github.com/Cray-HPE/bos/pull/138)

## Testing

I tested this implementation on starlord and verified that it fixes the problem reported in CASMTRIAGE-5404, I tested that I was still able to create V1 sessions using the `templateName` parameter, and I verified that the cmsdev BOS regression suite reported no new issues.

## Risks and Mitigations

Low risk -- the logic is pretty simple and contained.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
