### PR TITLE
CASMCMS-8830: Fix return type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Return the correct object from hsm's get_components call when there are no nodes in the session.
+
 ## [2.9.0] - 09-29-2023
 ### Changed
 - Update the spire-agent path

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -124,6 +124,8 @@ class Session:
                 for component_id in components:
                     data.append(self._operate(component_id, boot_set))
                 all_component_ids += components
+            if not all_component_ids:
+                raise SessionSetupException("No nodes were found to act upon.")
         except Exception as err:
             raise SessionSetupException(err)
         else:
@@ -160,7 +162,7 @@ class Session:
             nodes = set(hsmfilter._filter(list(nodes)))
         nodes = self._apply_tenant_limit(nodes)
         if not nodes:
-            self._log(LOGGER.warning, "No nodes were found to act on.")
+            self._log(LOGGER.warning, "No nodes were found to act upon.")
         return nodes
 
     def _apply_arch(self, nodes, arch):

--- a/src/bos/operators/utils/clients/hsm.py
+++ b/src/bos/operators/utils/clients/hsm.py
@@ -78,10 +78,47 @@ def read_all_node_xnames():
         raise HWStateManagerException(ke) from ke
 
 
-def get_components(node_list, enabled=None):
-    """Get information for all list components HSM"""
+def get_components(node_list, enabled=None) -> dict[str,list[dict]]:
+    """
+    Get information for all list components HSM
+
+    :return the HSM components
+    :rtype Dictionary containing a 'Components' key whose value is a list
+    containing each component, where each component is itself represented by a
+    dictionary.
+
+    Here is an example of the returned values.
+    {
+    "Components": [
+        {
+        "ID": "x3000c0s19b1n0",
+        "Type": "Node",
+        "State": "Ready",
+        "Flag": "OK",
+        "Enabled": true,
+        "Role": "Compute",
+        "NID": 1,
+        "NetType": "Sling",
+        "Arch": "X86",
+        "Class": "River"
+        },
+        {
+        "ID": "x3000c0s19b2n0",
+        "Type": "Node",
+        "State": "Ready",
+        "Flag": "OK",
+        "Enabled": true,
+        "Role": "Compute",
+        "NID": 1,
+        "NetType": "Sling",
+        "Arch": "X86",
+        "Class": "River"
+        }
+    ]
+    }
+    """
     if not node_list:
-        return []
+        return {'Components': []}
     session = requests_retry_session()
     try:
         payload = {'ComponentIDs': node_list}


### PR DESCRIPTION
## Summary and Scope

When there are no nodes in a session due to them being eliminated for one reason or another, ensure that hsm.py's get_components method returns the expected type of object.

In the case that there are no nodes within a session to act upon, raise an exception, so that the session is marked as having failed and has its error attribute filled in appropriately.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8830](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8830)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Mug`

### Test description:


I created BOS sessions containing no nodes and saw that the sessions had an error saying they contained no nodes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

