### PR TITLE
CASMCMS-8661/CASMCMS-8667: API spec linting & corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only indicated in the text description. 
 ### Fixed
 - Corrected many small errors and inconsistencies in the API spec description text fields.
+- Updated API spec so that it accurately describes the actual implementation:
+  - Successfully creating a V1 session template returns the name of that template.
 
 ## [2.0.18] - 2023-05-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.19] - 2023-06-09
+### Added
+- Updated the API spec to make use of the OpenAPI `deprecated` tag in places where it previously was
+  only indicated in the text description. 
+### Fixed
+- Corrected many small errors and inconsistencies in the API spec description text fields.
+
 ## [2.0.18] - 2023-05-30
 ### Fixed
 - Fix bug that accidentally started enforcing restrictions on session template names.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -103,6 +103,47 @@ servers:
   description: The service as exposed through Kubernetes DNS service mapping
 components:
   schemas:
+    # Version-agnostic schemas
+    BootSetEtag:
+      type: string
+      description: |
+        This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.
+    BootSetKernelParameters:
+      type: string
+      description: |
+        The kernel parameters to use to boot the nodes.
+    BootSetName:
+      type: string
+      description: |
+        The Boot Set name.
+    BootSetPath:
+      type: string
+      description: |
+        A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.
+        It will be processed based on the type attribute.
+    BootSetRootfsProvider:
+      type: string
+      description: |
+        The root file system provider.
+    BootSetRootfsProviderPassthrough:
+      type: string
+      description: |
+        The root file system provider passthrough.
+        These are additional kernel parameters that will be appended to
+        the 'rootfs=<protocol>' kernel parameter
+    BootSetType:
+      type: string
+      description: |
+        The MIME type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
+    CfsConfiguration:
+      type: string
+      description: |
+        The name of configuration to be applied.
+    EnableCfs:
+      type: boolean
+      description: |
+        Whether to enable the Configuration Framework Service (CFS).
+      default: true
     Healthz:
       description: Service health status
       type: object
@@ -112,24 +153,54 @@ components:
         apiStatus:
           type: string
       additionalProperties: false
-    Version:
-      description: Version data
+    Link:
+      description: Link to other resources
       type: object
       properties:
-        major:
+        href:
           type: string
-          pattern: '^(0|[1-9][0-9]*)$'
-        minor:
+        rel:
           type: string
-          pattern: '^(0|[1-9][0-9]*)$'
-        patch:
-          type: string
-          pattern: '^(0|[1-9][0-9]*)$'
-        links:
-          type: array
-          items:
-            $ref: '#/components/schemas/Link'
       additionalProperties: false
+    LinkList:
+      description: List of links to other resources
+      type: array
+      items:
+        $ref: '#/components/schemas/Link'
+    LinkListReadOnly:
+      description: List of links to other resources
+      type: array
+      readOnly: true
+      items:
+        $ref: '#/components/schemas/Link'
+    NodeList:
+      type: array
+      description: Node list.
+      minItems: 1
+      example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
+      items:
+        type: string
+        description: |
+          Hardware component name (xname).
+        example: x3001c0s39b0n0
+    NodeGroupList:
+      type: array
+      description: Node group list. Allows actions against associated nodes by logical groupings.
+      minItems: 1
+      items:
+        type: string
+        description: |
+          Name of a user-defined logical group in the Hardware State Manager (HSM).
+    NodeRoleList:
+      type: array
+      description: Node role list. Allows actions against nodes with associated roles.
+      minItems: 1
+      example: ["Compute", "Application"]
+      items:
+        type: string
+        description: |
+          Name of a role that is defined in the Hardware State Manager (HSM).
+        example: Compute
     ProblemDetails:
       description: An error response for RFC 7807 problem details.
       type: object
@@ -163,16 +234,61 @@ components:
             debugging information.
           type: string
       additionalProperties: false
-    Link:
-      description: Link to other resources
+    SessionLimit:
+      type: string
+      description: |
+        A comma-separated list of nodes, groups, or roles to which the Session
+        will be limited. Components are treated as OR operations unless
+        preceded by "&" for AND or "!" for NOT.
+    SessionTemplateDescription:
+      type: string
+      description: |
+        An optional description for the Session Template.
+    SessionTemplateName:
+      type: string
+      description: |
+        Name of the Session Template.
+
+        It is recommended to use names which meet the following restrictions:
+        * Maximum length of 127 characters.
+        * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+        * Begin and end with a letter or digit.
+
+        These restrictions are not enforced in this version of BOS, but they are
+        targeted to start being enforced in an upcoming BOS version.
+      minLength: 1
+      example: "cle-1.0.0"
+    Version:
+      description: Version data
       type: object
       properties:
-        href:
+        major:
           type: string
-        rel:
+          pattern: '^(0|[1-9][0-9]*)$'
+        minor:
           type: string
+          pattern: '^(0|[1-9][0-9]*)$'
+        patch:
+          type: string
+          pattern: '^(0|[1-9][0-9]*)$'
+        links:
+          $ref: '#/components/schemas/LinkList'
       additionalProperties: false
+
     # V1
+    V1CfsBranch:
+      type: string
+      deprecated: true
+      description: |
+        The name of the branch containing the configuration that you want to
+        apply to the nodes. Mutually exclusive with commit. (DEPRECATED)
+    V1CfsConfiguration:
+      $ref: '#/components/schemas/CfsConfiguration'
+    V1CfsUrl:
+      type: string
+      deprecated: true
+      description: |
+        The clone URL for the repository providing the configuration. (DEPRECATED)
     V1CfsParameters:
       type: object
       description: |
@@ -180,16 +296,9 @@ components:
         Framework Service when configuration is enabled.
       properties:
         clone_url:
-          type: string
-          deprecated: true
-          description: |
-            The clone URL for the repository providing the configuration. (DEPRECATED)
+          $ref: '#/components/schemas/V1CfsUrl'
         branch:
-          type: string
-          deprecated: true
-          description: |
-            The name of the branch containing the configuration that you want to
-            apply to the nodes. Mutually exclusive with commit. (DEPRECATED)
+          $ref: '#/components/schemas/V1CfsBranch'
         commit:
           type: string
           deprecated: true
@@ -201,11 +310,9 @@ components:
           deprecated: true
           description: |
             The name of the playbook to run for configuration. The file path must be specified
-            relative to the base directory of the config repo. (DEPRECATED)
+            relative to the base directory of the config repository. (DEPRECATED)
         configuration:
-          type: string
-          description: |
-            The name of configuration to be applied.
+          $ref: '#/components/schemas/V1CfsConfiguration'
       additionalProperties: false
     V1CompleteMetadata:
       type: boolean
@@ -225,8 +332,9 @@ components:
       example: "2020-04-24T12:00"
     V1StopTimeMetadata:
       type: string
-      description: The stop time
+      description: The stop time. In some contexts, the value may be null before the operation finishes.
       example: "2020-04-24T12:00"
+      nullable: true
     V1GenericMetadata:
       type: object
       description: |
@@ -244,12 +352,7 @@ components:
           $ref: '#/components/schemas/V1StopTimeMetadata'
       additionalProperties: false
     V1NodeList:
-      type: array
-      description: |
-        A list of node xnames.
-      items:
-        type: string
-        example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
+      $ref: '#/components/schemas/NodeList'
     V1PhaseCategoryName:
       type: string
       description: |
@@ -302,6 +405,8 @@ components:
       description: Unique BOS v1 Session identifier.
       format: uuid
       example: "8deb0746-b18c-427c-84a8-72ec6a28642c"
+    V1BootSetName:
+      $ref: '#/components/schemas/BootSetName'
     V1BootSetStatus:
       type: object
       description: |
@@ -314,10 +419,7 @@ components:
 
       properties:
         name:
-          type: string
-          minLength: 1
-          description: Name of the Boot Set
-          example: "Boot-Set"
+          $ref: '#/components/schemas/V1BootSetName'
         session:
           $ref: '#/components/schemas/V1SessionId'
         metadata:
@@ -327,9 +429,7 @@ components:
           items:
             $ref: '#/components/schemas/V1PhaseStatus'
         links:
-          type: array
-          items:
-            $ref: '#/components/schemas/Link'
+          $ref: '#/components/schemas/LinkList'
     V1SessionStatus:
       type: object
       description: |
@@ -348,14 +448,28 @@ components:
              The Boot Sets in the Session
            type: array
            items:
-             type: string
+             $ref: '#/components/schemas/V1BootSetName'
            minItems: 1
         id:
           $ref: '#/components/schemas/V1SessionId'
         links:
-          type: array
-          items:
-            $ref: '#/components/schemas/Link'
+          $ref: '#/components/schemas/LinkList'
+    V1BootSetPath:
+      $ref: '#/components/schemas/BootSetPath'
+    V1BootSetType:
+      $ref: '#/components/schemas/BootSetType'
+    V1BootSetEtag:
+      $ref: '#/components/schemas/BootSetEtag'
+    V1BootSetKernelParameters:
+      $ref: '#/components/schemas/BootSetKernelParameters'
+    V1NodeGroupList:
+      $ref: '#/components/schemas/NodeGroupList'
+    V1NodeRoleList:
+      $ref: '#/components/schemas/NodeRoleList'
+    V1BootSetRootfsProvider:
+      $ref: '#/components/schemas/BootSetRootfsProvider'
+    V1BootSetRootfsProviderPassthrough:
+      $ref: '#/components/schemas/BootSetRootfsProviderPassthrough'
     V1BootSet:
       description: |
         A Boot Set defines a collection of nodes and the information about the
@@ -367,9 +481,31 @@ components:
       type: object
       properties:
         name:
+          $ref: '#/components/schemas/V1BootSetName'
+        path:
+          $ref: '#/components/schemas/V1BootSetPath'
+        type:
+          $ref: '#/components/schemas/V1BootSetType'
+        etag:
+          $ref: '#/components/schemas/V1BootSetEtag'
+        kernel_parameters:
+          $ref: '#/components/schemas/V1BootSetKernelParameters'
+        node_list:
+          $ref: '#/components/schemas/V1NodeList'
+        node_roles_groups:
+          $ref: '#/components/schemas/V1NodeRoleList'
+        node_groups:
+          $ref: '#/components/schemas/V1NodeGroupList'
+        rootfs_provider:
+          $ref: '#/components/schemas/V1BootSetRootfsProvider'
+        rootfs_provider_passthrough:
+          $ref: '#/components/schemas/V1BootSetRootfsProviderPassthrough'
+        network:
           type: string
           description: |
-            The Boot Set name.
+            The network over which the node will boot.
+            Choices:  NMN -- Node Management Network
+          pattern: '^[nN][mM][nN]$'
         boot_ordinal:
           type: integer
           minimum: 0
@@ -382,76 +518,30 @@ components:
           description: |
             The shutdown ordinal. This will establish the order for Boot Set
             shutdown operations. Sets shutdown from low to high shutdown_ordinal.
-        path:
-          type: string
-          description: |
-            A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.
-            It will be processed based on the type attribute.
-        type:
-          type: string
-          description: |
-            The MIME type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
-        etag:
-          type: string
-          description: |
-            This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.
-        kernel_parameters:
-          type: string
-          description: |
-            The kernel parameters to use to boot the nodes.
-        network:
-          type: string
-          description: |
-            The network over which the node will boot.
-            Choices:  NMN -- Node Management Network
-          pattern: '^[nN][mM][nN]$'
-        node_list:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: |
-            The node list. This is an explicit mapping against hardware xnames.
-        node_roles_groups:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: |
-            The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.
-        node_groups:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: |
-            The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user-defined groups in SMD.
-        rootfs_provider:
-          type: string
-          description: |
-            The root file system provider.
-        rootfs_provider_passthrough:
-          type: string
-          description: |
-            The root file system provider passthrough.
-            These are additional kernel parameters that will be appended to
-            the 'rootfs=<protocol>' kernel parameter
       additionalProperties: false
       required: [path, type]
     V1SessionTemplateName:
