### PR TITLE
CASMCMS-8667: Update API spec to reflect fact that creating v1 template returns name of template on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Make use of the OpenAPI `deprecated` tag in places where it previously was only indicated in the text description. 
 ### Fixed
 - Corrected many small errors and inconsistencies in the API spec description text fields.
+- Updated API spec so that it accurately describes the actual implementation:
+  - Successfully creating a V1 session template returns the name of that template.
 
 ## [2.4.1] - 2023-06-06
 ### Fixed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -444,6 +444,20 @@ components:
             the 'rootfs=<protocol>' kernel parameter
       additionalProperties: false
       required: [path, type]
+    V1SessionTemplateName:
+          type: string
+          minLength: 1
+          description: |
+            Name of the Session Template.
+            
+            It is recommended to use names which meet the following restrictions:
+            * Maximum length of 127 characters.
+            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Begin and end with a letter or digit.
+            
+            These restrictions are not enforced in this version of BOS, but will be
+            enforced in a future version.
+          example: "cle-1.0.0"    
     V1SessionTemplate:
       type: object
       description: |
@@ -463,19 +477,7 @@ components:
             Specify either a templateURL, or the other Session
             template parameters.
         name:
-          type: string
-          minLength: 1
-          description: |
-            Name of the Session Template.
-            
-            It is recommended to use names which meet the following restrictions:
-            * Maximum length of 127 characters.
-            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
-            * Begin and end with a letter or digit.
-            
-            These restrictions are not enforced in this version of BOS, but will be
-            enforced in a future version.
-          example: "cle-1.0.0"
+          $ref: '#/components/schemas/V1SessionTemplateName'
         description:
           type: string
           description: |
@@ -1499,6 +1501,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V1SessionTemplate'
+    V1SessionTemplateName:
+      description: Session Template name
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V1SessionTemplateName'    
     # V2
     V2SessionTemplateDetails:
       description: Session Template details
@@ -1695,7 +1703,7 @@ paths:
                $ref: '#/components/schemas/V1SessionTemplate'
       responses:
         201:
-          $ref: '#/components/responses/V1SessionTemplateDetails'
+          $ref: '#/components/responses/V1SessionTemplateName'
         400:
           $ref: '#/components/responses/BadRequestOrMultiTenancyNotSupported'
     get:


### PR DESCRIPTION
## Summary and Scope

Somehow I overlooked this in my spate of changes before. The spec says that creating a V1 session template returns a session template object, but it actually just returns the template name. 

```text
ncn-m001:~/mitch/c # cray bos v1 sessiontemplate create --name harfharf --file v1temp.json
harfharf
```

This PR updates the spec to reflect this.

## Issues and Related PRs

* Resolves [CASMCMS-8667](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8667)
* [support/2.0 backport PR](https://github.com/Cray-HPE/bos/pull/154)

## Testing

* I ran the updated spec through an OpenAPI validation tool to make sure no fundamental errors were introduced.
* Tested on mug and verified that cmsdev tests passed, and that I was able to create and delete sessiontemplates and sessions using both v1 and v2 endpoints.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
