### PR TITLE
CASMCMS-8667: Update API spec to reflect fact that creating v1 template returns name of template on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only indicated in the text description. 
 ### Fixed
 - Corrected many small errors and inconsistencies in the API spec description text fields.
+- Updated API spec so that it accurately describes the actual implementation:
+  - Successfully creating a V1 session template returns the name of that template.
 
 ## [2.0.18] - 2023-05-30
 ### Fixed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -438,6 +438,20 @@ components:
             the 'rootfs=<protocol>' kernel parameter
       additionalProperties: false
       required: [path, type]
+    V1SessionTemplateName:
+          type: string
+          minLength: 1
+          description: |
+            Name of the Session Template.
+            
+            It is recommended to use names which meet the following restrictions:
+            * Maximum length of 127 characters.
+            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Begin and end with a letter or digit.
+            
+            These restrictions are not enforced in this version of BOS, but will be
+            enforced in a future version.
+          example: "cle-1.0.0"    
     V1SessionTemplate:
       type: object
       description: |
@@ -457,19 +471,7 @@ components:
             Specify either a templateURL, or the other Session
             template parameters.
         name:
-          type: string
-          minLength: 1
-          description: |
-            Name of the Session Template.
-            
-            It is recommended to use names which meet the following restrictions:
-            * Maximum length of 127 characters.
-            * Use only letters, digits, periods (.), dashes (-), and underscores (_).
-            * Begin and end with a letter or digit.
-            
-            These restrictions are not enforced in this version of BOS, but will be
-            enforced in a future version.
-          example: "cle-1.0.0"
+          $ref: '#/components/schemas/V1SessionTemplateName'
         description:
           type: string
           description: |
@@ -1453,6 +1455,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V1SessionTemplate'
+    V1SessionTemplateName:
+      description: Session Template name
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V1SessionTemplateName'    
     # V2
     V2SessionTemplateDetails:
       description: Session Template details
@@ -1626,7 +1634,7 @@ paths:
                $ref: '#/components/schemas/V1SessionTemplate'
       responses:
         201:
-          $ref: '#/components/responses/V1SessionTemplateDetails'
+          $ref: '#/components/responses/V1SessionTemplateName'
         400:
           $ref: '#/components/responses/BadRequest'
     get:


### PR DESCRIPTION
(cherry picked from commit 72ed45e902e42a0adaf368bb1595f928542024e3)

Backport to support branch of: https://github.com/Cray-HPE/bos/pull/153

This is just so we can autogenerate the API docs with these changes -- I don't plan to update the 1.4.1 BOS to include this (unless we end up pulling it in along with some other change that merits it)