### PR TITLE
CASMCMS-8756: Fixed repeated database key migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.6.1] - 08-10-2023
+### Fixed
+Fixed database key migration when upgrading from newer versions of BOS.
+
 ## [2.6.0] - 08-09-2023
 ### Changed
 - Build `bos-reporter` RPM as `noos`

--- a/src/bos/server/migrations.py
+++ b/src/bos/server/migrations.py
@@ -175,7 +175,7 @@ def migrate_database(db):
         data = db.get(old_key)
         name = data.get("name")
         tenant = data.get("tenant")
-        new_key = get_tenant_aware_key(name, tenant)
+        new_key = get_tenant_aware_key(name, tenant).encode()
         if new_key != old_key:
             LOGGER.info(f"Migrating {name} to new database key structure")
             db.put(new_key, data)


### PR DESCRIPTION
## Summary and Scope

Fixes a bug where repeating the database key migration, caused by migrating from a BOS version with multi-tenancy to a newer version of BOS, was causing session templates and sessions to dissapear.

## Issues and Related PRs

* Resolves CASMCMS-8756

## Testing

### Tested on:

  * Mug

### Test description:

Tested repeated upgrades

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