-          type: string
-          minLength: 1
-          description: |
-            Name of the Session Template.
-            
-            It is recommended to use names which meet the following restrictions:
-            * Maximum length of 127 characters.
-            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
-            * Begin and end with a letter or digit.
-            
-            These restrictions are not enforced in this version of BOS, but will be
-            enforced in a future version.
-          example: "cle-1.0.0"    
+      $ref: '#/components/schemas/SessionTemplateName'
+    V1SessionTemplateUuid:
+      type: string
+      description: |
+        DEPRECATED - use templateName. This field is ignored if templateName is also set.
+
+        Name of the Session Template.
+
+        It is recommended to use names which meet the following restrictions:
+        * 1-127 characters in length.
+        * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+        * Begin and end with a letter or digit.
+
+        These restrictions are not enforced in this version of BOS, but they are
+        targeted to start being enforced in an upcoming BOS version.
+      example: "my-session-template"
+      deprecated: true
+    V1SessionTemplateDescription:
+      $ref: '#/components/schemas/SessionTemplateDescription'
+    V1EnableCfs:
+      $ref: '#/components/schemas/EnableCfs'
     V1SessionTemplate:
       type: object
       description: |
@@ -469,29 +559,17 @@ components:
           description: |
             The URL to the resource providing the Session Template data.
             Specify either a templateURL, or the other Session
-            template parameters.
+            Template parameters.
         name:
           $ref: '#/components/schemas/V1SessionTemplateName'
         description:
-          type: string
-          description: |
-            An optional description for the Session Template.
+          $ref: '#/components/schemas/V1SessionTemplateDescription'
         cfs_url:
-          type: string
-          deprecated: true
-          description: |
-            The URL for the repository providing the configuration. DEPRECATED
+          $ref: '#/components/schemas/V1CfsUrl'
         cfs_branch:
-          type: string
-          deprecated: true
-          description: |
-            The name of the branch containing the configuration that you want to
-            apply to the nodes.  DEPRECATED.
+          $ref: '#/components/schemas/V1CfsBranch'
         enable_cfs:
-          type: boolean
-          description: |
-            Whether to enable the Configuration Framework Service (CFS).
-          default: true
+          $ref: '#/components/schemas/V1EnableCfs'
         cfs:
           $ref: '#/components/schemas/V1CfsParameters'
         partition:
@@ -500,13 +578,12 @@ components:
             The machine partition to operate on.
         boot_sets:
           type: object
+          description: |
+            Mapping from Boot Set names to Boot Sets.
           additionalProperties:
             $ref: '#/components/schemas/V1BootSet'
         links:
-          type: array
-          readOnly: true
-          items:
-            $ref: '#/components/schemas/Link'
+          $ref: '#/components/schemas/LinkListReadOnly'
       required: [name]
       additionalProperties: false
     V1BoaKubernetesJob:
@@ -517,7 +594,7 @@ components:
       example: "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
     V1Operation:
       type: string
-      description: >
+      description: |
         A Session represents an operation on a Session Template.
         The creation of a Session effectively results in the creation
         of a Kubernetes Boot Orchestration Agent (BOA) job to perform the
@@ -537,16 +614,6 @@ components:
 
       pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[rR][eE][bB][oO][oO][tT]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
       example: "boot"
-    V1TemplateName:
-       type: string
-       description: The name of the Session Template
-       example: "my-session-template"
-       minLength: 1
-    V1TemplateUuid:
-      type: string
-      description: DEPRECATED - use templateName. This field is ignored if templateName is also set.
-      example: "my-session-template"
-      deprecated: true
     V1SessionLink:
       description: Link to other resources
       type: object
@@ -588,7 +655,7 @@ components:
         stop_time:
           $ref: '#/components/schemas/V1StopTimeMetadata'
         templateName:
-          $ref: '#/components/schemas/V1TemplateName'
+          $ref: '#/components/schemas/V1SessionTemplateName'
     V1SessionDetailsByTemplateUuid:
       description: |
         Details about a Session using templateUuid instead of templateName.
@@ -613,7 +680,14 @@ components:
         stop_time:
           $ref: '#/components/schemas/V1StopTimeMetadata'
         templateName:
-          $ref: '#/components/schemas/V1TemplateName'
+          $ref: '#/components/schemas/V1SessionTemplateName'
+    V1SessionLimit:
+      $ref: '#/components/schemas/SessionLimit'
+    V1SessionLinkList:
+      type: array
+      readOnly: true
+      items:
+        $ref: '#/components/schemas/V1SessionLink'
     V1Session:
       description: |
         A Session object specified by templateName
@@ -626,22 +700,15 @@ components:
         operation:
           $ref: '#/components/schemas/V1Operation'
         templateUuid:
-          $ref: '#/components/schemas/V1TemplateUuid'
+          $ref: '#/components/schemas/V1SessionTemplateUuid'
         templateName:
-          $ref: '#/components/schemas/V1TemplateName'
+          $ref: '#/components/schemas/V1SessionTemplateName'
         job:
           $ref: '#/components/schemas/V1BoaKubernetesJob'
         limit:
-          type: string
-          description: >
-            A comma-separated list of nodes, groups, or roles to which the Session
-            will be limited. Components are treated as OR operations unless
-            preceded by "&" for AND or "!" for NOT.
+          $ref: '#/components/schemas/V1SessionLimit'
         links:
-          type: array
-          readOnly: true
-          items:
-            $ref: '#/components/schemas/V1SessionLink'
+          $ref: '#/components/schemas/V1SessionLinkList'
       required: [operation, templateName]
       additionalProperties: false
     V1SessionByTemplateUuid:
@@ -657,20 +724,13 @@ components:
         operation:
           $ref: '#/components/schemas/V1Operation'
         templateUuid:
-          $ref: '#/components/schemas/V1TemplateUuid'
+          $ref: '#/components/schemas/V1SessionTemplateUuid'
         job:
           $ref: '#/components/schemas/V1BoaKubernetesJob'
         limit:
-          type: string
-          description: >
-            A comma-separated list of nodes, groups, or roles to which the Session
-            will be limited. Components are treated as OR operations unless
-            preceded by "&" for AND or "!" for NOT.
+          $ref: '#/components/schemas/V1SessionLimit'
         links:
-          type: array
-          readOnly: true
-          items:
-            $ref: '#/components/schemas/V1SessionLink'
+          $ref: '#/components/schemas/V1SessionLinkList'
       required: [operation, templateUuid]
       additionalProperties: false
     V1PhaseName:
@@ -704,55 +764,64 @@ components:
         This does not overwrite previously existing errors.
       additionalProperties:
         $ref: '#/components/schemas/V1NodeList'
-    V1UpdateRequestNodeChangeList:
+    V1UpdateRequestNodeChange:
       description: |
-        This is the payload sent during an update request. It contains
+        This is an element of the payload sent during an update request. It contains
         updates to which categories nodes are in.
-      type: array
-      items:
-        type: object
-        properties:
-          update_type:
-            description: The type of update data
-            pattern: '^NodeChangeList$'
-            type: string
-          phase:
-            $ref: '#/components/schemas/V1PhaseName'
-          data:
-            $ref: '#/components/schemas/V1NodeChangeList'
-    V1UpdateRequestNodeErrorsList:
+      type: object
+      properties:
+        update_type:
+          description: The type of update data
+          enum: [ 'NodeChangeList' ]
+          type: string
+        phase:
+          $ref: '#/components/schemas/V1PhaseName'
+        data:
+          $ref: '#/components/schemas/V1NodeChangeList'
+      required: [ 'data', 'phase', 'update_type' ]
+    V1UpdateRequestNodeErrors:
       description: |
-        This is the payload sent during an update request. It contains
+        This is an element of the payload sent during an update request. It contains
         updates to which errors have occurred and which nodes encountered those errors
-      type: array
-      items:
-        type: object
-        properties:
-          update_type:
-            description: The type of update data
-            pattern: '^NodeErrorsList$'
-            type: string
-          phase:
-            $ref: '#/components/schemas/V1PhaseName'
-          data:
-            $ref: '#/components/schemas/V1NodeErrorsList'
+      type: object
+      properties:
+        update_type:
+          description: The type of update data
+          enum: [ 'NodeErrorsList' ]
+          type: string
+        phase:
+          $ref: '#/components/schemas/V1PhaseName'
+        data:
+          $ref: '#/components/schemas/V1NodeErrorsList'
+      required: [ 'data', 'phase', 'update_type' ]
     V1UpdateRequestGenericMetadata:
       description: |
-        This is the payload sent during an update request. It contains
+        This is an element of the payload sent during an update request. It contains
         updates to metadata, specifically start and stop times
+      type: object
+      properties:
+        update_type:
+          description: The type of update data
+          enum: [ 'GenericMetadata' ]
+          type: string
+        phase:
+          $ref: '#/components/schemas/V1PhaseName'
+        data:
+          $ref: '#/components/schemas/V1GenericMetadata'
+      required: [ 'data', 'phase', 'update_type' ]
+    V1UpdateRequestList:
+      description: |
+        This is the payload sent during an update request. It contains a list of updates.
       type: array
       items:
-        type: object
-        properties:
-          update_type:
-            description: The type of update data
-            pattern: '^GenericMetadata$'
-            type: string
-          phase:
-            $ref: '#/components/schemas/V1PhaseName'
-          data:
-            $ref: '#/components/schemas/V1GenericMetadata'
+        # Each item in the list should match exactly one of these schemas (since they are mutually exclusive)
+        oneOf:
+          - $ref: '#/components/schemas/V1UpdateRequestNodeChange'
+          - $ref: '#/components/schemas/V1UpdateRequestNodeErrors'
+          - $ref: '#/components/schemas/V1UpdateRequestGenericMetadata'
     # V2
+    V2CfsConfiguration:
+      $ref: '#/components/schemas/CfsConfiguration'
     V2CfsParameters:
       type: object
       description: |
@@ -761,10 +830,12 @@ components:
         a Session Template, or individually within a Boot Set.
       properties:
         configuration:
-          type: string
-          description: |
-            The name of configuration to be applied.
+          $ref: '#/components/schemas/V2CfsConfiguration'
       additionalProperties: false
+    V2SessionTemplateDescription:
+      $ref: '#/components/schemas/SessionTemplateDescription'
+    V2EnableCfs:
+      $ref: '#/components/schemas/EnableCfs'
     V2SessionTemplate:
       type: object
       description: |
@@ -782,115 +853,128 @@ components:
           readOnly: true
           description: |
             Name of the Session Template.
-            
+
             It is recommended to use names which meet the following restrictions:
             * Maximum length of 127 characters.
             * Use only letters, digits, periods (.), dashes (-), and underscores (_).
             * Begin and end with a letter or digit.
-            
-            These restrictions are not enforced in this version of BOS, but will be
-            enforced in a future version.
+
+            These restrictions are not enforced in this version of BOS, but they are
+            targeted to start being enforced in an upcoming BOS version.
           example: "cle-1.0.0"
         description:
-          type: string
-          description: |
-            An optional description for the Session Template.
+          $ref: '#/components/schemas/V2SessionTemplateDescription'
         enable_cfs:
-          type: boolean
-          description: |
-            Whether to enable the Configuration Framework Service (CFS).
-          default: true
+          $ref: '#/components/schemas/V2EnableCfs'
         cfs:
           $ref: '#/components/schemas/V2CfsParameters'
         boot_sets:
           type: object
+          description: |
+            Mapping from Boot Set names to Boot Sets.
           additionalProperties:
             $ref: '#/components/schemas/V2BootSet'
         links:
