### PR TITLE
CASMCMS-8659: Document tenant header parameter in API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Updated the API spec to document the header option required for tenant-specific operations.
+  Documented which v1 endpoint operations reject tenanted requests, and how they reject them.
+
 ## [2.4.1] - 2023-06-06
 ### Fixed
 - Fix bug that accidentally started enforcing restrictions on session template names.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -123,6 +123,9 @@ components:
           items:
             $ref: '#/components/schemas/Link'
       additionalProperties: false
+    TenantName:
+      type: string
+      description: Name of a tenant. Used for multi-tenancy. An empty string means no tenant.
     ProblemDetails:
       description: An error response for RFC 7807 problem details.
       type: object
@@ -1565,6 +1568,20 @@ components:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/ProblemDetails'
+    BadRequestOrMultiTenancyNotSupported:
+      description: |
+        Multi-tenancy is not supported for this BOS v1 request. 
+        If no tenant was specified, then the request was bad for another reason.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    MultiTenancyNotSupported:
+      description: Multi-tenancy is not supported for this BOS v1 request.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
     ResourceNotFound:
       description: The resource was not found.
       content:
@@ -1639,6 +1656,15 @@ paths:
         503:
           $ref: '#/components/responses/ServiceUnavailable'
   /v1/sessiontemplate:
+    parameters:
+      - name: Cray-Tenant-Name
+        in: header
+        description: |
+          Tenant name. Multi-tenancy is not supported for most BOS v1 endpoints.
+          If this parameter is set to a non-empty string, the request will be rejected.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     post:
       summary: Create session template
       tags:
@@ -1657,7 +1683,7 @@ paths:
         201:
           $ref: '#/components/responses/V1SessionTemplateDetails'
         400:
-          $ref: '#/components/responses/BadRequest'
+          $ref: '#/components/responses/BadRequestOrMultiTenancyNotSupported'
     get:
       summary: List session templates
       description: |
@@ -1670,6 +1696,8 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/SessionTemplateDetailsArray'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
   /v1/sessiontemplate/{session_template_id}:
     parameters:
       - name: session_template_id
@@ -1678,6 +1706,14 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: |
+          Tenant name. Multi-tenancy is not supported for most BOS v1 endpoints.
+          If this parameter is set to a non-empty string, the request will be rejected.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     get:
       summary: Get session template by ID
       description: |
@@ -1691,6 +1727,8 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/SessionTemplateDetails'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
@@ -1703,6 +1741,8 @@ paths:
       responses:
         204:
           $ref: '#/components/responses/ResourceDeleted'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
   /v1/sessiontemplatetemplate:
@@ -1720,6 +1760,15 @@ paths:
         200:
           $ref: '#/components/responses/V1SessionTemplateDetails'
   /v1/session:
+    parameters:
+      - name: Cray-Tenant-Name
+        in: header
+        description: |
+          Tenant name. Multi-tenancy is not supported for most BOS v1 endpoints.
+          If this parameter is set to a non-empty string, the request will be rejected.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     post:
       summary: Create a session
       description: |
@@ -1743,7 +1792,7 @@ paths:
         201:
           $ref: '#/components/responses/V1Session'
         400:
-          $ref: '#/components/responses/BadRequest'
+          $ref: '#/components/responses/BadRequestOrMultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     get:
@@ -1763,6 +1812,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/V1SessionId'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
   /v1/session/{session_id}:
     get:
       summary: Get session details by ID
@@ -1774,6 +1825,8 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/V1SessionDetails'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
@@ -1786,6 +1839,8 @@ paths:
       responses:
         204:
           $ref: '#/components/responses/ResourceDeleted'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     parameters:
@@ -1795,6 +1850,14 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: |
+          Tenant name. Multi-tenancy is not supported for most BOS v1 endpoints.
+          If this parameter is set to a non-empty string, the request will be rejected.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
   /v1/session/{session_id}/status:
     parameters:
       - name: session_id
