### PR TITLE
CASMTRIAGE-5820: Fix for HSM query handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.26] - 09-19-2023
+### Fixed
+- Fixed HSM query handling to prevent errors from querying with an empty list nodes.
+
 ## [2.0.25] - 2023-07-18
 ### Dependencies
 - Bump `PyYAML` from 6.0 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601

--- a/src/bos/operators/utils/clients/hsm.py
+++ b/src/bos/operators/utils/clients/hsm.py
@@ -80,6 +80,8 @@ def read_all_node_xnames():
 
 def get_components(node_list, enabled=None):
     """Get information for all list components HSM"""
+    if not node_list:
+        return []
     session = requests_retry_session()
     try:
         payload = {'ComponentIDs': node_list}


### PR DESCRIPTION
(cherry picked from commit ce67e85f141dbbc7cd853973c23e72cbe7329925)

## Summary and Scope

BOS queries HSM with a blank set of nodes which causes it to return a 400 response.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Yes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves: 
** [CASMTRIAGE-5820](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5820)
** [CASMTRIAGE-6045](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6045)
* Change will also be needed in `support/2.0`

## Testing

Debugged it on Gamora. It will be tested once IUF is rerun on gamora.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

