### PR TITLE
CASMCMS-8757: Update Jenkinsfile to disable concurrent builds of same branch/tag, and to add timeout value to avoid hung builds

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -33,6 +33,8 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
+        disableConcurrentBuilds()        
+        timeout(time: 90, unit: 'MINUTES')
         timestamps()
     }
 


### PR DESCRIPTION
This was already reviewed and approved in a separate PR, but was moved at request into its own PR.