-          type: array
-          readOnly: true
-          items:
-            $ref: '#/components/schemas/Link'
+          $ref: '#/components/schemas/LinkListReadOnly'
       additionalProperties: false
     V2SessionTemplateValidation:
       description: |
         Message describing errors or incompleteness in a Session Template.
       type: string
-    V2TemplateName:
-       type: string
-       description: The name of the Session Template
-       example: "my-session-template"
-       minLength: 1
+    V2SessionLimit:
+      $ref: '#/components/schemas/SessionLimit'
+    V2SessionName:
+      type: string
+      description: Name of the Session.
+      example: "session-20190728032600"
+      # These validation parameters are restricted by Kubernetes naming conventions.
+      minLength: 1
+      maxLength: 45
+      pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+    V2SessionOperation:
+      type: string
+      enum: ['boot', 'reboot', 'shutdown']
+      description: |
+        A Session represents a desired state that is being applied to a group
+        of Components.  Sessions run until all Components it manages have
+        either been disabled due to completion, or until all Components are
+        managed by other newer Sessions.
+
+        Operation -- An operation to perform on Components in this Session.
+            Boot                 Applies the Template to the Components and boots/reboots if necessary.
+            Reboot               Applies the Template to the Components; guarantees a reboot.
+            Shutdown             Power down Components that are on.
+    V2SessionTemplateName:
+      $ref: '#/components/schemas/SessionTemplateName'
     V2SessionCreate:
       description: |
-        A Session Creation object
+        A Session Creation object. A UUID name is generated if a name is not provided.
       type: object
       properties:
         name:
-          type: string
-          description: Name of the Session. A UUID name is generated if a name is not provided.
-          example: "session-20190728032600"
-          # These validation parameters are restricted by Kubernetes naming conventions.
-          minLength: 1
-          maxLength: 45
-          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          $ref: '#/components/schemas/V2SessionName'
         operation:
-          type: string
-          enum: ['boot', 'reboot', 'shutdown']
-          description: >
-            A Session represents a desired state that is being applied to a group
-            of Components.  Sessions run until all Components it manages have
-            either been disabled due to completion, or until all Components are
-            managed by other newer Sessions.
-
-            Operation -- An operation to perform on Components in this Session.
-                Boot                 Applies the Template to the Components and boots/reboots if necessary.
-                Reboot               Applies the Template to the Components; guarantees a reboot.
-                Shutdown             Power down Components that are on.
+          $ref: '#/components/schemas/V2SessionOperation'
         template_name:
-          $ref: '#/components/schemas/V2TemplateName'
+          $ref: '#/components/schemas/V2SessionTemplateName'
         limit:
-          type: string
-          description: >
-            A comma-separated list of nodes, groups, or roles to which the Session
-            will be limited. Components are treated as OR operations unless
-            preceded by "&" for AND or "!" for NOT.
+          $ref: '#/components/schemas/V2SessionLimit'
         stage:
           type: boolean
-          description: >
+          description: |
             Set to stage a Session which will not immediately change the state of any Components.
             The "applystaged" endpoint can be called at a later time to trigger the start of this Session.
           default: false
         include_disabled:
           type: boolean
-          description: >
+          description: |
             Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).
           default: false
       required: [operation, template_name]
       additionalProperties: false
+    V2SessionStatusLabel:
+      type: string
+      enum: ['pending', 'running', 'complete']
+      description: The status of a Session.
+    V2SessionTime:
+      type: string
+      description: When the Session was created or completed.
     V2SessionStatus:
       type: object
       description: |
         Information on the status of a Session.
       properties:
         start_time:
-          type: string
-          description: |
-            When the Session was created.
+          $ref: '#/components/schemas/V2SessionTime'
         end_time:
-          type: string
-          description: |
-            When the Session completed.
+          $ref: '#/components/schemas/V2SessionTime'
         status:
-          type: string
-          enum: ['pending', 'running', 'complete']
-          description: |
-            The status of a Session.
+          $ref: '#/components/schemas/V2SessionStatusLabel'
         error:
           type: string
           description: |
             Error which prevented the Session from running
       additionalProperties: false
+    V2BootSetName:
+      $ref: '#/components/schemas/BootSetName'
+    V2BootSetPath:
+      $ref: '#/components/schemas/BootSetPath'
+    V2BootSetType:
+      $ref: '#/components/schemas/BootSetType'
+    V2BootSetEtag:
+      $ref: '#/components/schemas/BootSetEtag'
+    V2BootSetKernelParameters:
+      $ref: '#/components/schemas/BootSetKernelParameters'
+    V2NodeList:
+      $ref: '#/components/schemas/NodeList'
+    V2NodeGroupList:
+      $ref: '#/components/schemas/NodeGroupList'
+    V2NodeRoleList:
+      $ref: '#/components/schemas/NodeRoleList'
+    V2BootSetRootfsProvider:
+      $ref: '#/components/schemas/BootSetRootfsProvider'
+    V2BootSetRootfsProviderPassthrough:
+      $ref: '#/components/schemas/BootSetRootfsProviderPassthrough'
     V2BootSet:
       description: |
         A Boot Set is a collection of nodes defined by an explicit list, their functional
@@ -900,59 +984,27 @@ components:
       type: object
       properties:
         name:
-          type: string
-          description: |
-            The Boot Set name.
+          $ref: '#/components/schemas/V2BootSetName'
         path:
-          type: string
-          description: |
-            A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.
-            It will be processed based on the type attribute.
+          $ref: '#/components/schemas/V2BootSetPath'
         cfs:
           $ref: '#/components/schemas/V2CfsParameters'
         type:
-          type: string
-          description: |
-            The MIME type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
+          $ref: '#/components/schemas/V2BootSetType'
         etag:
-          type: string
-          description: |
-            This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.
+          $ref: '#/components/schemas/V2BootSetEtag'
         kernel_parameters:
-          type: string
-          description: |
-            The kernel parameters to use to boot the nodes.
+          $ref: '#/components/schemas/V2BootSetKernelParameters'
         node_list:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: |
-            The node list. This is an explicit mapping against hardware xnames.
+          $ref: '#/components/schemas/V2NodeList'
         node_roles_groups:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: |
-            The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.
+          $ref: '#/components/schemas/V2NodeRoleList'
         node_groups:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: |
-            The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user-defined groups in SMD.
+          $ref: '#/components/schemas/V2NodeGroupList'
         rootfs_provider:
-          type: string
-          description: |
-            The root file system provider.
+          $ref: '#/components/schemas/V2BootSetRootfsProvider'
         rootfs_provider_passthrough:
-          type: string
-          description: |
-            The root file system provider passthrough.
-            These are additional kernel parameters that will be appended to
-            the 'rootfs=<protocol>' kernel parameter
+          $ref: '#/components/schemas/V2BootSetRootfsProviderPassthrough'
       additionalProperties: false
       required: [path, type]
     V2Session:
@@ -965,44 +1017,27 @@ components:
       type: object
       properties:
         name:
-          type: string
-          description: >
-            Name of the Session.
+          $ref: '#/components/schemas/V2SessionName'
         operation:
-          type: string
-          enum: ['boot', 'reboot', 'shutdown']
-          description: >
-            A Session represents a desired state that is being applied to a group
-            of Components.  Sessions run until all Components it manages have
-            either been disabled due to completion, or until all Components are
-            managed by other newer Sessions.
-
-            Operation -- An operation to perform on Components in this Session.
-                Boot                 Applies the Template to the Components and boots/reboots if necessary.
-                Reboot               Applies the Template to the Components; guarantees a reboot.
-                Shutdown             Power down Components that are on.
+          $ref: '#/components/schemas/V2SessionOperation'
         template_name:
-          $ref: '#/components/schemas/V2TemplateName'
+          $ref: '#/components/schemas/V2SessionTemplateName'
         limit:
-          type: string
-          description: >
-            A comma-separated list of nodes, groups, or roles to which the Session
-            will be limited. Components are treated as OR operations unless
-            preceded by "&" for AND or "!" for NOT.
+          $ref: '#/components/schemas/V2SessionLimit'
         stage:
           type: boolean
-          description: >
+          description: |
             Set to stage a Session which will not immediately change the state of any Components.
             The "applystaged" endpoint can be called at a later time to trigger the start of this Session.
         components:
           type: string
-          description: >
+          description: |
             A comma-separated list of nodes, representing the initial list of nodes
             the Session should operate against.  The list will remain even if
             other Sessions have taken over management of the nodes.
         include_disabled:
           type: boolean
-          description: >
+          description: |
             Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).
         status:
           $ref: '#/components/schemas/V2SessionStatus'
@@ -1040,13 +1075,9 @@ components:
         Detailed information on the timing of a Session.
       properties:
         start_time:
-          type: string
-          description: |
-            When the Session was created.
+          $ref: '#/components/schemas/V2SessionTime'
         end_time:
-          type: string
-          description: |
-            When the Session completed.
+          $ref: '#/components/schemas/V2SessionTime'
         duration:
           type: string
           description: |
@@ -1058,10 +1089,7 @@ components:
         Detailed information on the status of a Session.
       properties:
         status:
-          type: string
-          enum: ['pending', 'running', 'complete']
-          description: |
-            The status of a Session.
+          $ref: '#/components/schemas/V2SessionStatusLabel'
         managed_components_count:
           type: integer
           description: |
@@ -1102,6 +1130,12 @@ components:
           type: string
           description: Initrd ID
       additionalProperties: false
+    V2ComponentLastUpdated:
+      type: string
+      description: The date/time when the state was last updated in RFC 3339 format.
+      example: '2019-07-28T03:26:00Z'
+      format: date-time
+      readOnly: true
     V2ComponentActualState:
       description: |
         The desired boot artifacts and configuration for a Component
@@ -1111,15 +1145,11 @@ components:
           $ref: '#/components/schemas/V2BootArtifacts'
         bss_token:
           type: string
-          description: >
+          description: |
             A token received from the node identifying the boot artifacts.
             For BOS use-only, users should not set this field. It will be overwritten.
         last_updated:
-          type: string
-          description: The date/time when the state was last updated in RFC 3339 format.
-          example: '2019-07-28T03:26:00Z'
-          format: date-time
-          readOnly: true
+          $ref: '#/components/schemas/V2ComponentLastUpdated'
       additionalProperties: false
     V2ComponentDesiredState:
       description: |
@@ -1129,39 +1159,29 @@ components:
         boot_artifacts:
           $ref: '#/components/schemas/V2BootArtifacts'
         configuration:
-          type: string
-          description: A CFS configuration ID.
+          $ref: '#/components/schemas/V2CfsConfiguration'
         bss_token:
           type: string
-          description: >
+          description: |
             A token received from BSS identifying the boot artifacts.
             For BOS use-only, users should not set this field. It will be overwritten.
         last_updated:
-          type: string
-          description: The date/time when the state was last updated in RFC 3339 format.
-          example: '2019-07-28T03:26:00Z'
-          format: date-time
-          readOnly: true
+          $ref: '#/components/schemas/V2ComponentLastUpdated'
       additionalProperties: false
     V2ComponentStagedState:
       description: |
-        The desired boot artifacts and configuration for a Component
+        The desired boot artifacts and configuration for a Component. Optionally, a Session
+        may be set which can be triggered at a later time against this Component.
       type: object
       properties:
         boot_artifacts:
           $ref: '#/components/schemas/V2BootArtifacts'
         configuration:
-          type: string
-          description: A CFS configuration ID.
+          $ref: '#/components/schemas/V2CfsConfiguration'
         session:
-          type: string
-          description: A Session which can be triggered at a later time against this Component.
+          $ref: '#/components/schemas/V2SessionName'
         last_updated:
-          type: string
-          description: The date/time when the state was last updated in RFC 3339 format.
-          example: '2019-07-28T03:26:00Z'
-          format: date-time
-          readOnly: true
+          $ref: '#/components/schemas/V2ComponentLastUpdated'
       additionalProperties: false
     V2ComponentLastAction:
       description: |
