### PR TITLE
CASMCMS-8644: Move from v6.4.0 to v6.6.0 of openapi-generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated from BOA 1.3 to 1.4
 - For POST requests to `/v1/session` that include a `templateUuid` field, convert that field to a `templateName` field (if
   that field is not also specified) and delete the `templateUuid` field, before creating  a `V1Session` object.
+- Updated to using v6.6.0 of `openapi-generator` (up from v6.4.0)
 ### Fixed
 - Fixed a window during power-on operations which could lead to an incorrect status in larger systems
 - Updated API spec so that it accurately describes the actual implementation:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # Dockerfile for Cray Boot Orchestration Service (BOS)
 
 # Upstream Build Args
-ARG OPENAPI_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/openapitools/openapi-generator-cli:v6.4.0
+ARG OPENAPI_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/openapitools/openapi-generator-cli:v6.6.0
 ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3
 
 # Generate Code


### PR DESCRIPTION
## Summary and Scope

We are currently using v6.4.0 of the generator. It looks like v6.6.0 is the latest release. I think we should at least update to v6.5.0, because the release notes for that indicate that it improves support for `anyOf` and `allOf` OpenAPI keywords, and we're now making more use of those.

This PR just bumps the generator version used for generation in the Dockerfile.

## Testing

I ran the cmsdev regression tests and they passed.

## Risks and Mitigations

Low risk -- just a small version bump on the API generator.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

