### PR TITLE
CASMCMS-8806: Remove deprecated cfs fields from v1 session templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Update the changes made for `2.7.0` below to include the deprecated sub-fields of the `cfs`
+  field in v1 session templates.
+- Update the API spec to explicitly state which fields are automatically removed from v1 session
+  templates in this version of BOS.
+- Remove the now-superfluous read-only `links` field from V1 session templates, since BOS no longer
+  ever returns session templates using that schema; the schema is now only used to validate session
+  templates being created by the user, and thus there is no purpose for read-only fields in it.
+- Update the API spec to mark some v1-specific fields as deprecated that were not previously marked as
+  such (`partition`, `boot_ordinal`, `network`, and `shutdown_ordinal`). These fields already had no
+  effect and thus were effectively deprecated anyway.
 
 ## [2.7.0] - 09-12-2023
 ### Changed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -438,8 +438,11 @@ components:
 
         It is recommended that this should be 1-1023 characters in length.
 
-        This restriction is not enforced in this version of BOS, but it is
-        targeted to start being enforced in an upcoming BOS version.
+        When upgrading to this version of BOS, all existing V1 session
+        templates will automatically have this deprecated field removed from them.
+
+        When a V1 session template is created, this deprecated field is
+        automatically removed from it before storing it in BOS.
     V1CfsUrl:
       type: string
       deprecated: true
@@ -448,8 +451,11 @@ components:
 
         It is recommended that this should be 1-4096 characters in length.
 
-        This restriction is not enforced in this version of BOS, but it is
-        targeted to start being enforced in an upcoming BOS version.
+        When upgrading to this version of BOS, all existing V1 session
+        templates will automatically have this deprecated field removed from them.
+
+        When a V1 session template is created, this deprecated field is
+        automatically removed from it before storing it in BOS.
     V1CfsParameters:
       type: object
       description: |
@@ -470,8 +476,11 @@ components:
             git commit hashes are hexadecimal strings with a length of 40 characters (although
             fewer characters may be sufficient to uniquely identify a commit in some cases).
 
-            This restriction is not enforced in this version of BOS, but it is
-            targeted to start being enforced in an upcoming BOS version.
+            When upgrading to this version of BOS, all existing V1 session
+            templates will automatically have this deprecated field removed from them.
+
+            When a V1 session template is created, this deprecated field is
+            automatically removed from it before storing it in BOS.
         playbook:
           type: string
           deprecated: true
@@ -481,8 +490,11 @@ components:
 
             It is recommended that this should be 1-255 characters in length.
 
-            This restriction is not enforced in this version of BOS, but it is
-            targeted to start being enforced in an upcoming BOS version.
+            When upgrading to this version of BOS, all existing V1 session
+            templates will automatically have this deprecated field removed from them.
+
+            When a V1 session template is created, this deprecated field is
+            automatically removed from it before storing it in BOS.
         configuration:
           $ref: '#/components/schemas/CfsConfiguration'
       additionalProperties: false
@@ -654,12 +666,20 @@ components:
           $ref: '#/components/schemas/BootSetRootfsProviderPassthrough'
         network:
           type: string
+          deprecated: true
           description: |
             The network over which the node will boot.
             Choices:  NMN -- Node Management Network
+
+            When upgrading to this version of BOS, all existing V1 session
+            templates will automatically have this deprecated field removed from them.
+
+            When a V1 session template is created, this deprecated field is
+            automatically removed from it before storing it in BOS.
           pattern: '^[nN][mM][nN]$'
         boot_ordinal:
           type: integer
+          deprecated: true
           minimum: 0
           description: |
             The boot ordinal. This will establish the order for Boot Set operations.
@@ -667,10 +687,14 @@ components:
 
             It is recommended that this should have a maximum value of 65535.
 
-            This restriction is not enforced in this version of BOS, but it is
-            targeted to start being enforced in an upcoming BOS version.
+            When upgrading to this version of BOS, all existing V1 session
+            templates will automatically have this deprecated field removed from them.
+
+            When a V1 session template is created, this deprecated field is
+            automatically removed from it before storing it in BOS.
         shutdown_ordinal:
           type: integer
+          deprecated: true
           minimum: 0
           description: |
             The shutdown ordinal. This will establish the order for Boot Set
@@ -678,8 +702,11 @@ components:
 
             It is recommended that this should have a maximum value of 65535.
 
-            This restriction is not enforced in this version of BOS, but it is
-            targeted to start being enforced in an upcoming BOS version.
+            When upgrading to this version of BOS, all existing V1 session
+            templates will automatically have this deprecated field removed from them.
+
+            When a V1 session template is created, this deprecated field is
+            automatically removed from it before storing it in BOS.
       additionalProperties: false
       required: [path, type]
     V1SessionTemplateUuid:
@@ -693,9 +720,6 @@ components:
         * 1-127 characters in length.
         * Use only letters, digits, periods (.), dashes (-), and underscores (_).
         * Begin and end with a letter or digit.
-
-        These restrictions are not enforced in this version of BOS, but they are
-        targeted to start being enforced in an upcoming BOS version.
       minLength: 1
       example: "my-session-template"
       deprecated: true
@@ -706,6 +730,12 @@ components:
         A Session Template is used to create a Session which when combined with an
         action (i.e. boot, configure, reboot, shutdown) will create a Kubernetes BOA job
         to complete the required tasks for the operation.