@@ -1169,11 +1189,7 @@ components:
       type: object
       properties:
         last_updated:
-          type: string
-          description: The date/time when the state was last updated in RFC 3339 format.
-          example: '2019-07-28T03:26:00Z'
-          format: date-time
-          readOnly: true
+          $ref: '#/components/schemas/V2ComponentLastUpdated'
         action:
           type: string
           description: A description of the most recent operator/action to impact the Component.
@@ -1213,7 +1229,8 @@ components:
       additionalProperties: false
     V2Component:
       description: |
-        The current and desired artifacts state for a Component.
+        The current and desired artifacts state for a Component, and
+        the Session responsible for the Component's current state.
       type: object
       properties:
         id:
@@ -1238,8 +1255,7 @@ components:
           type: string
           description: A description of the most recent error to impact the Component.
         session:
-          type: string
-          description: The Session responsible for the Component's current state
+          $ref: '#/components/schemas/V2SessionName'
         retry_policy:
           type: integer
           description: |
@@ -1253,15 +1269,16 @@ components:
       items:
         $ref: '#/components/schemas/V2Component'
     V2ComponentsFilter:
-      description: Information for patching multiple Components.
+      description: |
+        Information for patching multiple Components.
+        If a Session name is specified, then all Components part of this Session will be patched.
       type: object
       properties:
         ids:
           type: string
           description: A comma-separated list of Component IDs
         session:
-          type: string
-          description: A Session name.  All Components part of this Session will be patched.
+          $ref: '#/components/schemas/V2SessionName'
     V2ComponentsUpdate:
       description: Information for patching multiple Components.
       type: object
@@ -1310,15 +1327,27 @@ components:
       properties:
         cleanup_completed_session_ttl:
           type: string
-          description: Delete complete Sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior.
+          description: |
+            Delete complete Sessions that are older than cleanup_completed_session_ttl (in minutes, hours, days, or weeks).
+            0 disables cleanup behavior.
+          example: 3d
+          format: '^(0|0[mMhHdDwW]|[1-9][0-9]*[mMhHdDwW])$'
+          minLength: 1
+          # This allows for over 10 years using the smallest units (minutes)
+          maxLength: 8
         clear_stage:
           type: boolean
           description: Allows a Component's staged information to be cleared when the requested staging action has been started. Defaults to false.
         component_actual_state_ttl:
           type: string
           description: |
-            The maximum amount of time a Component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes
-            and instructs bos-state-reporter to report once instead of periodically.
+            The maximum amount of time a Component's actual state is considered valid (in minutes, hours, days, or weeks).
+            0 disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically.
+          example: 6h
+          format: '^(0|0[mMhHdDwW]|[1-9][0-9]*[mMhHdDwW])$'
+          minLength: 1
+          # This allows for over 10 years using the smallest units (minutes)
+          maxLength: 8
         disable_components_on_completion:
           type: boolean
           description: |
@@ -1327,25 +1356,42 @@ components:
         discovery_frequency:
           type: integer
           description: How frequently the BOS discovery agent syncs new Components from HSM. (in seconds)
+          minimum: 0
+          # A little over a year
+          maximum: 33554432
         logging_level:
           type: string
           description: The logging level for all BOS services
         max_boot_wait_time:
           type: integer
           description: How long BOS will wait for a node to boot into a usable state before rebooting it again (in seconds)
+          minimum: 0
+          # Over 12 days
+          maximum: 1048576
         max_power_on_wait_time:
           type: integer
           description: How long BOS will wait for a node to power on before calling power on again (in seconds)
+          minimum: 0
+          # Over 12 days
+          maximum: 1048576
         max_power_off_wait_time:
           type: integer
           description: How long BOS will wait for a node to power off before forcefully powering off (in seconds)
+          minimum: 0
+          # Over 12 days
+          maximum: 1048576
         polling_frequency:
           type: integer
           description: How frequently the BOS operators check Component state for needed actions. (in seconds)
+          minimum: 0
+          # Over 12 days
+          maximum: 1048576
         default_retry_policy:
           type: integer
           description: The default maximum number attempts per node for failed actions.
           example: 1
+          minimum: 0
+          maximum: 1048576
       additionalProperties: true
     # Schemas that combine objects of different versions
     SessionTemplateArray:
@@ -1460,7 +1506,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/V1SessionTemplateName'    
+            $ref: '#/components/schemas/V1SessionTemplateName'
     # V2
     V2SessionTemplateDetails:
       description: Session Template details
@@ -1921,10 +1967,7 @@ paths:
          content:
            application/json:
              schema:
-               anyOf:
-                 - $ref: '#/components/schemas/V1UpdateRequestNodeChangeList'
-                 - $ref: '#/components/schemas/V1UpdateRequestNodeErrorsList'
-                 - $ref: '#/components/schemas/V1UpdateRequestGenericMetadata'
+               $ref: '#/components/schemas/V1UpdateRequestList'
       responses:
         200:
           description: A list of Boot Set Statuses and metadata
@@ -2234,20 +2277,20 @@ paths:
           schema:
             type: string
           in: query
-          description: >-
+          description: |-
             Return only Sessions older than the given age.  Age is given in the format "1d" or "6h"
         - name: max_age
           schema:
             type: string
           in: query
-          description: >-
+          description: |-
             Return only Sessions younger than the given age.  Age is given in the format "1d" or "6h"
         - name: status
           schema:
             type: string
             enum: ['pending', 'running', 'complete']
           in: query
-          description: >-
+          description: |-
             Return only Sessions with the given status.
       responses:
         200:
@@ -2267,20 +2310,20 @@ paths:
           schema:
             type: string
           in: query
-          description: >-
+          description: |-
             Return only Sessions older than the given age.  Age is given in the format "1d" or "6h"
         - name: max_age
           schema:
             type: string
           in: query
-          description: >-
+          description: |-
             Return only Sessions younger than the given age.  Age is given in the format "1d" or "6h"
         - name: status
           schema:
             enum: ['pending', 'running', 'complete']
             type: string
           in: query
-          description: >-
+          description: |-
             Return only Sessions with the given status.
       responses:
         204:
@@ -2380,7 +2423,7 @@ paths:
         - v2
         - components
       x-openapi-router-controller: bos.server.controllers.v2.components
-      description: >-
+      description: |-
         Retrieve the full collection of Components in the form of a
         ComponentArray. Full results can also be filtered by query
         parameters. Only the first filter parameter of each type is
@@ -2393,7 +2436,7 @@ paths:
           schema:
             type: string
           in: query
-          description: >-
+          description: |-
             Retrieve the Components with the given ID
             (e.g. xname for hardware Components). Can be chained
             for selecting groups of Components.
@@ -2401,31 +2444,31 @@ paths:
           schema:
             type: string
           in: query
-          description: >-
+          description: |-
             Retrieve the Components with the given Session ID.
         - name: staged_session
           schema:
             type: string
           in: query
-          description: >-
+          description: |-
             Retrieve the Components with the given staged Session ID.
         - name: enabled
           schema:
             type: boolean
           in: query
-          description: >-
+          description: |-
             Retrieve the Components with the "enabled" state.
         - name: phase
           schema:
             type: string
           in: query
-          description: >-
+          description: |-
             Retrieve the Components in the given phase.
         - name: status
           schema:
             type: string
           in: query
-          description: >-
+          description: |-
             Retrieve the Components with the given status.
       responses:
         200:

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -17,77 +17,84 @@ info:
     ## Resources
 
 
-    ### /sessiontemplate
+    ### Session Template
 
-    A session template sets the operational context of which nodes to operate on for
+    A Session Template sets the operational context of which nodes to operate on for
     any given set of nodes. It is largely comprised of one or more boot
     sets and their associated software configuration.
 
-    A boot set defines a list of nodes, the image you want to boot/reboot the nodes with,
+    A Boot Set defines a list of nodes, the image you want to boot/reboot the nodes with,
     kernel parameters to use to boot the nodes, and additional configuration management
     framework actions to apply during node bring up.
 
-    ### /session
+    ### Session
 
-    A BOS session applies a provided action to the nodes defined in a session
-    template.
-
-    ## Workflow
+    A BOS Session applies a provided action to the nodes defined in a Session Template.
 
 
-    ### Create a New Session
+    ## Workflow: Create a New Session
 
+    1. Choose the Session Template to use.
 
-    #### GET /sessiontemplate
+      Session Templates are uniquely identified by their names.
 
-    List available session templates.
-    Note the *name* which uniquely identifies each session template.
-    This value can be used to create a new session later,
-    if specified in the request body of POST /session.
+      a. List available Session Templates.
 
-    #### POST /sessiontemplate
+        GET /v1/sessiontemplate or /v2/sessiontemplates
 
-    If no session template pre-exists that satisfies requirements,
-    then create a new session template. *name* uniquely identifies the
-    session template.
-    This value can be used to create a new session later,
-    if specified in the request body of POST /session.
+      b. Create a new Session Template if desired.
 
-    #### POST /session
+        POST /v1/sessiontemplate or PUT /v2/sessiontemplate/{template_name}
 
-    Specify template_name and an
-    operation to create a new session.
-    The template_name corresponds to the session template *name*.
-    A new session is launched as a result of this call.
+        If no Session Template exists that satisfies requirements,
+        then create a new Session Template.
+        This Session Template can be used to create a new Session later.
 
-    A limit can also be specified to narrow the scope of the session. The limit
-    can consist of nodes, groups, or roles in a comma-separated list.
-    Multiple groups are treated as separated by OR, unless "&" is added to
-    the start of the component, in which case this becomes an AND.  Components
-    can also be preceded by "!" to exclude them.
+    2. Create the Session.
 
-    Note, the response from a successful session launch contains *links*.
-    Within *links*, *href* is a string that uniquely identifies the session.
-    *href* is constructed using the session template name and a generated UUID.
-    Use the entire *href* string as the path parameter *session_id*
-    to uniquely identify a session in for the /session/{session_id}
-    endpoint.
+      POST /v1/session or /v2/sessions
 
-    #### GET /session/{session_id}
+      Specify template_name and an operation to create a new Session.
+      The template_name corresponds to the Session Template *name*.
+      A new Session is launched as a result of this call (in the case of
+      /v2/sessions, the option to stage but not begin the Session also exists).
 
-    Get session details by session ID.
+      A limit can also be specified to narrow the scope of the Session. The limit
+      can consist of nodes, groups, or roles in a comma-separated list.
+      Multiple groups are treated as separated by OR, unless "&" is added to
+      the start of the component, in which case this becomes an AND.  Components
+      can also be preceded by "!" to exclude them.
 
-    List all in progress and completed sessions.
+      Note, the response from a successful Session launch contains *links*.
+      Within *links*, *href* is a string that uniquely identifies the Session.
+      *href* is constructed using the Session Template name and a generated UUID.
+      Use the entire *href* string as the path parameter *session_id*
+      to uniquely identify a Session.
+
+    3. Get details on the Session.
+
+      GET /v1/session/{session_id} or /v2/sessions/{session_id}
 
 
     ## Interactions with Other APIs
 
+    ### Configuration Framework Service (CFS)
 
-    BOS works in concert with Image Management Service (IMS) to access boot images,
-    and if *enable_cfs* is true then
-    BOS will invoke CFS to configure the compute nodes.
+    If *enable_cfs* is true in a Session Template, then BOS will invoke CFS to
+    configure the target nodes during *boot*, *reboot*, or *configure*
+    operations. The *configure* operation is only available in BOS v1 Sessions;
+    if desiring to only perform a CFS configuration on a set of nodes, it is
+    recommended to use CFS directly.
 
