### PR TITLE
CASMCMS-8755: Update BOS API spec to allow session fields to have empty string values in some contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.5] - 2023-08-04
+## [2.5.5] - 2023-08-07
 ### Fixed
 - Updated API spec to reflect the fact that BOS sometimes populates the `tenant` field with a null value.
+- Updated API spec to allow BOS session names to be empty strings in appropriate contexts (to indicate no
+  session, or to clear a populated session field).
 
 ## [2.5.4] - 2023-07-18
 ### Dependencies

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -221,6 +221,10 @@ components:
         This restriction is not enforced in this version of BOS, but it is
         targeted to start being enforced in an upcoming BOS version.
       example: "compute-23.4.0"
+    EmptyString:
+      type: string
+      description: An empty string value.
+      enum: [ '' ]
     EnableCfs:
       type: boolean
       description: |
@@ -1378,7 +1382,9 @@ components:
         configuration:
           $ref: '#/components/schemas/CfsConfiguration'
         session:
-          $ref: '#/components/schemas/V2SessionName'
+          oneOf:
+            - $ref: '#/components/schemas/V2SessionName'
+            - $ref: '#/components/schemas/EmptyString'
         last_updated:
           $ref: '#/components/schemas/V2ComponentLastUpdated'
       additionalProperties: false
@@ -1453,7 +1459,9 @@ components:
           type: string
           description: A description of the most recent error to impact the Component.
         session:
-          $ref: '#/components/schemas/V2SessionName'
+          oneOf:
+            - $ref: '#/components/schemas/V2SessionName'
+            - $ref: '#/components/schemas/EmptyString'
         retry_policy:
           type: integer
           description: |


### PR DESCRIPTION
Alternative implementation of this PR: https://github.com/Cray-HPE/bos/pull/192

They should be equivalent. I am testing to make sure of that. If so, I think this change is more elegant, but it may just be a matter of taste. I like that it avoids the duplication of the session name definition, just to pull in the possibility of a blank value. It seems a more natural fit for the `oneOf` construct, IMO