### PR TITLE
Add upcoming field limits into API spec description fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.0.23] - 2023-06-26
 ### Added
 - Updated the API spec to:
   - Make use of the OpenAPI `deprecated` tag in places where it previously was
     only indicated in the text description.
  - Accurately reflect that successfully creating a V1 session template returns the name of that template.
  - Add example values for some fields
+ - Add recommendations for limits on user-submitted string fields (noting that they are not currently
+   enforced, but will be enforced in a future BOS version).
 ### Removed
 - `templateUrl` option when creating BOS v1 templates.
 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -177,28 +177,54 @@ components:
           deprecated: true
           description: |
             The clone URL for the repository providing the configuration. (DEPRECATED)
+
+            It is recommended that this should be 1-4096 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         branch:
           type: string
           deprecated: true
           description: |
             The name of the branch containing the configuration that you want to
             apply to the nodes. Mutually exclusive with commit. (DEPRECATED)
+
+            It is recommended that this should be 1-1023 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         commit:
           type: string
           deprecated: true
           description: |
             The commit ID of the configuration that you want to
             apply to the nodes. Mutually exclusive with branch. (DEPRECATED)
+
+            git commit hashes are hexadecimal strings with a length of 40 characters (although
+            fewer characters may be sufficient to uniquely identify a commit in some cases).
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         playbook:
           type: string
           deprecated: true
           description: |
             The name of the playbook to run for configuration. The file path must be specified
             relative to the base directory of the config repo. (DEPRECATED)
+
+            It is recommended that this should be 1-255 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         configuration:
           type: string
           description: |
             The name of configuration to be applied.
+
+            It is recommended that this should be no more than 127 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "compute-23.4.0"
       additionalProperties: false
     V1CompleteMetadata:
@@ -364,6 +390,14 @@ components:
           type: string
           description: |
             The Boot Set name.
+
+            It is recommended that:
+            * Boot Set names should be 1-127 characters in length.
+            * Boot Set names should use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Boot Set names should begin and end with a letter or digit.
+
+            These restrictions are not enforced in this version of BOS, but they are
+            targeted to start being enforced in an upcoming BOS version.
           example: "compute"
         boot_ordinal:
           type: integer
@@ -371,32 +405,62 @@ components:
           description: |
             The boot ordinal. This will establish the order for boot set operations.
             Boot sets boot in order from the lowest to highest boot_ordinal.
+
+            It is recommended that this should have a maximum value of 65535.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         shutdown_ordinal:
           type: integer
           minimum: 0
           description: |
             The shutdown ordinal. This will establish the order for boot set
             shutdown operations. Sets shutdown from low to high shutdown_ordinal.
+
+            It is recommended that this should have a maximum value of 65535.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         path:
           type: string
           description: |
             A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.
             It will be processed based on the type attribute.
+
+            It is recommended that this should be 1-4095 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "s3://boot-images/9e3c75e1-ac42-42c7-873c-e758048897d6/manifest.json"
         type:
           type: string
           description: |
             The MIME type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
+
+            It is recommended that this should be 1-127 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "s3"
         etag:
           type: string
           description: |
             This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.
+
+            ETags are defined as being 1-65536 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "1cc4eef4f407bd8a62d7d66ee4b9e9c8"
         kernel_parameters:
           type: string
           description: |
             The kernel parameters to use to boot the nodes.
+
+            Linux kernel parameters may never exceed 4096 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=dhcp numa_interleave
 _omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y rd.neednet=1 rd.retry=10 rd.shell turbo_boost_lim
 it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
@@ -408,31 +472,74 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
           pattern: '^[nN][mM][nN]$'
         node_list:
           type: array
-          items:
-            type: string
-            example: "x3001c0s39b0n0"
-          minItems: 1
           description: |
             The node list. This is an explicit mapping against hardware xnames.
+
+            It is recommended that this list should be 1-65535 items in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
+          minItems: 1
+          example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
+          items:
+            type: string
+            description: |
+              Hardware component name (xname).
+
+              It is recommended that this should be 1-127 characters in length.
+
+              This restriction is not enforced in this version of BOS, but it is
+              targeted to start being enforced in an upcoming BOS version.
+            example: "x3001c0s39b0n0"
         node_roles_groups:
           type: array
+          description: |
+            The node roles list. Allows actions against nodes with associated roles.
+
+            It is recommended that this list should be 1-1023 items in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
+          minItems: 1
+          example: ["Compute", "Application"]
           items:
             type: string
