### PR TITLE
CASMCMS-8797: Update BOS session template templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Removed non-v2 fields from v1 session template template
+- Provide more useful example values in v1 and v2 session template templates
 
 ## [2.6.3] - 08-22-2023
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Removed non-v2 fields from v1 session template template
 
 ## [2.6.3] - 08-22-2023
 ### Changed

--- a/src/bos/server/controllers/v1/sessiontemplate.py
+++ b/src/bos/server/controllers/v1/sessiontemplate.py
@@ -39,14 +39,14 @@ LOGGER = logging.getLogger('bos.server.controllers.v1.sessiontemplate')
 DB = dbutils.get_wrapper(db='session_templates')
 
 EXAMPLE_BOOT_SET = {
-    "type": "your-boot-type",
-    "etag": "your_boot_image_etag",
+    "type": "s3",
+    "etag": "boot-image-s3-etag",
     "kernel_parameters": "your-kernel-parameters",
     "node_list": [
         "xname1", "xname2", "xname3"],
-    "path": "your-boot-path",
-    "rootfs_provider": "your-rootfs-provider",
-    "rootfs_provider_passthrough": "your-rootfs-provider-passthrough"}
+    "path": "s3://boot-images/boot-image-ims-id/manifest.json",
+    "rootfs_provider": "cpss3",
+    "rootfs_provider_passthrough": "dvs:api-gw-service-nmn.local:300:hsn0,nmn0:0"}
 
 EXAMPLE_SESSION_TEMPLATE = {
     "boot_sets": {

--- a/src/bos/server/controllers/v1/sessiontemplate.py
+++ b/src/bos/server/controllers/v1/sessiontemplate.py
@@ -38,13 +38,10 @@ from ..v2.sessiontemplates import get_v2_sessiontemplate, get_v2_sessiontemplate
 LOGGER = logging.getLogger('bos.server.controllers.v1.sessiontemplate')
 DB = dbutils.get_wrapper(db='session_templates')
 
-
 EXAMPLE_BOOT_SET = {
     "type": "your-boot-type",
-    "boot_ordinal": 1,
     "etag": "your_boot_image_etag",
     "kernel_parameters": "your-kernel-parameters",
-    "network": "nmn",
     "node_list": [
         "xname1", "xname2", "xname3"],
     "path": "your-boot-path",

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -35,15 +35,15 @@ DB = dbutils.get_wrapper(db='session_templates')
 BASEKEY = "/sessionTemplates"
 
 EXAMPLE_BOOT_SET = {
-    "type": "your-boot-type",
-    "etag": "your_boot_image_etag",
+    "type": "s3",
+    "etag": "boot-image-s3-etag",
     "kernel_parameters": "your-kernel-parameters",
     "cfs": {"configuration": "bootset-specific-cfs-override"},
     "node_list": [
         "xname1", "xname2", "xname3"],
-    "path": "your-boot-path",
-    "rootfs_provider": "your-rootfs-provider",
-    "rootfs_provider_passthrough": "your-rootfs-provider-passthrough"}
+    "path": "s3://boot-images/boot-image-ims-id/manifest.json",
+    "rootfs_provider": "cpss3",
+    "rootfs_provider_passthrough": "dvs:api-gw-service-nmn.local:300:hsn0,nmn0:0"}
 
 EXAMPLE_SESSION_TEMPLATE = {
     "boot_sets": {


### PR DESCRIPTION
## Summary and Scope

We have decided to change BOS in CSM 1.5 so that even when using the v1 endpoint to create session templates, BOS will always create a v2-compatible session template. This PR contains two commits:

1. In order to help with this, this PR updates the v1 session template template to no longer include v1 fields that will just end up being stripped when the template is created.

2. This PR also updates some of the example fields being returned to be more useful to users (by populating them with typical defaults or with values closer to the expected actual field formats). This change is for both the v1 and v2 session template templates.

I don't intend to merge this to master and tag it yet -- I intend for this to go in alongside the other BOS changes we're planning.