@@ -1803,6 +1866,14 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: |
+          Tenant name. Multi-tenancy is not supported for most BOS v1 endpoints.
+          If this parameter is set to a non-empty string, the request will be rejected.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     get:
       summary: A list of the statuses for the different boot sets.
       description: |
@@ -1814,6 +1885,8 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/V1SessionStatus'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     post:
@@ -1835,7 +1908,7 @@ paths:
         200:
           $ref: '#/components/responses/V1SessionStatus'
         400:
-          $ref: '#/components/responses/BadRequest'
+          $ref: '#/components/responses/BadRequestOrMultiTenancyNotSupported'
         409:
           $ref: '#/components/responses/AlreadyExists'
     patch:
@@ -1856,6 +1929,8 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/V1SessionStatus'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/BadRequest'
     delete:
@@ -1870,7 +1945,7 @@ paths:
         204:
           $ref: '#/components/responses/ResourceDeleted'
         400:
-          $ref: '#/components/responses/BadRequest'
+          $ref: '#/components/responses/BadRequestOrMultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
   /v1/session/{session_id}/status/{boot_set_name}:
@@ -1887,6 +1962,14 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: |
+          Tenant name. Multi-tenancy is not supported for most BOS v1 endpoints.
+          If this parameter is set to a non-empty string, the request will be rejected.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     get:
       summary: Get the status for a boot set.
       description: Get the status for a boot set.
@@ -1901,6 +1984,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/V1BootSetStatus'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     post:
@@ -1926,6 +2011,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/V1BootSetStatus'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         409:
           $ref: '#/components/responses/AlreadyExists'
     patch:
@@ -1955,6 +2042,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/V1BootSetStatus'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
@@ -1969,7 +2058,7 @@ paths:
         204:
           $ref: '#/components/responses/ResourceDeleted'
         400:
-          $ref: '#/components/responses/BadRequest'
+          $ref: '#/components/responses/BadRequestOrMultiTenancyNotSupported'
   /v1/session/{session_id}/status/{boot_set_name}/{phase_name}:
     parameters:
       - name: session_id
@@ -1990,6 +2079,14 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: |
+          Tenant name. Multi-tenancy is not supported for most BOS v1 endpoints.
+          If this parameter is set to a non-empty string, the request will be rejected.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     get:
       summary: Get the status for a specific boot set and phase.
       description: Get the status for a specific boot set and phase.
@@ -2004,6 +2101,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/V1PhaseStatus'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
   /v1/session/{session_id}/status/{boot_set_name}/{phase_name}/{category_name}:
@@ -2032,6 +2131,14 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: |
+          Tenant name. Multi-tenancy is not supported for most BOS v1 endpoints.
+          If this parameter is set to a non-empty string, the request will be rejected.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     get:
       summary: Get the status for a specific boot set, phase, and category.
       description: Get the status for a specific boot set, phase, and category.
@@ -2046,6 +2153,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/V1PhaseCategoryStatus'
+        400:
+          $ref: '#/components/responses/MultiTenancyNotSupported'
         404:
           $ref: '#/components/responses/ResourceNotFound'
   /v1/version:
@@ -2094,6 +2203,18 @@ paths:
         503:
           $ref: '#/components/responses/ServiceUnavailable'
   /v2/sessiontemplates:
+    parameters:
+      - name: Cray-Tenant-Name
+        in: header
+        description: >
+          Tenant name.
+
+          Requests with a non-empty tenant name will restict the context of the operation to session templates owned by that tenant.
+
+          Requests with an empty tenant name, or that omit this paarameter, will have no such context restrictions.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     get:
       summary: List session templates
       description: |
@@ -2115,6 +2236,17 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: >
+          Tenant name.
+
+          Requests with a non-empty tenant name will restict the context of the operation to session templates owned by that tenant.
+
+          Requests with an empty tenant name, or that omit this paarameter, will have no such context restrictions.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     get:
       summary: Validate the session template by ID
       description: |
