### PR TITLE
CASMCMS-8613: Fix patching of component actual_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.0.17] - 2023-05-24
 ### Fixed
 - Fixed minor errors and did minor linting of repository [`README.md`](README.md).
+- Fixed component patching issues when patching actual_state during on-going changes to component state.
 
 ## [2.0.16] - 2023-05-19
 ### Fixed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1515,6 +1515,12 @@ components:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/ProblemDetails'
+    UpdateConflict:
+      description: The update was not allowed due to a conflict.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
     ServiceUnavailable:
       description: Service Unavailable
       content:
@@ -2476,6 +2482,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         404:
           $ref: '#/components/responses/ResourceNotFound'
+        409:
+          $ref: '#/components/responses/UpdateConflict'
     delete:
       tags:
         - v2


### PR DESCRIPTION
## Summary and Scope

Pulls in a fix so that actual_state is not updated by state-reporters during the setup steps of a new session, which could interrupt reboots to the same set of artifacts.

## Issues and Related PRs

* Resolves CASMCMS-8613

## Testing

### Tested on:

  * Ashton

### Test description:

This is a scale system issue, so I had scripts mimic the issue and validate that the correct error was returned.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

