### PR TITLE
CASMCMS-8691: Build bos-reporter RPM as noos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.6.0] - 08-09-2023
+### Changed
+- Build `bos-reporter` RPM as `noos`
+
 ## [2.5.6] - 08-08-2023
 ### Changed
 - IsAlive attribute look-up.

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -46,10 +46,6 @@ pipeline {
         IS_STABLE = getBuildIsStable()
         DOCKER_BUILDKIT = "1"
         BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)
-        PUBLISH_SP2 = "sle-15sp2"
-        PUBLISH_SP3 = "sle-15sp3"
-        PUBLISH_SP4 = "sle-15sp4"
-        PUBLISH_SP5 = "sle-15sp5"
     }
 
     stages {
@@ -83,6 +79,11 @@ pipeline {
                 runLibraryScript("addRpmMetaData.sh", env.RPTR_SPEC_FILE)
             }
         }
+        stage("RPM Build Prepare") {
+            steps {
+               sh "make rpm_prepare"
+        	}
+        }
         stage("Build Image and Chart") {
             parallel {
                 stage('Image') {
@@ -104,9 +105,22 @@ pipeline {
                         sh "make chart"
                     }
                 }
+                stage("RPM Build") {
+                    agent {
+                        docker {
+                            image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp5_build_environment:latest"
+                            reuseNode true
+                            // Support docker in docker for clamav scan
+                            args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
+                        }
+                    }
+                    steps {
+                        sh "make rptr_rpm_prepare"
+                        sh "make rptr_rpm"
+                    }
+                }
             }
         }
-
         stage('Publish ') {
             parallel {
                 stage('Image and Chart') {
@@ -118,109 +132,16 @@ pipeline {
                         publishCsmHelmCharts(component: env.NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", isStable: env.IS_STABLE)
                     }
                 }
-            }
-        }
-        stage("RPM Build Prepare") {
-            steps {
-               sh "make rpm_prepare"
-        	}
-        }
-        stage("SLES15SP2 RPM Build") {
-            agent {
-                docker {
-                    // https://rndwiki-pro.its.hpecorp.net/display/CSMTemp/Build+Environment+Docker+Images
-                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
-                    reuseNode true
-                    // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
+                stage("RPM Publish") {
+                    steps {
+                        script {
+                            publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: "noos", arch: "noarch", isStable: env.IS_STABLE)
+                            publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "noos", arch: "src", isStable: env.IS_STABLE)
+                        }
+                        sh "make rpm_build_clean"
+                        sh "make rpm_build_source_clean"
+                    }
                 }
-            }
-            steps {
-                sh "make rptr_rpm_prepare"
-                sh "make rptr_rpm"
-            }
-        }
-        stage("SLES15SP2 RPM Publish") {
-            steps {
-                script {
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP2, arch: "noarch", isStable: env.IS_STABLE)
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP2, arch: "src", isStable: env.IS_STABLE)
-	             }
-                sh "make rpm_build_clean"
-                sh "make rpm_build_source_clean"
-	        }
-        }
-        stage("SLES15SP3 RPM Build") {
-            agent {
-                docker {
-                    // https://rndwiki-pro.its.hpecorp.net/display/CSMTemp/Build+Environment+Docker+Images
-                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
-                    reuseNode true
-                    // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
-                }
-            }
-            steps {
-                sh "make rptr_rpm_prepare"
-                sh "make rptr_rpm"
-            }
-        }
-        stage("SLES15SP3 RPM Publish") {
-            steps {
-                script {
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP3, arch: "noarch", isStable: env.IS_STABLE)
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP3, arch: "src", isStable: env.IS_STABLE)
-	            }
-                sh "make rpm_build_clean"
-                sh "make rpm_build_source_clean"
-	        }
-	    }
-        stage("SLES15SP4 RPM Build") {
-            agent {
-                docker {
-                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp4_build_environment:latest"
-                    reuseNode true
-                    // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
-                }
-            }
-            steps {
-                sh "make rptr_rpm_prepare"
-                sh "make rptr_rpm"
-            }
-        }
-        stage("SLES15SP4 RPM Publish") {
-            steps {
-                script {
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP4, arch: "noarch", isStable: env.IS_STABLE)
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP4, arch: "src", isStable: env.IS_STABLE)
-                }
-                sh "make rpm_build_clean"
-                sh "make rpm_build_source_clean"
-            }
-        }
-        stage("SLES15SP5 RPM Build") {
-            agent {
-                docker {
-                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp5_build_environment:latest"
-                    reuseNode true
-                    // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
-                }
-            }
-            steps {
-                sh "make rptr_rpm_prepare"
-                sh "make rptr_rpm"
-            }
-        }
-        stage("SLES15SP5 RPM Publish") {
-            steps {
-                script {
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP5, arch: "noarch", isStable: env.IS_STABLE)
-                    publishCsmRpms(component: env.REPORTER_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP5, arch: "src", isStable: env.IS_STABLE)
-                }
-                sh "make rpm_build_clean"
-                sh "make rpm_build_source_clean"
             }
         }
     }


### PR DESCRIPTION
## Summary and Scope

When having to jump through a lot of hoops to get the new SLES15 SP5 RPMs added to various manifests, Rusty asked if we could instead build our RPMs as "noos", to avoid having to do this in the future. I think most CMS RPMs fit the criteria. While some do have SOME level of OS dependence (like relying on systemctl), all OSes that we ever intended to support with these RPMs are going to meet that requirement.

For bos-reporter in particular, there is no reason not to make it OS independent.

This has the additional benefit of allowing us to make our Jenkins build jobs much shorter and more parallelized.
