### PR TITLE
CASMINST-6451: Relax BOS session template name restrictions and convert the restrictions into recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2023-06-06
+### Fixed
+- Fix bug that accidentally started enforcing restrictions on session template names.
+  This fix updated the API spec in two ways:
+  - Relaxed the stated restrictions on session template names.
+  - Changed the restrictions to recommendations (noting that they are not currently
+    enforced, but will be enforced in a future BOS version).
+
 ## [2.4.0] - 2023-05-24
 ### Changed
 - Updated BOS server setup file from Python 3.6 to Python 3.11

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -450,10 +450,18 @@ components:
             template parameters.
         name:
           type: string
-          description: Name of the SessionTemplate. The length of the name is restricted to 45 characters.
-          example: "cle-1.0.0"
           minLength: 1
-          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          description: |
+            Name of the Session Template.
+            
+            It is recommended to use names which meet the following restrictions:
+            * Maximum length of 127 characters.
+            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Begin and end with a letter or digit.
+            
+            These restrictions are not enforced in this version of BOS, but will be
+            enforced in a future version.
+          example: "cle-1.0.0"
         description:
           type: string
           description: |
@@ -522,6 +530,7 @@ components:
        type: string
        description: The name of the Session Template
        example: "my-session-template"
+       minLength: 1
     V1TemplateUuid:
       type: string
       description: DEPRECATED - use templateName. This field is ignored if templateName is also set.
@@ -787,13 +796,19 @@ components:
       properties:
         name:
           type: string
-          description: Name of the SessionTemplate. The length of the name is restricted to 45 characters.
-          example: "cle-1.0.0"
-          # These validation parameters are restricted by Kubernetes naming conventions.
           minLength: 1
-          maxLength: 45
-          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
           readOnly: true
+          description: |
+            Name of the Session Template.
+            
+            It is recommended to use names which meet the following restrictions:
+            * Maximum length of 127 characters.
+            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Begin and end with a letter or digit.
+            
+            These restrictions are not enforced in this version of BOS, but will be
+            enforced in a future version.
+          example: "cle-1.0.0"
         tenant:
           type: string
           description: >
@@ -826,6 +841,11 @@ components:
       description: |
         Message describing errors or incompleteness in a Session Template.
       type: string
+    V2TemplateName:
+       type: string
+       description: The name of the Session Template
+       example: "my-session-template"
+       minLength: 1
     V2SessionCreate:
       description: |
         A Session Creation object
@@ -853,9 +873,7 @@ components:
                 Reboot               Applies the template to the components guarantees a reboot.
                 Shutdown             Power down nodes that are on.
         template_name:
-          type: string
-          description: The name of the Session Template
-          example: "my-session-template"
+          $ref: '#/components/schemas/V2TemplateName'
         limit:
           type: string
           description: >
@@ -995,9 +1013,7 @@ components:
                 Reboot               Applies the template to the components guarantees a reboot.
                 Shutdown             Power down nodes that are on.
         template_name:
-          type: string
-          description: The name of the Session Template
-          example: "my-session-template"
+          $ref: '#/components/schemas/V2TemplateName'
         limit:
           type: string
           description: >


### PR DESCRIPTION
(cherry picked from commit 009aa0d5c6942e7f8bdeb40113efe6ce7f060bdb)

Pulls fix for the following PR into the master branch as well:
https://github.com/Cray-HPE/bos/pull/146