-    All boot images specified via the session template must be available via IMS.
+    ### Hardware State Manager (HSM)
+
+    In some situations BOS checks HSM to determine if a node has been disabled.
+
+    ### Image Management Service (IMS)
+
+    BOS works in concert with IMS to access boot images.
+    All boot images specified via the Session Template must be available via IMS.
+
 
 servers:
 - url: https://api-gw-service-nmn.local/apis/bos
@@ -169,25 +176,29 @@ components:
     V1CfsParameters:
       type: object
       description: |
-        CFS Parameters is the collection of parameters that are passed to the Configuration
+        This is the collection of parameters that are passed to the Configuration
         Framework Service when configuration is enabled.
       properties:
         clone_url:
           type: string
+          deprecated: true
           description: |
-            The clone url for the repository providing the configuration. (DEPRECATED)
+            The clone URL for the repository providing the configuration. (DEPRECATED)
         branch:
           type: string
+          deprecated: true
           description: |
             The name of the branch containing the configuration that you want to
             apply to the nodes. Mutually exclusive with commit. (DEPRECATED)
         commit:
           type: string
+          deprecated: true
           description: |
             The commit ID of the configuration that you want to
             apply to the nodes. Mutually exclusive with branch. (DEPRECATED)
         playbook:
           type: string
+          deprecated: true
           description: |
             The name of the playbook to run for configuration. The file path must be specified
             relative to the base directory of the config repo. (DEPRECATED)
@@ -249,11 +260,11 @@ components:
     V1PhaseCategoryStatus:
       type: object
       description: |
-        A list of the nodes in a given category within a phase.
+        A list of the nodes in a given category within a Phase.
 
         ## Link Relationships
 
-        * self : The session object
+        * self : The phase category status object
 
       properties:
         name:
@@ -268,7 +279,7 @@ components:
 
         ## Link Relationships
 
-        * self : The session object
+        * self : The phase status object
 
       properties:
         name:
@@ -288,7 +299,7 @@ components:
           $ref: '#/components/schemas/V1NodeErrorsList'
     V1SessionId:
       type: string
-      description: Unique BOS v1 session identifier.
+      description: Unique BOS v1 Session identifier.
       format: uuid
       example: "8deb0746-b18c-427c-84a8-72ec6a28642c"
     V1BootSetStatus:
@@ -298,8 +309,8 @@ components:
 
         ## Link Relationships
 
-        * self : The session object
-        * phase : A phase of the boot set
+        * self : The Boot Set Status object
+        * phase : A phase of the Boot Set
 
       properties:
         name:
@@ -322,10 +333,11 @@ components:
     V1SessionStatus:
       type: object
       description: |
-        The status for a Boot Session. It is a list of all of the Boot Set Statuses in the session.
+        The status for a Session. It is a list of all of the Boot Set Statuses in the Session.
+
         ## Link Relationships
 
-        * self : The session object
+        * self : The Session status object
         * boot sets: URL to access the Boot Set status
 
       properties:
@@ -333,7 +345,7 @@ components:
           $ref: '#/components/schemas/V1GenericMetadata'
         boot_sets:
            description: |
-             The boot sets in the Session
+             The Boot Sets in the Session
            type: array
            items:
              type: string
@@ -346,11 +358,11 @@ components:
             $ref: '#/components/schemas/Link'
     V1BootSet:
       description: |
-        A boot set defines a collection of nodes and the information about the
+        A Boot Set defines a collection of nodes and the information about the
         boot artifacts and parameters to be sent to each node over the specified
-        network to enable these nodes to boot. When multiple boot sets are used
-        in a session template, the boot_ordinal and shutdown_ordinal indicate
-        the order in which boot sets need to be acted upon. Boot sets sharing
+        network to enable these nodes to boot. When multiple Boot Sets are used
+        in a Session Template, the boot_ordinal and shutdown_ordinal indicate
+        the order in which Boot Sets need to be acted upon. Boot Sets sharing
         the same ordinal number will be addressed at the same time.
       type: object
       properties:
@@ -362,13 +374,13 @@ components:
           type: integer
           minimum: 0
           description: |
-            The boot ordinal. This will establish the order for boot set operations.
-            Boot sets boot in order from the lowest to highest boot_ordinal.
+            The boot ordinal. This will establish the order for Boot Set operations.
+            Boot Sets boot in order from the lowest to highest boot_ordinal.
         shutdown_ordinal:
           type: integer
           minimum: 0
           description: |
-            The shutdown ordinal. This will establish the order for boot set
+            The shutdown ordinal. This will establish the order for Boot Set
             shutdown operations. Sets shutdown from low to high shutdown_ordinal.
         path:
           type: string
@@ -430,23 +442,19 @@ components:
       type: object
       description: |
         A Session Template object represents a collection of resources and metadata.
-        A session template is used to create a Session which when combined with an
-        action (i.e. boot, reconfigure, reboot, shutdown) will create a Kubernetes BOA job
+        A Session Template is used to create a Session which when combined with an
+        action (i.e. boot, configure, reboot, shutdown) will create a Kubernetes BOA job
         to complete the required tasks for the operation.
-
-        A Session Template can be created from a JSON structure.  It will return
-        a SessionTemplate name if successful.
-        This name is required when creating a Session.
 
         ## Link Relationships
 
-        * self : The session object
+        * self : The Session Template object
       properties:
         templateUrl:
           type: string
           description: |
-            The URL to the resource providing the session template data.
-            Specify either a templateURL, or the other session
+            The URL to the resource providing the Session Template data.
+            Specify either a templateURL, or the other Session
             template parameters.
         name:
           type: string
@@ -465,13 +473,15 @@ components:
         description:
           type: string
           description: |
-            An optional description for the session template.
+            An optional description for the Session Template.
         cfs_url:
           type: string
+          deprecated: true
           description: |
-            The url for the repository providing the configuration. DEPRECATED
+            The URL for the repository providing the configuration. DEPRECATED
         cfs_branch:
           type: string
+          deprecated: true
           description: |
             The name of the branch containing the configuration that you want to
             apply to the nodes.  DEPRECATED.
@@ -479,7 +489,6 @@ components:
           type: boolean
           description: |
             Whether to enable the Configuration Framework Service (CFS).
-            Choices: true/false
           default: true
         cfs:
           $ref: '#/components/schemas/V1CfsParameters'
@@ -502,17 +511,17 @@ components:
       type: string
       maxLength: 64
       readOnly: true
-      description: The identity of the Kubernetes job that is created to handle the session.
+      description: The identity of the Kubernetes job that is created to handle the Session.
       example: "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
     V1Operation:
       type: string
       description: >
-        A Session represents an operation on a SessionTemplate.
-        The creation of a session effectively results in the creation
+        A Session represents an operation on a Session Template.
+        The creation of a Session effectively results in the creation
         of a Kubernetes Boot Orchestration Agent (BOA) job to perform the
         duties required to complete the operation.
 
-        Operation -- An operation to perform on nodes in this session.
+        Operation -- An operation to perform on nodes in this Session.
 
             Boot         Boot nodes that are off.
 
@@ -535,6 +544,7 @@ components:
       type: string
       description: DEPRECATED - use templateName. This field is ignored if templateName is also set.
       example: "my-session-template"
+      deprecated: true
     V1SessionLink:
       description: Link to other resources
       type: object
@@ -552,7 +562,7 @@ components:
       additionalProperties: false
     V1SessionStatusUri:
       type: string
-      description: URI to the status for this session
+      description: URI to the status for this Session
       format: uri
       example: "/v1/session/90730844-094d-45a5-9b90-d661d14d9444/status"
     V1SessionDetails:
@@ -580,7 +590,8 @@ components:
     V1SessionDetailsByTemplateUuid:
       description: |
         Details about a Session using templateUuid instead of templateName.
-        DEPRECATED -- these will only exist from sessions created before templateUuid was deprecated.
+        DEPRECATED -- these will only exist from Sessions created before templateUuid was deprecated.
+      deprecated: true
       type: object
       properties:
         complete:
@@ -607,7 +618,7 @@ components:
 
         ## Link Relationships
 
-        * self : The session object
+        * self : The Session object
       type: object
       properties:
         operation:
@@ -621,7 +632,7 @@ components:
         limit:
           type: string
           description: >
-            A comma-separated of nodes, groups, or roles to which the session
+            A comma-separated list of nodes, groups, or roles to which the Session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
         links:
@@ -637,7 +648,8 @@ components:
 
         ## Link Relationships
 
-        * self : The session object
+        * self : The Session object
+      deprecated: true
       type: object
       properties:
         operation:
@@ -649,7 +661,7 @@ components:
         limit:
           type: string
           description: >
-            A comma-separated of nodes, groups, or roles to which the session
+            A comma-separated list of nodes, groups, or roles to which the Session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
         links:
@@ -742,9 +754,9 @@ components:
     V2CfsParameters:
       type: object
       description: |
-        CFS Parameters is the collection of parameters that are passed to the Configuration
+        This is the collection of parameters that are passed to the Configuration
         Framework Service when configuration is enabled. Can be set as the global value for
-        a Session Template, or individually within a boot set.
+        a Session Template, or individually within a Boot Set.
       properties:
         configuration:
           type: string
@@ -755,16 +767,12 @@ components:
       type: object
       description: |
         A Session Template object represents a collection of resources and metadata.
-        A session template is used to create a Session which applies the data to
-        group of components.
-
-        A Session Template can be created from a JSON structure.  It will return
-        a SessionTemplate name if successful.
-        This name is required when creating a Session.
+        A Session Template is used to create a Session which applies the data to
+        group of Components.
 
         ## Link Relationships
 
-        * self : The session object
+        * self : The Session Template object
       properties:
         name:
           type: string
@@ -784,12 +792,11 @@ components:
         description:
           type: string
           description: |
-            An optional description for the session template.
+            An optional description for the Session Template.
         enable_cfs:
           type: boolean
           description: |
             Whether to enable the Configuration Framework Service (CFS).
-            Choices: true/false
           default: true
         cfs:
           $ref: '#/components/schemas/V2CfsParameters'
@@ -819,7 +826,7 @@ components:
       properties:
         name:
           type: string
-          description: Name of the session. A UUID name is generated if a name is not provided.
+          description: Name of the Session. A UUID name is generated if a name is not provided.
           example: "session-20190728032600"
           # These validation parameters are restricted by Kubernetes naming conventions.
           minLength: 1
@@ -830,61 +837,61 @@ components:
           enum: ['boot', 'reboot', 'shutdown']
           description: >
             A Session represents a desired state that is being applied to a group
-            of components.  Sessions run until all components it manages have
-            either been disabled due to completion, or until all components are
-            managed by other newer sessions.
+            of Components.  Sessions run until all Components it manages have
+            either been disabled due to completion, or until all Components are
+            managed by other newer Sessions.
 
-            Operation -- An operation to perform on nodes in this session.
-                Boot                 Applies the template to the components and boots/reboots if necessary.
-                Reboot               Applies the template to the components guarantees a reboot.
-                Shutdown             Power down nodes that are on.
+            Operation -- An operation to perform on Components in this Session.
+                Boot                 Applies the Template to the Components and boots/reboots if necessary.
+                Reboot               Applies the Template to the Components; guarantees a reboot.
+                Shutdown             Power down Components that are on.
         template_name:
           $ref: '#/components/schemas/V2TemplateName'
         limit:
           type: string
           description: >
-            A comma-separated of nodes, groups, or roles to which the session
+            A comma-separated list of nodes, groups, or roles to which the Session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
         stage:
           type: boolean
           description: >
-            Set to stage a session which will not immediately change the state of any components.
-            The "applystaged" endpoint can be called at a later time to trigger the start of this session.
+            Set to stage a Session which will not immediately change the state of any Components.
+            The "applystaged" endpoint can be called at a later time to trigger the start of this Session.
           default: false
         include_disabled:
           type: boolean
           description: >
-            Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM)
+            Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).
           default: false
       required: [operation, template_name]
       additionalProperties: false
     V2SessionStatus:
       type: object
       description: |
