### PR TITLE
CASMCMS-8713: Bump PyYAML from 6.0. to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.4] - 2023-07-18
+### Dependencies
+- Bump `PyYAML` from 6.0 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
 
 ## [2.5.3] - 2023-06-29
 ### Added

--- a/constraints.txt
+++ b/constraints.txt
@@ -30,7 +30,7 @@ pyasn1-modules==0.2.8
 pyparsing==3.0.9
 pyrsistent==0.19.3
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 redis==4.5.1
 requests==2.28.2
 requests-oauthlib==1.3.1


### PR DESCRIPTION
## Summary and Scope

BOS builds are failing due to the problem documented in [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713). Moving to PyYAML 6.0.1 resolves the problem. This PR moves PyYAML from 6.0 to 6.0.1. The only difference between these two versions is to force PyYAML to build using a Cython version < 3.0, which is what 6.0 was doing up until very recently (when Cython 3.0 was released and wrought havoc). This has no functional impact to PyYAML itself, nor to BOS, but builds will fail without this PR.

A similar change is being made to a number of CSM repositories that are similarly affected.