+            description: |
+              Name of a role that is defined in the Hardware State Manager (HSM).
+
+              It is recommended that this should be 1-127 characters in length.
+
+              This restriction is not enforced in this version of BOS, but it is
+              targeted to start being enforced in an upcoming BOS version.
             example: "Compute"
-          minItems: 1
-          description: |
-            The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.
         node_groups:
           type: array
+          description: |
+            The node groups list. Allows actions against associated nodes by logical groupings.
+
+            It is recommended that this list should be 1-4095 items in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
+          minItems: 1
           items:
             type: string
-          minItems: 1
-          description: |
-            The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user-defined groups in SMD.
+            description: |
+              Name of a user-defined logical group in the Hardware State Manager (HSM).
+
+              It is recommended that this should be 1-127 characters in length.
+
+              This restriction is not enforced in this version of BOS, but it is
+              targeted to start being enforced in an upcoming BOS version.
         rootfs_provider:
           type: string
           description: |
             The root file system provider.
+
+            It is recommended that this should be 1-511 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "cpss3"
         rootfs_provider_passthrough:
           type: string
@@ -440,6 +547,11 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
             The root file system provider passthrough.
             These are additional kernel parameters that will be appended to
             the 'rootfs=<protocol>' kernel parameter
+
+            Linux kernel parameters may never exceed 4096 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "dvs:api-gw-service-nmn.local:300:nmn0"
       additionalProperties: false
       required: [path, type]
@@ -482,17 +594,32 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
           type: string
           description: |
             An optional description for the session template.
+
+            It is recommended that this should be 1-1023 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         cfs_url:
           type: string
           deprecated: true
           description: |
             The URL for the repository providing the configuration. DEPRECATED
+
+            It is recommended that this should be 1-4096 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         cfs_branch:
           type: string
           deprecated: true
           description: |
             The name of the branch containing the configuration that you want to
             apply to the nodes.  DEPRECATED.
+
+            It is recommended that this should be 1-1023 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         enable_cfs:
           type: boolean
           description: |
@@ -504,8 +631,25 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
           type: string
           description: |
             The machine partition to operate on.
+
+            It is recommended that this should be 1-255 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         boot_sets:
           type: object
+          description: |
+            Mapping from Boot Set names to Boot Sets.
+
+            It is recommended that:
+            * At least one Boot Set should be defined, because a Session Template with no
+              Boot Sets is not functional.
+            * Boot Set names should be 1-127 characters in length.
+            * Boot Set names should use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Boot Set names should begin and end with a letter or digit.
+
+            These restrictions are not enforced in this version of BOS, but they are
+            targeted to start being enforced in an upcoming BOS version.
           additionalProperties:
             $ref: '#/components/schemas/V1BootSet'
         links:
@@ -544,14 +688,32 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
       pattern: '^([bB][oO][oO][tT]|[cC][oO][nN][fF][iI][gG][uU][rR][eE]|[rR][eE][bB][oO][oO][tT]|[sS][hH][uU][tT][dD][oO][wW][nN])$'
       example: "boot"
     V1TemplateName:
-       type: string
-       description: The name of the Session Template
-       example: "my-session-template"
-       minLength: 1
+      type: string
+      description: |
+        The name of the Session Template
+
+        It is recommended to use names which meet the following restrictions:
+        * Maximum length of 127 characters.
+        * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+        * Begin and end with a letter or digit.
+
+        These restrictions are not enforced in this version of BOS, but will be
+        enforced in a future version.
+      example: "my-session-template"
+      minLength: 1
     V1TemplateUuid:
       type: string
       deprecated: true
-      description: DEPRECATED - use templateName. This field is ignored if templateName is also set.
+      description: |
+        DEPRECATED - use templateName. This field is ignored if templateName is also set.
+
+        It is recommended to use names which meet the following restrictions:
+        * Length of 1-127 characters.
+        * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+        * Begin and end with a letter or digit.
+
+        These restrictions are not enforced in this version of BOS, but will be
+        enforced in a future version.
       example: "my-session-template"
     V1SessionLink:
       description: Link to other resources
@@ -643,6 +805,11 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
             A comma-separated of nodes, groups, or roles to which the session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
+
+            It is recommended that this should be 1-65535 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         links:
           type: array
           readOnly: true
@@ -672,6 +839,11 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
             A comma-separated of nodes, groups, or roles to which the session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
+
+            It is recommended that this should be 1-65535 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         links:
           type: array
           readOnly: true
@@ -806,6 +978,11 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
           type: string
           description: |
             An optional description for the session template.
+
+            It is recommended that this should be 1-1023 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         enable_cfs:
           type: boolean
           description: |
