### PR TITLE
CASMTRIAGE-5820: Fix for HSM query handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.6.2] - 08-14-2023
+### Fixed
+Fixed HSM query handling to prevent errors from querying with an empty list nodes.
+
 ## [2.6.1] - 08-10-2023
 ### Fixed
 Fixed database key migration when upgrading from newer versions of BOS.

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -181,7 +181,7 @@ class Session:
         """
         valid_archs = set([arch])
         if arch == 'X86':
-            valid_archs.add('Unknown')
+            valid_archs.add('UNKNOWN')
         hsm_filter = HSMState(enabled=True)
         return set(hsm_filter.filter_by_arch(nodes, valid_archs))
 

--- a/src/bos/operators/utils/clients/hsm.py
+++ b/src/bos/operators/utils/clients/hsm.py
@@ -80,6 +80,8 @@ def read_all_node_xnames():
 
 def get_components(node_list, enabled=None):
     """Get information for all list components HSM"""
+    if not node_list:
+        return []
     session = requests_retry_session()
     try:
         payload = {'ComponentIDs': node_list}


### PR DESCRIPTION
## Summary and Scope

Fixes the architecture handling to correctly handle what is expected from HSM and fixes the component querying so that HSM is not queried with an empty list.

## Issues and Related PRs

* Resolves CASMTRIAGE-5820

## Testing

### Tested on:

  * fearne (Virtual Shasta)

### Test description:

- Ran a test session that was previously failing

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