@@ -2139,6 +2271,17 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: >
+          Tenant name.
+
+          Requests with a non-empty tenant name will restict the context of the operation to session templates owned by that tenant.
+
+          Requests with an empty tenant name, or that omit this paarameter, will have no such context restrictions.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     get:
       summary: Get session template by ID
       description: |
@@ -2226,6 +2369,20 @@ paths:
         200:
           $ref: '#/components/responses/V2SessionTemplateDetails'
   /v2/sessions:
+    parameters:
+      - name: Cray-Tenant-Name
+        in: header
+        description: >
+          Tenant name.
+
+          Requests with a non-empty tenant name will restict the context of the operation to:
+          * Sessions and session templates owned by that tenant, and
+          * Components to which that tenant has access.
+
+          Requests with an empty tenant name, or that omit this paarameter, will have no such context restrictions.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
     post:
       summary: Create a session
       description: |
@@ -2362,6 +2519,19 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: >
+          Tenant name.
+
+          Requests with a non-empty tenant name will restict the context of the operation to:
+          * Sessions and session templates owned by that tenant, and
+          * Components to which that tenant has access.
+
+          Requests with an empty tenant name, or that omit this paarameter, will have no such context restrictions.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
   /v2/sessions/{session_id}/status:
     get:
       summary: Get session extended status information by ID
@@ -2397,6 +2567,19 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: >
+          Tenant name.
+
+          Requests with a non-empty tenant name will restict the context of the operation to:
+          * Sessions and session templates owned by that tenant, and
+          * Components to which that tenant has access.
+
+          Requests with an empty tenant name, or that omit this paarameter, will have no such context restrictions.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
   /v2/components:
     get:
       summary: Retrieve the state of a collection of components
@@ -2490,6 +2673,18 @@ paths:
           $ref: '#/components/responses/BadRequest'
         404:
           $ref: '#/components/responses/ResourceNotFound'
+    parameters:
+      - name: Cray-Tenant-Name
+        in: header
+        description: >
+          Tenant name.
+
+          Requests with a non-empty tenant name will restict the context of the operation to components to which that tenant has access.
+
+          Requests with an empty tenant name, or that omit this paarameter, will have no such context restrictions.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
   /v2/components/{component_id}:
     get:
       summary: Retrieve the state of a single component
@@ -2561,6 +2756,17 @@ paths:
         required: true
         schema:
           type: string
+      - name: Cray-Tenant-Name
+        in: header
+        description: >
+          Tenant name.
+
+          Requests with a non-empty tenant name will restict the context of the operation to components to which that tenant has access.
+
+          Requests with an empty tenant name, or that omit this paarameter, will have no such context restrictions.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
   /v2/applystaged:
     post:
       summary: Start a staged session for the specified components
@@ -2581,6 +2787,18 @@ paths:
           $ref: '#/components/responses/V2applyStagedResponse'
         400:
           $ref: '#/components/responses/BadRequest'
+    parameters:
+      - name: Cray-Tenant-Name
+        in: header
+        description: >
+          Tenant name.
+
+          Requests with a non-empty tenant name will restict the context of the operation to components to which that tenant has access.
+
+          Requests with an empty tenant name, or that omit this paarameter, will have no such context restrictions.
+        required: false
+        schema:
+          $ref: '#/components/schemas/TenantName'
   /v2/options:
     get:
       summary: Retrieve the BOS service options


### PR DESCRIPTION
## Summary and Scope

The BOS API is going to rely on a header parameter to receive the tenant name, but that is not currently captured in the BOS API spec. This PR is an attempt to correct that.

## Issues and Related PRs

* Resolves [CASMCMS-8659](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8659)

## Testing

I deployed this on wasp and verified that the cmsdev suite executed without error for BOS and I was still able to create sessions and session templates.

## Risks and Mitigations

Hopefully low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