@@ -815,6 +992,18 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
           $ref: '#/components/schemas/V2CfsParameters'
         boot_sets:
           type: object
+          description: |
+            Mapping from Boot Set names to Boot Sets.
+
+            It is recommended that:
+            * At least one Boot Set should be defined, because a Session Template with no
+              Boot Sets is not functional.
+            * Boot Set names should be 1-127 characters in length.
+            * Boot Set names should use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Boot Set names should begin and end with a letter or digit.
+
+            These restrictions are not enforced in this version of BOS, but they are
+            targeted to start being enforced in an upcoming BOS version.
           additionalProperties:
             $ref: '#/components/schemas/V2BootSet'
         links:
@@ -829,7 +1018,16 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
       type: string
     V2TemplateName:
        type: string
-       description: The name of the Session Template
+       description: |
+         The name of the Session Template
+
+         It is recommended to use names which meet the following restrictions:
+         * Maximum length of 127 characters.
+         * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+         * Begin and end with a letter or digit.
+
+         These restrictions are not enforced in this version of BOS, but will be
+         enforced in a future version.
        example: "my-session-template"
        minLength: 1
     V2SessionCreate:
@@ -866,6 +1064,11 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
             A comma-separated of nodes, groups, or roles to which the session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
+
+            It is recommended that this should be 1-65535 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         stage:
           type: boolean
           description: >
@@ -914,12 +1117,25 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
           type: string
           description: |
             The Boot Set name.
+
+            It is recommended that:
+            * Boot Set names should be 1-127 characters in length.
+            * Boot Set names should use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Boot Set names should begin and end with a letter or digit.
+
+            These restrictions are not enforced in this version of BOS, but they are
+            targeted to start being enforced in an upcoming BOS version.
           example: "compute"
         path:
           type: string
           description: |
             A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.
             It will be processed based on the type attribute.
+
+            It is recommended that this should be 1-4095 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "s3://boot-images/9e3c75e1-ac42-42c7-873c-e758048897d6/manifest.json"
         cfs:
           $ref: '#/components/schemas/V2CfsParameters'
@@ -927,46 +1143,104 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
           type: string
           description: |
             The MIME type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
+
+            It is recommended that this should be 1-127 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "s3"
         etag:
           type: string
           description: |
             This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.
+
+            ETags are defined as being 1-65536 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "1cc4eef4f407bd8a62d7d66ee4b9e9c8"
         kernel_parameters:
           type: string
           description: |
             The kernel parameters to use to boot the nodes.
+
+            Linux kernel parameters may never exceed 4096 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=dhcp numa_interleave
 _omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y rd.neednet=1 rd.retry=10 rd.shell turbo_boost_lim
 it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
         node_list:
           type: array
-          items:
-            type: string
-            example: "x3001c0s39b0n0"
-          minItems: 1
           description: |
             The node list. This is an explicit mapping against hardware xnames.
+
+            It is recommended that this list should be 1-65535 items in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
+          minItems: 1
+          example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
+          items:
+            type: string
+            description: |
+              Hardware component name (xname).
+
+              It is recommended that this should be 1-127 characters in length.
+
+              This restriction is not enforced in this version of BOS, but it is
+              targeted to start being enforced in an upcoming BOS version.
+            example: "x3001c0s39b0n0"
         node_roles_groups:
           type: array
+          description: |
+            The node roles list. Allows actions against nodes with associated roles.
+
+            It is recommended that this list should be 1-1023 items in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
+          minItems: 1
+          example: ["Compute", "Application"]
           items:
             type: string
+            description: |
+              Name of a role that is defined in the Hardware State Manager (HSM).
+
+              It is recommended that this should be 1-127 characters in length.
+
+              This restriction is not enforced in this version of BOS, but it is
+              targeted to start being enforced in an upcoming BOS version.
             example: "Compute"
-          minItems: 1
-          description: |
-            The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.
         node_groups:
           type: array
+          description: |
+            The node groups list. Allows actions against associated nodes by logical groupings.
+
+            It is recommended that this list should be 1-4095 items in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
+          minItems: 1
           items:
             type: string
-          minItems: 1
-          description: |
-            The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user-defined groups in SMD.
+            description: |
+              Name of a user-defined logical group in the Hardware State Manager (HSM).
+
+              It is recommended that this should be 1-127 characters in length.
+
+              This restriction is not enforced in this version of BOS, but it is
+              targeted to start being enforced in an upcoming BOS version.
         rootfs_provider:
           type: string
           description: |
             The root file system provider.
