### PR TITLE
Updated the API spec to make use of the OpenAPI deprecated tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Updated the API spec to:
+  - Make use of the OpenAPI `deprecated` tag in places where it previously was
+    only indicated in the text description.
+
 ## [2.0.22] - 2023-06-23
 ### Reverted
 #### Added

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -174,20 +174,24 @@ components:
       properties:
         clone_url:
           type: string
+          deprecated: true
           description: |
             The clone url for the repository providing the configuration. (DEPRECATED)
         branch:
           type: string
+          deprecated: true
           description: |
             The name of the branch containing the configuration that you want to
             apply to the nodes. Mutually exclusive with commit. (DEPRECATED)
         commit:
           type: string
+          deprecated: true
           description: |
             The commit ID of the configuration that you want to
             apply to the nodes. Mutually exclusive with branch. (DEPRECATED)
         playbook:
           type: string
+          deprecated: true
           description: |
             The name of the playbook to run for configuration. The file path must be specified
             relative to the base directory of the config repo. (DEPRECATED)
@@ -468,10 +472,12 @@ components:
             An optional description for the session template.
         cfs_url:
           type: string
+          deprecated: true
           description: |
             The url for the repository providing the configuration. DEPRECATED
         cfs_branch:
           type: string
+          deprecated: true
           description: |
             The name of the branch containing the configuration that you want to
             apply to the nodes.  DEPRECATED.
@@ -533,6 +539,7 @@ components:
        minLength: 1
     V1TemplateUuid:
       type: string
+      deprecated: true
       description: DEPRECATED - use templateName. This field is ignored if templateName is also set.
       example: "my-session-template"
     V1SessionLink:
@@ -581,6 +588,7 @@ components:
       description: |
         Details about a Session using templateUuid instead of templateName.
         DEPRECATED -- these will only exist from sessions created before templateUuid was deprecated.
+      deprecated: true
       type: object
       properties:
         complete:
@@ -638,6 +646,7 @@ components:
         ## Link Relationships
 
         * self : The session object
+      deprecated: true
       type: object
       properties:
         operation:


### PR DESCRIPTION
Baby step #1 -- add back "deprecated" tag to objects which previously only noted it in their description texts. This should only impact the API docs that are generated and not any of BOS itself.