### PR TITLE
CASMTRIAGE-5575: Update API spec to reflect that node lists are permitted to be empty in some circumstances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
+
+## [2.5.1] - 2023-06-23
+### Fixed
+- Update the API spec to reflect that node lists are permitted to be empty in some circumstances.
 
 ## [2.5.0] - 2023-06-22
 ### Added

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -226,6 +226,16 @@ components:
       description: |
         Whether to enable the Configuration Framework Service (CFS).
       default: true
+    HardwareComponentName:
+      type: string
+      description: |
+        Hardware component name (xname).
+
+        It is recommended that this should be 1-127 characters in length.
+
+        This restriction is not enforced in this version of BOS, but it is
+        targeted to start being enforced in an upcoming BOS version.
+      example: "x3001c0s39b0n0"
     Healthz:
       description: Service health status
       type: object
@@ -258,7 +268,7 @@ components:
     NodeList:
       type: array
       description: |
-        Node list.
+        A node list that is required to have at least one node.
 
         It is recommended that this list should be 1-65535 items in length.
 
@@ -267,15 +277,19 @@ components:
       minItems: 1
       example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
       items:
-        type: string
-        description: |
-          Hardware component name (xname).
+        $ref: '#/components/schemas/HardwareComponentName'
+    NodeListEmptyOk:
+      type: array
+      description: |
+        A node list that is allowed to be empty.
 
-          It is recommended that this should be 1-127 characters in length.
+        It is recommended that this list should be no more than 65535 items in length.
 
-          This restriction is not enforced in this version of BOS, but it is
-          targeted to start being enforced in an upcoming BOS version.
-        example: "x3001c0s39b0n0"
+        This restriction is not enforced in this version of BOS, but it is
+        targeted to start being enforced in an upcoming BOS version.
+      example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
+      items:
+        $ref: '#/components/schemas/HardwareComponentName'
     NodeGroupList:
       type: array
       description: |
@@ -525,7 +539,7 @@ components:
         name:
           $ref: '#/components/schemas/V1PhaseCategoryName'
         node_list:
-          $ref: '#/components/schemas/NodeList'
+          $ref: '#/components/schemas/NodeListEmptyOk'
     V1PhaseStatus:
       type: object
       description: |
@@ -920,7 +934,7 @@ components:
         destination:
           $ref: '#/components/schemas/V1PhaseCategoryName'
         node_list:
-          $ref: '#/components/schemas/NodeList'
+          $ref: '#/components/schemas/NodeListEmptyOk'
       additionalProperties: false
       required: [phase, source, destination, node_list]
     V1NodeErrorsList:
@@ -930,7 +944,7 @@ components:
         This is an additive characterization. Nodes will be added to existing errors.
         This does not overwrite previously existing errors.
       additionalProperties:
-        $ref: '#/components/schemas/NodeList'
+        $ref: '#/components/schemas/NodeListEmptyOk'
     V1UpdateRequestNodeChange:
       description: |
         This is an element of the payload sent during an update request. It contains


### PR DESCRIPTION
## Summary and Scope

In the context of boot sets, node lists are required to be non-empty. This is not a new requirement in the API spec.

However, I accidentally imposed this requirement on V1 status update requests as well, and those ARE allowed to have the node lists be empty.

This PR makes two different node list schemas, one which is allowed to be empty and one which is not. For boot sets, it uses the one which requires an element. For the status updates, it uses the one which allows it to be empty. This will make things be back to the way they were before my recent PR, which caused this problem.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5575](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5575)
* Problem injected by [CASMCMS-8661](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8661)