+
+            It is recommended that this should be 1-511 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "cpss3"
         rootfs_provider_passthrough:
           type: string
@@ -974,6 +1248,11 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
             The root file system provider passthrough.
             These are additional kernel parameters that will be appended to
             the 'rootfs=<protocol>' kernel parameter
+
+            Linux kernel parameters may never exceed 4096 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
           example: "dvs:api-gw-service-nmn.local:300:nmn0"
       additionalProperties: false
       required: [path, type]
@@ -1240,7 +1519,14 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
       properties:
         id:
           type: string
-          description: The component's ID. e.g. xname for hardware components
+          description: |
+            The component's ID. e.g. xname for hardware components
+
+            It is recommended that this should be 1-127 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
+          example: "x3001c0s39b0n0"
         actual_state:
           $ref: '#/components/schemas/V2ComponentActualState'
         desired_state:
@@ -1280,10 +1566,23 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
       properties:
         ids:
           type: string
-          description: A comma-separated list of component IDs
+          description: |
+            A comma-separated list of component IDs
+
+            It is recommended that this should be 1-65535 characters in length.
+
+            This restriction is not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
         session:
           type: string
-          description: A session name.  All components part of this session will be patched.
+          description: |
+            A session name.  All components part of this session will be patched.
+
+            BOS v2 session names must be 1-45 characters in length and match the
+            following regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+
+            These restrictions are not enforced in this version of BOS, but it is
+            targeted to start being enforced in an upcoming BOS version.
     V2ComponentsUpdate:
       description: Information for patching multiple components.
       type: object
@@ -1671,7 +1970,16 @@ paths:
     parameters:
       - name: session_template_id
         in: path
-        description: Session Template ID
+        description: |
+          Session Template ID
+
+          It is recommended to use names which meet the following restrictions:
+          * Length of 1-127 characters.
+          * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+          * Begin and end with a letter or digit.
+
+          These restrictions are not enforced in this version of BOS, but they are
+          targeted to start being enforced in an upcoming BOS version.
         required: true
         schema:
           type: string
@@ -2107,7 +2415,16 @@ paths:
     parameters:
       - name: session_template_id
         in: path
-        description: Session Template ID
+        description: |
+          Session Template ID
+
+          It is recommended to use names which meet the following restrictions:
+          * Length of 1-127 characters.
+          * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+          * Begin and end with a letter or digit.
+
+          These restrictions are not enforced in this version of BOS, but they are
+          targeted to start being enforced in an upcoming BOS version.
         required: true
         schema:
           type: string
@@ -2131,7 +2448,16 @@ paths:
     parameters:
       - name: session_template_id
         in: path
-        description: Session Template ID
+        description: |
+          Session Template ID
+
+          It is recommended to use names which meet the following restrictions:
+          * Length of 1-127 characters.
+          * Use only letters, digits, periods (.), dashes (-), and underscores (_).
+          * Begin and end with a letter or digit.
+
+          These restrictions are not enforced in this version of BOS, but they are
+          targeted to start being enforced in an upcoming BOS version.
         required: true
         schema:
           type: string
@@ -2354,7 +2680,14 @@ paths:
     parameters:
       - name: session_id
         in: path
-        description: Session ID
+        description: |
+          Session ID
+
+          BOS v2 session IDs must be 1-45 characters in length and match the
+          following regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+
+          These restrictions are not enforced in this version of BOS, but it is
+          targeted to start being enforced in an upcoming BOS version.
         required: true
         schema:
           type: string
@@ -2389,7 +2722,14 @@ paths:
     parameters:
       - name: session_id
         in: path
-        description: Session ID
+        description: |
+          Session ID
+
+          BOS v2 session IDs must be 1-45 characters in length and match the
+          following regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+
+          These restrictions are not enforced in this version of BOS, but it is
+          targeted to start being enforced in an upcoming BOS version.
         required: true
         schema:
           type: string
@@ -2553,7 +2893,13 @@ paths:
     parameters:
       - name: component_id
         in: path
-        description: Component ID. e.g. xname for hardware components
+        description: |
+          Component ID. e.g. xname for hardware components
+
+          It is recommended that this should be 1-127 characters in length.
+
+          This restriction is not enforced in this version of BOS, but it is
+          targeted to start being enforced in an upcoming BOS version.
         required: true
         schema:
           type: string


### PR DESCRIPTION
Final targeted support/2.0 PR -- this one adds back the upcoming field restrictions, adding them to the description text fields. No new actual limits are imposed by this PR. Also, no schemas are created to avoid repeated statements of these limits.