### PR TITLE
CASMCMS-8674: Remove templateUrl option for creating v1 session templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.19] - 2023-06-09
+## [2.0.19] - 2023-06-15
 ### Added
 - Updated the API spec to make use of the OpenAPI `deprecated` tag in places where it previously was
   only indicated in the text description. 
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected many small errors and inconsistencies in the API spec description text fields.
 - Updated API spec so that it accurately describes the actual implementation:
   - Successfully creating a V1 session template returns the name of that template.
+### Removed
+- `templateUrl` option when creating BOS v1 templates.
 
 ## [2.0.18] - 2023-05-30
 ### Fixed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -554,12 +554,6 @@ components:
 
         * self : The Session Template object
       properties:
-        templateUrl:
-          type: string
-          description: |
-            The URL to the resource providing the Session Template data.
-            Specify either a templateURL, or the other Session
-            Template parameters.
         name:
           $ref: '#/components/schemas/V1SessionTemplateName'
         description:

--- a/constraints.txt
+++ b/constraints.txt
@@ -46,6 +46,4 @@ tomli==2.0.1
 urllib3==1.26.10
 websocket-client==1.3.3
 Werkzeug==2.0.3
-wget==3.2
 wrapt==1.14.1
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@
 kubernetes
 redis
 requests
-wget
 etcd3
 boto3
 liveness

--- a/src/bos/server/controllers/v1/sessiontemplate.py
+++ b/src/bos/server/controllers/v1/sessiontemplate.py
@@ -26,7 +26,6 @@
 import logging
 import connexion
 import json
-import wget
 import os
 
 from bos.server import redis_db_utils as dbutils
@@ -97,9 +96,10 @@ def create_v1_sessiontemplate():  # noqa: E501
     try:
         """Convert the JSON request data into a SessionTemplate object.
            Any exceptions caught here would be generated from the model
-           (i.e. bos.server.models.session_template).
-           An example is an exception for a session template name that
-           does not confirm to Kubernetes naming convention.
+           (i.e. bos.server.models.session_template). Examples are
+           an exception for a session template missing the required name
+           field, or an exception for a session template name that does not
+           confirm to Kubernetes naming convention.
            In this case return 400 with a description of the specific error.
         """
         sessiontemplate = SessionTemplate.from_dict(connexion.request.get_json())
@@ -108,63 +108,14 @@ def create_v1_sessiontemplate():  # noqa: E501
             status=400, title="The session template could not be created.",
             detail=str(err))
 
-    if sessiontemplate.template_url:
-        """If a template URL was provided in the body treat this as a reference
-           to a JSON session template structure which needs to be read and
-           stored.
-        """
-        LOGGER.debug("create_v1_sessiontemplate template_url: %s", sessiontemplate.template_url)
-
-        """Downloads the content locally into a file named after the uri.
-           An optional 'out' parameter can be specified as the base dir
-           for the file
-        """
-        sessionTemplateFile = ""
-        try:
-            sessionTemplateFile = wget.download(sessiontemplate.template_url)
-            LOGGER.debug("Downloaded: %s", sessionTemplateFile)
-        except Exception as err:
-            return connexion.problem(
-                status=400,
-                title="Error while getting content from '{}'".format(
-                    sessiontemplate.template_url),
-                detail=str(err))
-
-        # Read in the session template file
-        with open(sessionTemplateFile, 'r') as f:
-            st_json = json.load(f)
-            if 'name' not in st_json.keys() or st_json['name'] == "":
-                return connexion.problem(
-                    status=400, title="Bad request",
-                    detail="The Session Template '{}' "
-                           "is missing the required \'name\' attribute."
-                    .format(sessiontemplate.template_url))
-            json_st_str = json.dumps(sanitize_xnames(st_json))
-        LOGGER.debug("Removing temporary local file: '%s'", sessionTemplateFile)
-        os.remove(sessionTemplateFile)
-
-        # Create a Session Template from the content.
-        """Store the Session Template content.
-           For now overwrite any existing template by name w/o warning.
-           Later this can be changed (detected and blocked) when we
-           support patching operations. This could also be changed to
-           result in an HTTP 409 Conflict. TBD.
-        """
-        sessiontemplate_name = st_json['name']
-        DB.put(sessiontemplate_name, st_json)
-        return sessiontemplate_name, 201
-
-    if sessiontemplate.name:
-        """If a template name has been provided in the body, treat this as
-           a complete JSON session template record and store it.
-           For now overwrite any existing template by name w/o warning.
-           Later this can be changed when we support patching operations.
-           This could also be changed to result in an HTTP 409 Conflict. TBD.
-        """
-        LOGGER.debug("create_v1_sessiontemplate name: %s", sessiontemplate.name)
-        st_json = connexion.request.get_json()
-        DB.put(sessiontemplate.name, st_json)
-        return sessiontemplate.name, 201
+    """For now overwrite any existing template by name w/o warning.
+       Later this can be changed when we support patching operations.
+       This could also be changed to result in an HTTP 409 Conflict. TBD.
+    """
+    LOGGER.debug("create_v1_sessiontemplate name: %s", sessiontemplate.name)
+    st_json = connexion.request.get_json()
+    DB.put(sessiontemplate.name, st_json)
+    return sessiontemplate.name, 201
 
 
 def get_v1_sessiontemplates():  # noqa: E501


### PR DESCRIPTION
(cherry picked from commit 883f649e2715714632e86ddf790d34032a32f4c0)

Backport to support branch of https://github.com/Cray-HPE/bos/pull/158

Since I hadn't tagged the support branch for the 2.0.19 version yet, I figured I can just pull this into it as well. No need for 2 version bumps.