+
+        When upgrading to this version of BOS, all existing V1 session templates
+        will automatically have all deprecated fields removed from them.
+
+        When a V1 session template is created, all deprecated fields are automatically
+        removed from it before storing it in BOS.
 
         ## Link Relationships
 
@@ -725,13 +755,17 @@ components:
           $ref: '#/components/schemas/V1CfsParameters'
         partition:
           type: string
+          deprecated: true
           description: |
             The machine partition to operate on.
 
             It is recommended that this should be 1-255 characters in length.
 
-            This restriction is not enforced in this version of BOS, but it is
-            targeted to start being enforced in an upcoming BOS version.
+            When upgrading to this version of BOS, all existing V1 session
+            templates will automatically have this deprecated field removed from them.
+
+            When a V1 session template is created, this deprecated field is
+            automatically removed from it before storing it in BOS.
         boot_sets:
           type: object
           description: |
@@ -743,13 +777,8 @@ components:
             * Boot Set names should be 1-127 characters in length.
             * Boot Set names should use only letters, digits, periods (.), dashes (-), and underscores (_).
             * Boot Set names should begin and end with a letter or digit.
-
-            These restrictions are not enforced in this version of BOS, but they are
-            targeted to start being enforced in an upcoming BOS version.
           additionalProperties:
             $ref: '#/components/schemas/V1BootSet'
-        links:
-          $ref: '#/components/schemas/LinkListReadOnly'
       required: [name]
       additionalProperties: false
     V1BoaKubernetesJob:

--- a/src/bos/server/controllers/v1/sessiontemplate.py
+++ b/src/bos/server/controllers/v1/sessiontemplate.py
@@ -56,8 +56,9 @@ EXAMPLE_SESSION_TEMPLATE = {
         "configuration": "desired-cfs-config"},
     "enable_cfs": True}
 
-V1_SPECIFIC_ST_FIELDS = [ "cfs_url", "cfs_branch", "partition" ]
-V1_SPECIFIC_BOOTSET_FIELDS = [ "network", "boot_ordinal", "shutdown_ordinal" ]
+V1_SPECIFIC_ST_FIELDS = [ "cfs_branch", "cfs_url", "partition" ]
+V1_SPECIFIC_CFS_FIELDS = [ "branch", "clone_url", "commit", "playbook" ]
+V1_SPECIFIC_BOOTSET_FIELDS = [ "boot_ordinal", "network", "shutdown_ordinal" ]
 
 def sanitize_xnames(st_json):
     """
@@ -85,10 +86,13 @@ def strip_v1_only_fields(template_data):
     Returns False if nothing was removed.
     """
     changes_made=False
+
     # Strip out the v1-specific fields from the dictionary
     for v1_field_name in V1_SPECIFIC_ST_FIELDS:
         try:
             del template_data[v1_field_name]
+            LOGGER.info("Stripped %s field from session template %s", v1_field_name,
+                        template_data.get("name", ""))
             changes_made=True
         except KeyError:
             pass
@@ -100,9 +104,23 @@ def strip_v1_only_fields(template_data):
             for v1_bs_field_name in V1_SPECIFIC_BOOTSET_FIELDS:
                 try:
                     del bs[v1_bs_field_name]
+                    LOGGER.info("Stripped %s field from a boot set in session template %s",
+                                v1_bs_field_name, template_data.get("name", ""))
                     changes_made=True
                 except KeyError:
                     pass
+
+    # Do the same for the cfs field, if present
+    if "cfs" in template_data:
+        cfs_data = template_data["cfs"]
+        for v1_cfs_field_name in V1_SPECIFIC_CFS_FIELDS:
+            try:
+                del cfs_data[v1_cfs_field_name]
+                LOGGER.info("Stripped cfs.%s field from session template %s", v1_cfs_field_name,
+                            template_data.get("name", ""))
+                changes_made=True
+            except KeyError:
+                pass
 
     return changes_made
 


### PR DESCRIPTION
## Summary and Scope

I overlooked a couple of deprecated V1 fields in my changes for [CASMCMS-8799](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8799). Specifically, while I covered `cfs_url` and `cfs_branch` at the session template level, I did not address the deprecated fields within the `cfs` field of the session template.

This PR takes care of that, as well:
* Makes a few updates to the description fields of the API spec to explicitly state which fields are automatically removed in this version of BOS.
* Removes the now-superfluous read-only `links` field from the V1SessionTemplate schema, since that schema is now never used to return information from BOS, and is only used to validate session templates being created by the user. Thus, read-only fields will never exist. (plus, I don't think we ever populated the links for session templates anyway, as best I can recall)
* Updates the API spec to mark the `boot_ordinal`, `network`, `shutdown_ordinal`, and `partition` fields as deprecated.
* Because BOS v1 is being removed in CSM 1.6, for all of the v1 deprecated fields, I updated the API spec and removed the part of the description text which stated that its limits would be enforced in an upcoming version of BOS (since that will not be the case).

## Issues and Related PRs

* Continuation of the work from [CASMCMS-8799](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8799)

## Testing

I tested this on mug and verified that the migration code now correctly handles the cfs sub-fields, as does the v1 session template creation.
