### PR TITLE
CASMCMS-8697: Mark status/error and status/end_time string fields as nullable in API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.24] - 2023-06-29
+### Added
+- Marked BOS v2 session status `error` and `end_time` fields as `nullable` in API spec, because they begin
+  populated with null values (rather than empty string values). Added comment to description text for these
+  fields to explain this.
+
 ## [2.0.23] - 2023-06-26
 ### Added
 - Updated the API spec to:

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1093,8 +1093,10 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
             When the session was created.
         end_time:
           type: string
+          nullable: true
           description: |
             When the session completed.
+            A null value means the session has not ended.
         status:
           type: string
           enum: ['pending', 'running', 'complete']
@@ -1102,8 +1104,10 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
             The status of a session.
         error:
           type: string
+          nullable: true
           description: |
-            Error which prevented the session from running
+            Error which prevented the session from running.
+            A null value means the session has not encountered an error.
       additionalProperties: false
     V2BootSet:
       description: |
@@ -1346,8 +1350,10 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
             When the session was created.
         end_time:
           type: string
+          nullable: true
           description: |
             When the session completed.
+            A null value means the session has not ended.
         duration:
           type: string
           description: |


### PR DESCRIPTION
## Summary and Scope

When creating a new BOS v2 session, the end_time and error status fields begin with null values. This contradicts the spec, which says they take string values. OpenAPI offers the "nullable" option to indicate when such fields may take null values. These fields should be marked as such.

Changing this will have no functional impact on BOS.

## Issues and Related PRs

* Resolves [CASMCMS-8697](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8697)
* develop branch PR forthcoming