-        Information on the status of a session.
+        Information on the status of a Session.
       properties:
         start_time:
           type: string
           description: |
-            When the session was created.
+            When the Session was created.
         end_time:
           type: string
           description: |
-            When the session completed.
+            When the Session completed.
         status:
           type: string
           enum: ['pending', 'running', 'complete']
           description: |
-            The status of a session.
+            The status of a Session.
         error:
           type: string
           description: |
-            Error which prevented the session from running
+            Error which prevented the Session from running
       additionalProperties: false
     V2BootSet:
       description: |
-        A boot set is a collection of nodes defined by an explicit list, their functional
+        A Boot Set is a collection of nodes defined by an explicit list, their functional
         role, and their logical groupings. This collection of nodes is associated with one
         set of boot artifacts and optional additional records for configuration and root
         filesystem provisioning.
@@ -952,129 +959,129 @@ components:
 
         ## Link Relationships
 
-        * self : The session object
+        * self : The Session object
       type: object
       properties:
         name:
           type: string
           description: >
-            Name of the session.
+            Name of the Session.
         operation:
           type: string
           enum: ['boot', 'reboot', 'shutdown']
           description: >
             A Session represents a desired state that is being applied to a group
-            of components.  Sessions run until all components it manages have
-            either been disabled due to completion, or until all components are
-            managed by other newer sessions.
+            of Components.  Sessions run until all Components it manages have
+            either been disabled due to completion, or until all Components are
+            managed by other newer Sessions.
 
-            Operation -- An operation to perform on nodes in this session.
-                Boot                 Applies the template to the components and boots/reboots if necessary.
-                Reboot               Applies the template to the components guarantees a reboot.
-                Shutdown             Power down nodes that are on.
+            Operation -- An operation to perform on Components in this Session.
+                Boot                 Applies the Template to the Components and boots/reboots if necessary.
+                Reboot               Applies the Template to the Components; guarantees a reboot.
+                Shutdown             Power down Components that are on.
         template_name:
           $ref: '#/components/schemas/V2TemplateName'
         limit:
           type: string
           description: >
-            A comma-separated of nodes, groups, or roles to which the session
+            A comma-separated list of nodes, groups, or roles to which the Session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
         stage:
           type: boolean
           description: >
-            Set to stage a session which will not immediately change the state of any components.
-            The "applystaged" endpoint can be called at a later time to trigger the start of this session.
+            Set to stage a Session which will not immediately change the state of any Components.
+            The "applystaged" endpoint can be called at a later time to trigger the start of this Session.
         components:
           type: string
           description: >
             A comma-separated list of nodes, representing the initial list of nodes
-            the session should operate against.  The list will remain even if
-            other sessions have taken over management of the nodes.
+            the Session should operate against.  The list will remain even if
+            other Sessions have taken over management of the nodes.
         include_disabled:
           type: boolean
           description: >
-            Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM)
+            Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).
         status:
           $ref: '#/components/schemas/V2SessionStatus'
       additionalProperties: false
     V2SessionArray:
-      description: An array of sessions.
+      description: An array of Sessions.
       type: array
       items:
         $ref: '#/components/schemas/V2Session'
     V2SessionExtendedStatusPhases:
       type: object
       description: |
-        Detailed information on the phases of a session.
+        Detailed information on the phases of a Session.
       properties:
         percent_complete:
           type: number
           description: |
-            The percent of components currently in a completed/stable state
+            The percent of Components currently in a completed/stable state
         percent_powering_on:
           type: number
           description: |
-            The percent of components currently in the powering-on phase
+            The percent of Components currently in the powering-on phase
         percent_powering_off:
           type: number
           description: |
-            The percent of components currently in the powering-off phase
+            The percent of Components currently in the powering-off phase
         percent_configuring:
           type: number
           description: |
-            The percent of components currently in the configuring phase
+            The percent of Components currently in the configuring phase
       additionalProperties: false
     V2SessionExtendedStatusTiming:
       type: object
       description: |
-        Detailed information on the timing of a session.
+        Detailed information on the timing of a Session.
       properties:
         start_time:
           type: string
           description: |
-            When the session was created.
+            When the Session was created.
         end_time:
           type: string
           description: |
-            When the session completed.
+            When the Session completed.
         duration:
           type: string
           description: |
-            The current duration of the on-going session or final duration of the completed session.
+            The current duration of the ongoing Session or final duration of the completed Session.
       additionalProperties: false
     V2SessionExtendedStatus:
       type: object
       description: |
-        Detailed information on the status of a session.
+        Detailed information on the status of a Session.
       properties:
         status:
           type: string
           enum: ['pending', 'running', 'complete']
           description: |
-            The status of a session.
+            The status of a Session.
         managed_components_count:
           type: integer
           description: |
-            The count of components currently managed by this session
+            The count of Components currently managed by this Session
         phases:
           $ref: '#/components/schemas/V2SessionExtendedStatusPhases'
         percent_successful:
           type: number
           description: |
-            The percent of components currently in a successful state
+            The percent of Components currently in a successful state
         percent_failed:
           type: number
           description: |
-            The percent of components currently in a failed state
+            The percent of Components currently in a failed state
         percent_staged:
           type: number
           description: |
-            The percent of components currently still staged for this session
+            The percent of Components currently still staged for this Session
         error_summary:
           type: object
           description: |
-            A summary of the errors currently listed by all components
+            A summary of the errors currently listed by all Components
         timing:
           $ref: '#/components/schemas/V2SessionExtendedStatusTiming'
       additionalProperties: false
@@ -1095,7 +1102,7 @@ components:
       additionalProperties: false
     V2ComponentActualState:
       description: |
-        The desired boot artifacts and configuration for a component
+        The desired boot artifacts and configuration for a Component
       type: object
       properties:
         boot_artifacts:
@@ -1114,7 +1121,7 @@ components:
       additionalProperties: false
     V2ComponentDesiredState:
       description: |
-        The desired boot artifacts and configuration for a component
+        The desired boot artifacts and configuration for a Component
       type: object
       properties:
         boot_artifacts:
@@ -1136,7 +1143,7 @@ components:
       additionalProperties: false
     V2ComponentStagedState:
       description: |
-        The desired boot artifacts and configuration for a component
+        The desired boot artifacts and configuration for a Component
       type: object
       properties:
         boot_artifacts:
@@ -1146,7 +1153,7 @@ components:
           description: A CFS configuration ID.
         session:
           type: string
-          description: A session which can be triggered at a later time against this component.
+          description: A Session which can be triggered at a later time against this Component.
         last_updated:
           type: string
           description: The date/time when the state was last updated in RFC 3339 format.
@@ -1167,7 +1174,7 @@ components:
           readOnly: true
         action:
           type: string
-          description: A description of the most recent operator/action to impact the component.
+          description: A description of the most recent operator/action to impact the Component.
         failed:
           type: boolean
           description: Denotes if the last action failed to accomplish its task
@@ -1188,15 +1195,15 @@ components:
           description: How many attempts have been made to power-off forcefully since the last time the node was in the desired state.
       additionalProperties: false
     V2ComponentStatus:
-      description: Status information for the component
+      description: Status information for the Component
       type: object
       properties:
         phase:
           type: string
-          description: The current phase of the component in the boot process.
+          description: The current phase of the Component in the boot process.
         status:
           type: string
-          description: The current status of the component.  More detailed than phase.
+          description: The current status of the Component.  More detailed than phase.
           readOnly: true
         status_override:
           type: string
@@ -1204,12 +1211,12 @@ components:
       additionalProperties: false
     V2Component:
       description: |
-        The current and desired artifacts state for a component.
+        The current and desired artifacts state for a Component.
       type: object
       properties:
         id:
           type: string
-          description: The component's ID. e.g. xname for hardware components
+          description: The Component's ID. e.g. xname for hardware Components
         actual_state:
           $ref: '#/components/schemas/V2ComponentActualState'
         desired_state:
@@ -1224,13 +1231,13 @@ components:
           $ref: '#/components/schemas/V2ComponentStatus'
         enabled:
           type: boolean
-          description: A flag indicating if actions should be taken for this component.
+          description: A flag indicating if actions should be taken for this Component.
         error:
           type: string
-          description: A description of the most recent error to impact the component.
+          description: A description of the most recent error to impact the Component.
         session:
           type: string
-          description: The session responsible for the component's current state
+          description: The Session responsible for the Component's current state
         retry_policy:
           type: integer
           description: |
@@ -1239,22 +1246,22 @@ components:
           example: 1
       additionalProperties: false
     V2ComponentArray:
-      description: An array of component states.
+      description: An array of Component states.
       type: array
       items:
         $ref: '#/components/schemas/V2Component'
     V2ComponentsFilter:
-      description: Information for patching multiple components.
+      description: Information for patching multiple Components.
       type: object
       properties:
         ids:
           type: string
-          description: A comma-separated list of component IDs
+          description: A comma-separated list of Component IDs
         session:
           type: string
-          description: A session name.  All components part of this session will be patched.
+          description: A Session name.  All Components part of this Session will be patched.
     V2ComponentsUpdate:
-      description: Information for patching multiple components.
+      description: Information for patching multiple Components.
       type: object
       properties:
         patch:
@@ -1264,32 +1271,32 @@ components:
       required: [patch, filters]
     V2ApplyStagedComponents:
       description: |
-        A list of components that should have their staged session applied.
+        A list of Components that should have their staged Session applied.
       type: object
       properties:
         xnames:
-          description: The list of component xnames
+          description: The list of Component xnames
           type: array
           items:
             type: string
       additionalProperties: false
     V2ApplyStagedStatus:
       description: |
-        A list of components that should have their staged session applied.
+        A list of Components that should have their staged Session applied.
       type: object
       properties:
         succeeded:
-          description: The list of component xnames
+          description: The list of Component xnames
           type: array
           items:
             type: string
         failed:
-          description: The list of component xnames
+          description: The list of Component xnames
           type: array
           items:
             type: string
         ignored:
-          description: The list of component xnames
+          description: The list of Component xnames
           type: array
           items:
             type: string
@@ -1301,19 +1308,23 @@ components:
       properties:
         cleanup_completed_session_ttl:
           type: string
-          description: Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior.
+          description: Delete complete Sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior.
         clear_stage:
           type: boolean
-          description: Allows components staged information to be cleared when the requested staging action has been started. Defaults to false.
+          description: Allows a Component's staged information to be cleared when the requested staging action has been started. Defaults to false.
         component_actual_state_ttl:
           type: string
-          description: The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically.
+          description: |
+            The maximum amount of time a Component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes
+            and instructs bos-state-reporter to report once instead of periodically.
         disable_components_on_completion:
           type: boolean
-          description: Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes.
+          description: |
+            Allows for BOS Components to be marked as disabled after a Session has been completed. If false, BOS will continue to maintain the state
+            of the nodes declaratively, even after a Session finishes.
         discovery_frequency:
           type: integer
-          description: How frequently the BOS discovery agent syncs new components from HSM. (in seconds)
+          description: How frequently the BOS discovery agent syncs new Components from HSM. (in seconds)
         logging_level:
           type: string
           description: The logging level for all BOS services
@@ -1328,7 +1339,7 @@ components:
           description: How long BOS will wait for a node to power off before forcefully powering off (in seconds)
         polling_frequency:
           type: integer
-          description: How frequently the BOS operators check component state for needed actions. (in seconds)
+          description: How frequently the BOS operators check Component state for needed actions. (in seconds)
         default_retry_policy:
           type: integer
           description: The default maximum number attempts per node for failed actions.
@@ -1336,7 +1347,7 @@ components:
       additionalProperties: true
     # Schemas that combine objects of different versions
     SessionTemplateArray:
-      description: An array of session templates.
+      description: An array of Session Templates.
       type: array
       items:
         anyOf:
