### PR TITLE
CASMCMS-8674: Remove templateUrl option for creating v1 session templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected many small errors and inconsistencies in the API spec description text fields.
 - Updated API spec so that it accurately describes the actual implementation:
   - Successfully creating a V1 session template returns the name of that template.
+### Removed
+- `templateUrl` option when creating BOS v1 templates.
 
 ## [2.4.2] - 2023-06-14
 ### Fixed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -560,12 +560,6 @@ components:
 
         * self : The Session Template object
       properties:
-        templateUrl:
-          type: string
-          description: |
-            The URL to the resource providing the Session Template data.
-            Specify either a templateURL, or the other Session
-            Template parameters.
         name:
           $ref: '#/components/schemas/V1SessionTemplateName'
         description:

--- a/constraints.txt
+++ b/constraints.txt
@@ -43,4 +43,3 @@ tenacity==8.2.2
 urllib3==1.26.15
 websocket-client==1.5.1
 Werkzeug==2.2.3
-wget==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@
 kubernetes
 redis
 requests
-wget
 etcd3
 boto3
 liveness


### PR DESCRIPTION
## Summary and Scope

The `templateUrl` option when creating session templates has been broken since BOS started using non-root users in its containers (CSM 1.2). Given that it has been broken for that long without it being reported by anyone, presumably it is not being used. Therefore this PR removes it from the spec and removes the associated code.

Note that the code is further simplified by the fact that 'name' is a required field for session templates, and since this function does make use of the API model in that case, it will throw an exception if one is provided with no name. Therefore this PR also removes the superfluous conditional checking for the name.

## Issues and Related PRs

* Resolves [CASMCMS-8674](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8674)
* [support/2.0 backport](https://github.com/Cray-HPE/bos/pull/159)
* [Cray CLI PR](https://github.com/Cray-HPE/craycli/pull/115)

## Testing

* I've run the Swagger spec through a validator to make sure there are no problems.
* I tested this on fanta (along with the updated CLI [from this PR](https://github.com/Cray-HPE/craycli/pull/115)) and verified that cmsdev passes, and that I was able to create and delete v1 session templates.

## Risks and Mitigations

Low risk -- the parameter is already broken.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
