### PR TITLE
CASMCMS-8753: Update API spec to reflect that BOS sometimes populates the 'tenant' field with a null value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.5] - 2023-08-04
+### Fixed
+- Updated API spec to reflect the fact that BOS sometimes populates the `tenant` field with a null value.
+
 ## [2.5.4] - 2023-07-18
 ### Dependencies
 - Bump `PyYAML` from 6.0 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1005,7 +1005,10 @@ components:
       type: string
       description: |
         Name of the tenant that owns this resource. Only used in environments
-        with multi-tenancy enabled.
+        with multi-tenancy enabled. An empty string or null value means the resource
+        is not owned by a tenant. The absence of this field from a resource indicates
+        the same.
+      nullable: true
       readOnly: true
     V2CfsParameters:
       type: object
@@ -1908,7 +1911,7 @@ components:
 
         Requests with a non-empty tenant name will restict the context of the operation to Session Templates owned by that tenant.
 
-        Requests with an empty tenant name, or that omit this paarameter, will have no such context restrictions.
+        Requests with an empty tenant name, or that omit this parameter, will have no such context restrictions.
       required: false
       schema:
         $ref: '#/components/schemas/TenantName'


### PR DESCRIPTION
## Summary and Scope

When making the test changes for [CASMCMS-8553](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8553), I discovered that in some contexts, BOS populates the `tenant` field with a null value (as opposed to an empty string value). 

```text
ncn-w003:/tmp/zebrafish # cray bos v2 sessions list --format json
```
```json
[
  {
    "components": "",
    "include_disabled": false,
    "limit": "",
    "name": "caa05de4-5c27-477a-98fb-8f330c87690d",
    "operation": "boot",
    "stage": false,
    "status": {
      "end_time": null,
      "error": null,
      "start_time": "2023-08-04T16:58:09",
      "status": "pending"
    },
    "template_name": "test3",
    "tenant": null
  },
  {
    "components": "",
    "include_disabled": false,
    "limit": "",
    "name": "8d217f08-a306-44ee-b82c-976a660eaf7c",
    "operation": "boot",
    "stage": false,
    "status": {
      "end_time": null,
      "error": null,
      "start_time": "2023-08-04T17:01:57",
      "status": "pending"
    },
    "template_name": "test3",
    "tenant": "vcluster-blue"
  }
]
```

This in turn caused my updated test to fail, because it was going by the API spec, which indicated that if present, the `tenant` field would always have a string value (although possibly 0-length). The lowest risk and easiest fix here seems to be to update the API spec to reflect the BOS reality. Then I'll make the corresponding change to the test.

Apart from fixing one spelling error in a description field of the API spec, this PR only updates the description text for the `tenant` field and adds the `nullable: true` value for it. This should have no impact on BOS behavior -- clearly BOS itself wasn't enforcing the API spec in this regard anyway, but if it was, this change would allow it to not have problems.

## Testing

I deployed this on mug as part of my testing for [this PR](https://github.com/Cray-HPE/bos/pull/192) and did not find any problems.

## Issues and Related PRs

* Resolves [CASMCMS-8753](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8753)
* Required for [CASMCMS-8553](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8553)

