### PR TITLE
CASMCMS-8697: Mark status/error and status/end_time string fields as nullable in API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.3] - 2023-06-29
+### Added
+- Marked BOS v2 session status `error` and `end_time` fields as `nullable` in API spec, because they begin
+  populated with null values (rather than empty string values). Added comment to description text for these
+  fields to explain this.
+
 ## [2.5.2] - 2023-6-26
 ### Changed
 - Added etcd_disable_prestop value for the etcd chart

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1125,24 +1125,30 @@ components:
       type: string
       enum: ['pending', 'running', 'complete']
       description: The status of a Session.
-    V2SessionTime:
+    V2SessionStartTime:
       type: string
-      description: When the Session was created or completed.
+      description: When the Session was created.
+    V2SessionEndTime:
+      type: string
+      nullable: true
+      description: When the Session was completed. A null value means the Session has not ended.
     V2SessionStatus:
       type: object
       description: |
         Information on the status of a Session.
       properties:
         start_time:
-          $ref: '#/components/schemas/V2SessionTime'
+          $ref: '#/components/schemas/V2SessionStartTime'
         end_time:
-          $ref: '#/components/schemas/V2SessionTime'
+          $ref: '#/components/schemas/V2SessionEndTime'
         status:
           $ref: '#/components/schemas/V2SessionStatusLabel'
         error:
           type: string
+          nullable: true
           description: |
-            Error which prevented the Session from running
+            Error which prevented the Session from running.
+            A null value means the Session has not encountered an error.
       additionalProperties: false
     V2BootSet:
       description: |
@@ -1254,9 +1260,9 @@ components:
         Detailed information on the timing of a Session.
       properties:
         start_time:
-          $ref: '#/components/schemas/V2SessionTime'
+          $ref: '#/components/schemas/V2SessionStartTime'
         end_time:
-          $ref: '#/components/schemas/V2SessionTime'
+          $ref: '#/components/schemas/V2SessionEndTime'
         duration:
           type: string
           description: |


### PR DESCRIPTION
develop branch version of https://github.com/Cray-HPE/bos/pull/181