### PR TITLE
CASMCMS-8722: Use update_external_versions to get latest patch version of liveness Python module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tox.log
 gitInfo.txt
 api/openapi.yaml
 bos.egg-info
+constraints.txt
 kubernetes/cray-bos/values.yaml
 kubernetes/cray-bos/Chart.yaml
 cray-boa.version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Dependencies
+- Use `update_external_versions` to get latest patch version of `liveness` Python module.
+
 ## [2.5.4] - 2023-07-18
 ### Dependencies
 - Bump `PyYAML` from 6.0 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ clone_input_files:
 		cp ${CHART_PATH}/${NAME}/Chart.yaml.in ${CHART_PATH}/${NAME}/Chart.yaml
 		cp ${CHART_PATH}/${NAME}/values.yaml.in ${CHART_PATH}/${NAME}/values.yaml
 		cp bos-reporter.spec.in bos-reporter.spec
+		cp constraints.txt.in constraints.txt
 		cp src/setup.py.in src/setup.py
 		cp api/openapi.yaml.in api/openapi.yaml
 

--- a/constraints.txt.in
+++ b/constraints.txt.in
@@ -20,7 +20,7 @@ Jinja2==3.0.3
 jmespath==1.0.1
 jsonschema==4.17.3
 kubernetes==26.1.0
-liveness==1.4.1
+liveness==0.0.0-liveness
 MarkupSafe==2.1.2
 oauthlib==3.2.2
 packaging==21.3

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -81,3 +81,9 @@
 image: cray-boa
     major: 1
     minor: 4
+
+# Built from the k8s-liveness repository
+image: liveness
+    source: python
+    major: 1
+    minor: 4

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -75,3 +75,9 @@ targetfile: kubernetes/cray-bos/values.yaml
 sourcefile: .docker_version
 tag: 0.0.0-app-version
 targetfile: kubernetes/cray-bos/templates/post-upgrade-job.yaml
+
+# The following file does not exist in the repo as a static file
+# It is generated at build time by the runBuildPrep.sh script
+sourcefile: liveness.version
+tag: 0.0.0-liveness
+targetfile: constraints.txt


### PR DESCRIPTION
## Summary and Scope

Now that `update_external_versions` handles Python modules, this update this repo to use it in order to grab the latest patch version of the `liveness` Python module.

(This was prompted by my noticing some cases in other repos where we are using outdated versions of our Python modules)