### PR TITLE
CASMINST-6451: Relax BOS session template name restrictions and convert the restrictions into recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.18] - 2023-05-30
+### Fixed
+- Fix bug that accidentally started enforcing restrictions on session template names.
+  This fix updated the API spec in two ways:
+  - Relaxed the stated restrictions on session template names.
+  - Changed the restrictions to recommendations (noting that they are not currently
+    enforced, but will be enforced in a future BOS version).
+
 ## [2.0.17] - 2023-05-24
 ### Fixed
 - Fixed minor errors and did minor linting of repository [`README.md`](README.md).

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -450,10 +450,18 @@ components:
             template parameters.
         name:
           type: string
-          description: Name of the SessionTemplate. The length of the name is restricted to 45 characters.
-          example: "cle-1.0.0"
           minLength: 1
-          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          description: |
+            Name of the Session Template.
+            
+            It is recommended to use names which meet the following restrictions:
+            * Maximum length of 127 characters.
+            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Begin and end with a letter or digit.
+            
+            These restrictions are not enforced in this version of BOS, but will be
+            enforced in a future version.
+          example: "cle-1.0.0"
         description:
           type: string
           description: |
@@ -522,6 +530,7 @@ components:
        type: string
        description: The name of the Session Template
        example: "my-session-template"
+       minLength: 1
     V1TemplateUuid:
       type: string
       description: DEPRECATED - use templateName. This field is ignored if templateName is also set.
@@ -759,13 +768,19 @@ components:
       properties:
         name:
           type: string
-          description: Name of the SessionTemplate. The length of the name is restricted to 45 characters.
-          example: "cle-1.0.0"
-          # These validation parameters are restricted by Kubernetes naming conventions.
           minLength: 1
-          maxLength: 45
-          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
           readOnly: true
+          description: |
+            Name of the Session Template.
+            
+            It is recommended to use names which meet the following restrictions:
+            * Maximum length of 127 characters.
+            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Begin and end with a letter or digit.
+            
+            These restrictions are not enforced in this version of BOS, but will be
+            enforced in a future version.
+          example: "cle-1.0.0"
         description:
           type: string
           description: |
@@ -792,6 +807,11 @@ components:
       description: |
         Message describing errors or incompleteness in a Session Template.
       type: string
+    V2TemplateName:
+       type: string
+       description: The name of the Session Template
+       example: "my-session-template"
+       minLength: 1
     V2SessionCreate:
       description: |
         A Session Creation object
@@ -819,9 +839,7 @@ components:
                 Reboot               Applies the template to the components guarantees a reboot.
                 Shutdown             Power down nodes that are on.
         template_name:
-          type: string
-          description: The name of the Session Template
-          example: "my-session-template"
+          $ref: '#/components/schemas/V2TemplateName'
         limit:
           type: string
           description: >
@@ -955,9 +973,7 @@ components:
                 Reboot               Applies the template to the components guarantees a reboot.
                 Shutdown             Power down nodes that are on.
         template_name:
-          type: string
-          description: The name of the Session Template
-          example: "my-session-template"
+          $ref: '#/components/schemas/V2TemplateName'
         limit:
           type: string
           description: >


### PR DESCRIPTION
## Summary and Scope

It looks like some of the session template naming restrictions were actually being enforced. Kind of. The regular expression fields were being enforced, but they were also written so that they would mistakenly match any session template name. When we fixed the regular expressions in the API spec to fix [CASMTRIAGE-5367](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5367), it then prevented session templates from being created which did not fit the corrected regular expression.

We had already planned to modify the spec to remove these restrictions and state that they are only recommendations ([CASMCMS-8649](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8649)), but now that appears to be a more urgent need. This PR does that just for the template name field. CASMCMS-8649 will also state the upcoming restrictions on some other text input fields, but that is not urgently needed like this is.

## Issues and Related PRs

* Resolves [CASMINST-6451](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6451)
* Caused by fix for [CASMTRIAGE-5367](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5367)
* Related to [CASMCMS-8649](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8649)

## Testing

On mug, I verified that this problem did not exist in BOS 2.0.13 (the last version without the CASMTRIAGE-5367 changes) and verified that the problem does exist in BOS 2.0.14, 2.0.16, and 2.0.17. I then installed the version from this PR and verified that it corrected the problem. I also ran the cmsdev regression suite to make sure that no other issues were found.

## Risks and Mitigations

Low risk. This removes restrictions that originally were not being enforced in any meaningful way, and whose accidental enforcement caused the problem.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
