### PR TITLE
CASMCMS-8532: Fix actual state cleanup operator patching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.3] - 2023-06-20
+### Fixed
+- Fixed actual state clearup operation
+
 ## [2.4.2] - 2023-06-14
 ### Fixed
 - Fixed python decorators to preserve function signatures

--- a/src/bos/operators/actual_state_cleanup.py
+++ b/src/bos/operators/actual_state_cleanup.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,18 +25,13 @@
 import logging
 
 from bos.common.utils import duration_to_timedelta
+from bos.common.values import EMPTY_ACTUAL_STATE
 from bos.operators.utils.clients.bos.options import options
 from bos.operators.base import BaseOperator, main
 from bos.operators.filters import BOSQuery, ActualStateAge, ActualBootStateIsSet
 
 LOGGER = logging.getLogger('bos.operators.actual_state_cleanup')
 
-
-ZEROED_ACTUAL_STATE = {'bss_token': '',
-                       'configuration': '',
-                       'boot_artifacts': {'kernel': '',
-                                          'initrd': '',
-                                          'kernel_parameters': ''}}
 
 class ActualStateCleanupOperator(BaseOperator):
     """
@@ -67,7 +62,7 @@ class ActualStateCleanupOperator(BaseOperator):
         data = []
         for component_id in [component['id'] for component in components]:
             data.append({'id': component_id,
-                         'actual_state': ZEROED_ACTUAL_STATE})
+                         'actual_state': EMPTY_ACTUAL_STATE})
         if data:
             LOGGER.debug('Calling to update with payload: %s' %(data))
             self.bos_client.components.update_components(data)


### PR DESCRIPTION
## Summary and Scope

Fixes an issue where the actual state cleanup operator was trying to clear a configuration field which is not actually stored in the actual state.  This switches to using the common definition for clearing the actual state

## Issues and Related PRs

* Resolves CASMCMS-8532

## Testing

### Tested on:

  * Dorian - updated the actual state for component and verified that the cleanup operator zero'd the state correctly.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

