### PR TITLE
CASMCMS-8770: List spire-agent as a required package for bos-reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.6.3] - 08-22-2023
+### Changed
+Updated `bos-reporter` spec file to reflect the fact that it should not be installed without `spire-agent` being present.
+
 ## [2.6.2] - 08-14-2023
 ### Fixed
 Fixed HSM query handling to prevent errors from querying with an empty list nodes.

--- a/bos-reporter.spec.in
+++ b/bos-reporter.spec.in
@@ -38,6 +38,7 @@ Requires: python3-base
 Requires: python3-requests
 Requires: systemd
 Requires: cray-auth-utils
+Requires: spire-agent
 
 # Death to Fascist build policies
 %define _unpackaged_files_terminate_build 0


### PR DESCRIPTION
## Summary and Scope

The bos-reporter RPM relies on spire-agent in order to function. This PR updates the spec file for the bos-reporter RPM to reflect this requirement.