@@ -1344,28 +1355,28 @@ components:
           - $ref: '#/components/schemas/V2SessionTemplate'
   requestBodies:
     V2sessionCreateRequest:
-      description: The information to create a session
+      description: The information to create a Session
       required: true
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/V2SessionCreate'
     V2componentUpdateRequest:
-      description: The state for a single component
+      description: The state for a single Component
       required: true
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/V2Component'
     V2componentsPutRequest:
-      description: The state for an array of components
+      description: The state for an array of Components
       required: true
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/V2ComponentArray'
     V2componentsUpdateRequest:
-      description: The state for an array of components
+      description: The state for an array of Components
       required: true
       content:
         application/json:
@@ -1381,14 +1392,14 @@ components:
           schema:
             $ref: '#/components/schemas/V2Options'
     V2sessionUpdateRequest:
-      description: The state for a single session
+      description: The state for a single Session
       required: true
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/V2Session'
     V2applyStagedRequest:
-      description: A list of xnames that should have their staged session applied.
+      description: A list of xnames that should have their staged Session applied.
       required: true
       content:
         application/json:
@@ -1437,20 +1448,20 @@ components:
           schema:
             $ref: '#/components/schemas/V1SessionStatus'
     V1SessionTemplateDetails:
-      description: Session template details
+      description: Session Template details
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/V1SessionTemplate'
     # V2
     V2SessionTemplateDetails:
-      description: Session template details
+      description: Session Template details
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/V2SessionTemplate'
     V2SessionTemplateValidation:
-      description: Session template validity details
+      description: Session Template validity details
       content:
         application/json:
           schema:
@@ -1474,19 +1485,19 @@ components:
           schema:
             $ref: '#/components/schemas/V2SessionExtendedStatus'
     V2componentDetails:
-      description: A single component state
+      description: A single Component state
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/V2Component'
     V2componentDetailsArray:
-      description: A collection of component states
+      description: A collection of Component states
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/V2ComponentArray'
     V2applyStagedResponse:
-      description: A list of xnames that should have their staged session applied.
+      description: A list of xnames that should have their staged Session applied.
       content:
         application/json:
           schema:
@@ -1499,7 +1510,7 @@ components:
             $ref: '#/components/schemas/V2Options'
     # Responses that may contain V1 or V2 objects
     SessionTemplateDetails:
-      description: Session template details
+      description: Session Template details
       content:
         application/json:
           schema:
@@ -1507,7 +1518,7 @@ components:
               - $ref: '#/components/schemas/V1SessionTemplate'
               - $ref: '#/components/schemas/V2SessionTemplate'
     SessionTemplateDetailsArray:
-      description: Session template details array
+      description: Session Template details array
       content:
         application/json:
           schema:
@@ -1600,14 +1611,14 @@ paths:
           $ref: '#/components/responses/ServiceUnavailable'
   /v1/sessiontemplate:
     post:
-      summary: Create session template
+      summary: Create Session Template
       tags:
         - sessiontemplate
       x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
       operationId: create_v1_sessiontemplate
-      description: Create a new session template.
+      description: Create a new Session Template.
       requestBody:
-         description: A JSON object for creating a session template
+         description: A JSON object for creating a Session Template
          required: true
          content:
            application/json:
@@ -1619,10 +1630,9 @@ paths:
         400:
           $ref: '#/components/responses/BadRequest'
     get:
-      summary: List session templates
+      summary: List Session Templates
       description: |
-        List all session templates. Session templates are
-        uniquely identified by the name.
+        List all Session Templates.
       tags:
         - sessiontemplate
       x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
@@ -1639,11 +1649,11 @@ paths:
         schema:
           type: string
     get:
-      summary: Get session template by ID
+      summary: Get Session Template by ID
       description: |
-        Get session template by session template ID.
-        The session template ID corresponds to the *name*
-        of the session template.
+        Get Session Template by Session Template ID.
+        The Session Template ID corresponds to the *name*
+        of the Session Template.
       tags:
         - sessiontemplate
       x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
@@ -1654,8 +1664,8 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
-      summary: Delete a session template
-      description: Delete a session template.
+      summary: Delete a Session Template
+      description: Delete a Session Template.
       tags:
         - sessiontemplate
       x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
@@ -1667,11 +1677,11 @@ paths:
           $ref: '#/components/responses/ResourceNotFound'
   /v1/sessiontemplatetemplate:
     get:
-      summary: Get an example session template.
+      summary: Get an example Session Template.
       description: |
-        Returns a skeleton of a session template, which can be
+        Returns a skeleton of a Session Template, which can be
         used as a starting point for users creating their own
-        session templates.
+        Session Templates.
       tags:
         - sessiontemplate
       x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
@@ -1681,11 +1691,11 @@ paths:
           $ref: '#/components/responses/V1SessionTemplateDetails'
   /v1/session:
     post:
-      summary: Create a session
+      summary: Create a Session
       description: |
-        The creation of a session performs the operation
+        The creation of a Session performs the operation
         specified in the SessionCreateRequest
-        on the boot set(s) defined in the session template.
+        on the Boot Sets defined in the Session Template.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.session
@@ -1707,9 +1717,9 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     get:
-      summary: List session IDs
+      summary: List Session IDs
       description: |
-        List IDs of all sessions, including those in progress and those complete.
+        List IDs of all Sessions, including those in progress and those complete.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.session
@@ -1725,8 +1735,8 @@ paths:
                   $ref: '#/components/schemas/V1SessionId'
   /v1/session/{session_id}:
     get:
-      summary: Get session details by ID
-      description: Get session details by session ID.
+      summary: Get Session details by ID
+      description: Get Session details by Session ID.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.session
@@ -1737,8 +1747,8 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
-      summary: Delete session by ID
-      description: Delete session by session ID.
+      summary: Delete Session by ID
+      description: Delete Session by Session ID.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.session
@@ -1764,9 +1774,9 @@ paths:
         schema:
           type: string
     get:
-      summary: A list of the statuses for the different boot sets.
+      summary: A list of the statuses for the different Boot Sets.
       description: |
-        A list of the statuses for the different boot sets.
+        A list of the statuses for the different Boot Sets.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.status
@@ -1777,15 +1787,15 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     post:
-      summary: Create the initial session status
+      summary: Create the initial Session status
       description: |
-        Creates the initial session status.
+        Creates the initial Session status.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: create_v1_session_status
       requestBody:
-         description: A JSON object for creating the status for a session
+         description: A JSON object for creating the status for a Session
          required: true
          content:
            application/json:
@@ -1799,15 +1809,15 @@ paths:
         409:
           $ref: '#/components/responses/AlreadyExists'
     patch:
-      summary: Update the session status
+      summary: Update the Session status
       description: |
-        Update the session status. You can update the start or stop times.
+        Update the Session status. You can update the start or stop times.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: update_v1_session_status
       requestBody:
-        description: A JSON object for updating the status for a session
+        description: A JSON object for updating the status for a Session
         required: true
         content:
           application/json:
@@ -1819,7 +1829,7 @@ paths:
         404:
           $ref: '#/components/responses/BadRequest'
     delete:
-      summary: Delete the session status
+      summary: Delete the Session status
       description: |
         Deletes an existing Session status
       tags:
@@ -1843,13 +1853,13 @@ paths:
           type: string
       - name: boot_set_name
         in: path
-        description: Boot set name
+        description: Boot Set name
         required: true
         schema:
           type: string
     get:
-      summary: Get the status for a boot set.
-      description: Get the status for a boot set.
+      summary: Get the status for a Boot Set.
+      description: Get the status for a Boot Set.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.status
@@ -1892,14 +1902,13 @@ paths:
       summary: Update the status.
       description: |
         This will change the status for one or more nodes within
-        the boot set.
+        the Boot Set.
       tags:
         - session
-        # - cli_ignore
       x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: update_v1_session_status_by_bootset
       requestBody:
-         description: A JSON object for updating the status for a session
+         description: A JSON object for updating the status for a Session
          required: true
          content:
            application/json:
@@ -1940,7 +1949,7 @@ paths:
           type: string
       - name: boot_set_name
         in: path
-        description: Boot set name
+        description: Boot Set name
         required: true
         schema:
           type: string
@@ -1951,8 +1960,8 @@ paths:
         schema:
           type: string
     get:
-      summary: Get the status for a specific boot set and phase.
-      description: Get the status for a specific boot set and phase.
+      summary: Get the status for a specific Boot Set and phase.
+      description: Get the status for a specific Boot Set and phase.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.status
@@ -1976,7 +1985,7 @@ paths:
           type: string
       - name: boot_set_name
         in: path
-        description: Boot set name
+        description: Boot Set name
         required: true
         schema:
           type: string
@@ -1993,8 +2002,8 @@ paths:
         schema:
           type: string
     get:
-      summary: Get the status for a specific boot set, phase, and category.
-      description: Get the status for a specific boot set, phase, and category.
+      summary: Get the status for a specific Boot Set, phase, and category.
+      description: Get the status for a specific Boot Set, phase, and category.
       tags:
         - session
       x-openapi-router-controller: bos.server.controllers.v1.status
@@ -2055,10 +2064,9 @@ paths:
           $ref: '#/components/responses/ServiceUnavailable'
   /v2/sessiontemplates:
     get:
-      summary: List session templates
+      summary: List Session Templates
       description: |
-        List all session templates. Session templates are
-        uniquely identified by the name.
+        List all Session Templates.
       tags:
         - v2
         - sessiontemplates
@@ -2076,11 +2084,11 @@ paths:
         schema:
           type: string
     get:
-      summary: Validate the session template by ID
+      summary: Validate the Session Template by ID
       description: |
-        Validate session template by session template ID.
-        The session template ID corresponds to the *name*
-        of the session template.
+        Validate Session Template by Session Template ID.
+        The Session Template ID corresponds to the *name*
+        of the Session Template.
       tags:
         - v2
         - sessiontemplatess
@@ -2100,11 +2108,11 @@ paths:
         schema:
           type: string
     get:
-      summary: Get session template by ID
+      summary: Get Session Template by ID
       description: |
-        Get session template by session template ID.
-        The session template ID corresponds to the *name*
-        of the session template.
+        Get Session Template by Session Template ID.
+        The Session Template ID corresponds to the *name*
+        of the Session Template.
       tags:
         - v2
         - sessiontemplatess
@@ -2116,15 +2124,15 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     put:
-      summary: Create session template
+      summary: Create Session Template
       tags:
         - v2
         - sessiontemplates
       x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
       operationId: put_v2_sessiontemplate
-      description: Create a new session template.
+      description: Create a new Session Template.
       requestBody:
-         description: A JSON object for creating a session template
+         description: A JSON object for creating a Session Template
          required: true
          content:
            application/json:
@@ -2136,15 +2144,15 @@ paths:
         400:
           $ref: '#/components/responses/BadRequest'
     patch:
-      summary: Update a session template
+      summary: Update a Session Template
       tags:
         - v2
         - sessiontemplates
       x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
       operationId: patch_v2_sessiontemplate
-      description: Update an existing session template.
+      description: Update an existing Session Template.
       requestBody:
-        description: A JSON object for updating a session template
+        description: A JSON object for updating a Session Template
         required: true
         content:
           application/json:
@@ -2158,8 +2166,8 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
-      summary: Delete a session template
-      description: Delete a session template.
+      summary: Delete a Session Template
+      description: Delete a Session Template.
       tags:
         - v2
         - sessiontemplates
@@ -2172,11 +2180,11 @@ paths:
           $ref: '#/components/responses/ResourceNotFound'
   /v2/sessiontemplatetemplate:
     get:
-      summary: Get an example session template.
+      summary: Get an example Session Template.
       description: |
-        Returns a skeleton of a session template, which can be
+        Returns a skeleton of a Session Template, which can be
         used as a starting point for users creating their own
