### PR TITLE
CASMTRIAGE-5525: Fix decorators to preserve function signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2023-06-14
+### Fixed
+- Fixed python decorators to preserve function signatures
+
 ## [2.4.1] - 2023-06-06
 ### Fixed
 - Fix bug that accidentally started enforcing restrictions on session template names.

--- a/src/bos/common/tenant_utils.py
+++ b/src/bos/common/tenant_utils.py
@@ -23,6 +23,7 @@
 #
 
 import connexion
+import functools
 import logging
 import hashlib
 from requests.exceptions import HTTPError
@@ -104,7 +105,7 @@ def validate_tenant_exists(tenant: str) -> bool:
 
 def tenant_error_handler(func):
     """Decorator for returning errors if there is an exception when calling tapms"""
-
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
@@ -117,7 +118,7 @@ def tenant_error_handler(func):
 
 def reject_invalid_tenant(func):
     """Decorator for preemptively validating the tenant exists"""
-
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         tenant = get_tenant_from_header()
         if tenant and not validate_tenant_exists(tenant):
@@ -130,7 +131,7 @@ def reject_invalid_tenant(func):
 
 def no_v1_multi_tenancy_support(func):
     """Decorator for returning errors if the endpoint doesn't support multi-tenancy"""
-
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         if get_tenant_from_header():
             return connexion.problem(

--- a/src/bos/server/redis_db_utils.py
+++ b/src/bos/server/redis_db_utils.py
@@ -22,6 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 import connexion
+import functools
 import json
 import logging
 import redis
@@ -137,7 +138,7 @@ class DBWrapper():
 
 def redis_error_handler(func):
     """Decorator for returning better errors if Redis is unreachable"""
-
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
             if 'body' in kwargs:


### PR DESCRIPTION
## Summary and Scope

Fixes v1 session template creation.  Connexion was passing arguments to the controller function according to the function's signature, but the v1_multitenancy decorator was altering the signature.  Using functools preserves the signature of the underlying function.

## Issues and Related PRs

* Resolves CASMTRIAGE-5525

## Testing

### Tested on:

  * Fanta

### Test description:

Successfully ran the barebones boot test, which had previously been failing.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

