### PR TITLE
CASMCMS-8667: Update API spec to reflect fact that creating v1 template returns name of template on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the API spec to:
   - Make use of the OpenAPI `deprecated` tag in places where it previously was
     only indicated in the text description.
- 
+ - Accurately reflect that successfully creating a V1 session template returns the name of that template.
+
 ## [2.0.22] - 2023-06-23
 ### Reverted
 #### Added

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -430,6 +430,11 @@ components:
             the 'rootfs=<protocol>' kernel parameter
       additionalProperties: false
       required: [path, type]
+    V1SessionTemplateName:
+      type: string
+      description: |
+        Name of the Session Template.
+      example: "cle-1.0.0"
     V1SessionTemplate:
       type: object
       description: |
@@ -1449,6 +1454,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V1SessionTemplate'
+    V1SessionTemplateName:
+      description: Session Template name
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V1SessionTemplateName'
     # V2
     V2SessionTemplateDetails:
       description: Session template details
@@ -1622,7 +1633,7 @@ paths:
                $ref: '#/components/schemas/V1SessionTemplate'
       responses:
         201:
-          $ref: '#/components/responses/V1SessionTemplateDetails'
+          $ref: '#/components/responses/V1SessionTemplateName'
         400:
           $ref: '#/components/responses/BadRequest'
     get:


### PR DESCRIPTION
Targeted baby-step PR two:
- Update spec to correctly tell you what you get back when creating a V1 template (the name of the template).