-        session templates.
+        Session Templates.
       tags:
         - v2
         - sessiontemplates
@@ -2187,11 +2195,11 @@ paths:
           $ref: '#/components/responses/V2SessionTemplateDetails'
   /v2/sessions:
     post:
-      summary: Create a session
+      summary: Create a Session
       description: |
-        The creation of a session performs the operation
+        The creation of a Session performs the operation
         specified in the SessionCreateRequest
-        on the boot set(s) defined in the session template.
+        on the Boot Sets defined in the Session Template.
       tags:
         - v2
         - sessions
@@ -2205,9 +2213,9 @@ paths:
         400:
           $ref: '#/components/responses/BadRequest'
     get:
-      summary: List sessions
+      summary: List Sessions
       description: |
-        List all sessions, including those in progress and those complete.
+        List all Sessions, including those in progress and those complete.
       tags:
         - v2
         - sessions
@@ -2219,53 +2227,53 @@ paths:
             type: string
           in: query
           description: >-
-            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Return only Sessions older than the given age.  Age is given in the format "1d" or "6h"
         - name: max_age
           schema:
             type: string
           in: query
           description: >-
-            Return only sessions younger than the given age.  Age is given in the format "1d" or "6h"
+            Return only Sessions younger than the given age.  Age is given in the format "1d" or "6h"
         - name: status
           schema:
             type: string
             enum: ['pending', 'running', 'complete']
           in: query
           description: >-
-            Return only sessions with the given status.
+            Return only Sessions with the given status.
       responses:
         200:
           $ref: '#/components/responses/V2SessionDetailsArray'
     delete:
-      summary: Delete multiple sessions.
+      summary: Delete multiple Sessions.
       tags:
         - v2
         - sessions
       x-openapi-router-controller: bos.server.controllers.v2.sessions
       operationId: delete_v2_sessions
       description: |
-        Delete multiple sessions.  If filters are provided, only sessions matching
-        all filters will be deleted.  By default only completed sessions will be deleted.
+        Delete multiple Sessions.  If filters are provided, only Sessions matching
+        all filters will be deleted.  By default only completed Sessions will be deleted.
       parameters:
         - name: min_age
           schema:
             type: string
           in: query
           description: >-
-            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Return only Sessions older than the given age.  Age is given in the format "1d" or "6h"
         - name: max_age
           schema:
             type: string
           in: query
           description: >-
-            Return only sessions younger than the given age.  Age is given in the format "1d" or "6h"
+            Return only Sessions younger than the given age.  Age is given in the format "1d" or "6h"
         - name: status
           schema:
             enum: ['pending', 'running', 'complete']
             type: string
           in: query
           description: >-
-            Return only sessions with the given status.
+            Return only Sessions with the given status.
       responses:
         204:
           $ref: '#/components/responses/ResourceDeleted'
@@ -2273,8 +2281,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
   /v2/sessions/{session_id}:
     get:
-      summary: Get session details by ID
-      description: Get session details by session ID.
+      summary: Get Session details by ID
+      description: Get Session details by Session ID.
       tags:
         - v2
         - sessions
@@ -2286,12 +2294,12 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     patch:
-      summary: Update a single session
+      summary: Update a single Session
       tags:
         - v2
         - sessions
       x-openapi-router-controller: bos.server.controllers.v2.sessions
-      description: Update the state for a given session in the BOS database
+      description: Update the state for a given Session in the BOS database
       operationId: patch_v2_session
       requestBody:
         $ref: '#/components/requestBodies/V2sessionUpdateRequest'
@@ -2303,8 +2311,8 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
-      summary: Delete session by ID
-      description: Delete session by session ID.
+      summary: Delete Session by ID
+      description: Delete Session by Session ID.
       tags:
         - v2
         - sessions
@@ -2324,8 +2332,8 @@ paths:
           type: string
   /v2/sessions/{session_id}/status:
     get:
-      summary: Get session extended status information by ID
-      description: Get session extended status information by ID
+      summary: Get Session extended status information by ID
+      description: Get Session extended status information by ID
       tags:
         - v2
         - sessions
@@ -2337,13 +2345,13 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     post:
-      summary: Saves the current session to database
+      summary: Saves the current Session to database
       tags:
         - v2
         - sessions
         - cli_ignore
       x-openapi-router-controller: bos.server.controllers.v2.sessions
-      description: Saves the current session to database.  For use at session completion.
+      description: Saves the current Session to database.  For use at Session completion.
       operationId: save_v2_session_status
       responses:
         200:
@@ -2359,13 +2367,13 @@ paths:
           type: string
   /v2/components:
     get:
-      summary: Retrieve the state of a collection of components
+      summary: Retrieve the state of a collection of Components
       tags:
         - v2
         - components
       x-openapi-router-controller: bos.server.controllers.v2.components
       description: >-
-        Retrieve the full collection of components in the form of a
+        Retrieve the full collection of Components in the form of a
         ComponentArray. Full results can also be filtered by query
         parameters. Only the first filter parameter of each type is
         used and the parameters are applied in an AND fashion.
@@ -2378,52 +2386,52 @@ paths:
             type: string
           in: query
           description: >-
-            Retrieve the components with the given ID
-            (e.g. xname for hardware components). Can be chained
-            for selecting groups of components.
+            Retrieve the Components with the given ID
+            (e.g. xname for hardware Components). Can be chained
+            for selecting groups of Components.
         - name: session
           schema:
             type: string
           in: query
           description: >-
-            Retrieve the components with the given session ID.
+            Retrieve the Components with the given Session ID.
         - name: staged_session
           schema:
             type: string
           in: query
           description: >-
-            Retrieve the components with the given staged session ID.
+            Retrieve the Components with the given staged Session ID.
         - name: enabled
           schema:
             type: boolean
           in: query
           description: >-
-            Retrieve the components with the "enabled" state.
+            Retrieve the Components with the "enabled" state.
         - name: phase
           schema:
             type: string
           in: query
           description: >-
-            Retrieve the components in the given phase.
+            Retrieve the Components in the given phase.
         - name: status
           schema:
             type: string
           in: query
           description: >-
-            Retrieve the components with the given status.
+            Retrieve the Components with the given status.
       responses:
         200:
           $ref: '#/components/responses/V2componentDetailsArray'
         400:
           $ref: '#/components/responses/BadRequest'
     put:
-      summary: Add or Replace a collection of components
+      summary: Add or Replace a collection of Components
       tags:
         - v2
         - components
         - cli_ignore
       x-openapi-router-controller: bos.server.controllers.v2.components
-      description: Update the state for a collection of components in the BOS database
+      description: Update the state for a collection of Components in the BOS database
       operationId: put_v2_components
       requestBody:
         $ref: '#/components/requestBodies/V2componentsPutRequest'
@@ -2433,13 +2441,13 @@ paths:
         400:
           $ref: '#/components/responses/BadRequest'
     patch:
-      summary: Update a collection of components
+      summary: Update a collection of Components
       tags:
         - v2
         - components
         - cli_ignore
       x-openapi-router-controller: bos.server.controllers.v2.components
-      description: Update the state for a collection of components in the BOS database
+      description: Update the state for a collection of Components in the BOS database
       operationId: patch_v2_components
       requestBody:
         $ref: '#/components/requestBodies/V2componentsUpdateRequest'
@@ -2452,12 +2460,12 @@ paths:
           $ref: '#/components/responses/ResourceNotFound'
   /v2/components/{component_id}:
     get:
-      summary: Retrieve the state of a single component
+      summary: Retrieve the state of a single Component
       tags:
         - v2
         - components
       x-openapi-router-controller: bos.server.controllers.v2.components
-      description: Retrieve the current and desired state of a single component
+      description: Retrieve the current and desired state of a single Component
       operationId: get_v2_component
       responses:
         200:
@@ -2467,12 +2475,12 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     put:
-      summary: Add or Replace a single component
+      summary: Add or Replace a single Component
       tags:
         - v2
         - components
       x-openapi-router-controller: bos.server.controllers.v2.components
-      description: Update the state for a given component in the BOS database
+      description: Update the state for a given Component in the BOS database
       operationId: put_v2_component
       requestBody:
         $ref: '#/components/requestBodies/V2componentUpdateRequest'
@@ -2482,12 +2490,12 @@ paths:
         400:
           $ref: '#/components/responses/BadRequest'
     patch:
-      summary: Update a single component
+      summary: Update a single Component
       tags:
         - v2
         - components
       x-openapi-router-controller: bos.server.controllers.v2.components
-      description: Update the state for a given component in the BOS database
+      description: Update the state for a given Component in the BOS database
       operationId: patch_v2_component
       requestBody:
         $ref: '#/components/requestBodies/V2componentUpdateRequest'
@@ -2505,9 +2513,9 @@ paths:
         - v2
         - components
         - cli_ignore
-      summary: Delete a single component
+      summary: Delete a single Component
       x-openapi-router-controller: bos.server.controllers.v2.components
-      description: Delete the given component
+      description: Delete the given Component
       operationId: delete_v2_component
       responses:
         204:
@@ -2517,17 +2525,17 @@ paths:
     parameters:
       - name: component_id
         in: path
-        description: Component ID. e.g. xname for hardware components
+        description: Component ID. e.g. xname for hardware Components
         required: true
         schema:
           type: string
   /v2/applystaged:
     post:
-      summary: Start a staged session for the specified components
+      summary: Start a staged Session for the specified Components
       description: |
-        Given a list of xnames, this will trigger the start of any sessions
-        staged for those components.  Components without a staged session
-        will be ignored, and a list all components that are acted on will
+        Given a list of xnames, this will trigger the start of any Sessions
+        staged for those Components.  Components without a staged Session
+        will be ignored, and a list all Components that are acted on will
         be returned in the response.
       tags:
         - v2

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -438,6 +438,20 @@ components:
             the 'rootfs=<protocol>' kernel parameter
       additionalProperties: false
       required: [path, type]
+    V1SessionTemplateName:
+          type: string
+          minLength: 1
+          description: |
+            Name of the Session Template.
+            
+            It is recommended to use names which meet the following restrictions:
+            * Maximum length of 127 characters.
+            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Begin and end with a letter or digit.
+            
+            These restrictions are not enforced in this version of BOS, but will be
+            enforced in a future version.
+          example: "cle-1.0.0"    
     V1SessionTemplate:
       type: object
       description: |
@@ -457,19 +471,7 @@ components:
             Specify either a templateURL, or the other Session
             template parameters.
         name:
-          type: string
-          minLength: 1
-          description: |
-            Name of the Session Template.
-            
-            It is recommended to use names which meet the following restrictions:
-            * Maximum length of 127 characters.
-            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
-            * Begin and end with a letter or digit.
-            
-            These restrictions are not enforced in this version of BOS, but will be
-            enforced in a future version.
-          example: "cle-1.0.0"
+          $ref: '#/components/schemas/V1SessionTemplateName'
         description:
           type: string
           description: |
@@ -1453,6 +1455,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V1SessionTemplate'
+    V1SessionTemplateName:
+      description: Session Template name
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V1SessionTemplateName'    
     # V2
     V2SessionTemplateDetails:
       description: Session Template details
@@ -1626,7 +1634,7 @@ paths:
                $ref: '#/components/schemas/V1SessionTemplate'
       responses:
         201:
-          $ref: '#/components/responses/V1SessionTemplateDetails'
+          $ref: '#/components/responses/V1SessionTemplateName'
         400:
           $ref: '#/components/responses/BadRequest'
     get:


### PR DESCRIPTION
(cherry picked from commit 27c62b1ce440708fd7950505dfa7c926ba9088db)

Backport to support branch of: https://github.com/Cray-HPE/bos/pull/150

This is just so we can autogenerate the API docs with these changes -- I don't plan to update the 1.4.1 BOS to include this (unless we end up pulling it in along with some other change that merits it)