### PR TITLE
feature/CASMCMS-8752: Increased resiliency settings for read and heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Global read timeout values for all objects and operations which leverage requests_retry handler.
+- Heartbeat threads now exit when main thread is no longer alive.
 ### Dependencies
 - Use `update_external_versions` to get latest patch version of `liveness` Python module.
 - Bumped depndency patch versions

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -40,6 +40,7 @@ from bos.operators.utils.clients.bos import BOSClient
 from bos.operators.utils.liveness.timestamp import Timestamp
 
 LOGGER = logging.getLogger('bos.operators.base')
+MAIN_THREAD = threading.currentThread()
 
 
 class BaseOperatorException(Exception):
@@ -251,6 +252,9 @@ def _liveliness_heartbeat() -> NoReturn:
     period of time.
     """
     while True:
+        if not MAIN_THREAD.isAlive():
+            # All hope abandon ye who enter here
+            return
         Timestamp()
         time.sleep(10)
 


### PR DESCRIPTION
## Summary and Scope

Introduced global read timeout values for undetected half open connections caused by network reconfiguration or istio interruptions. Now all connections that take longer than 10 seconds to send any data are considered dead. This prevents us from waiting indefinitely for APIs that will never respond over an undetected closed connection.

Added logic to automatically terminate zombie operators that have their main threads terminate (for whatever reason). When a main thread exits, the heartbeat thread will notice and exit as well.
## Issues and Related PRs

* Resolves [CASMCMS-8752](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8752)
* Change will also be needed in corresponding release/1.5

## Testing

Simulated do-no-harm testing on local dev system; these changes are identical to some that went in to cfs-state-reporter and the cms-ipxe builder deployment.

### Tested on:
  * Local development environment

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
