### PR TITLE
CASMCMS-8835: Do not prematurely filter out disabled nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
+- Make the include_disabled option work as intended.
 - Return the correct object from hsm's get_components call when there are no nodes in the session.
 
 ## [2.9.0] - 09-29-2023

--- a/src/bos/operators/power_off_forceful.py
+++ b/src/bos/operators/power_off_forceful.py
@@ -53,7 +53,7 @@ class ForcefulPowerOffOperator(BaseOperator):
             BOSQuery(enabled=True, status=','.join([Status.power_off_forcefully_called,
                                                     Status.power_off_gracefully_called])),
             TimeSinceLastAction(seconds=options.max_power_off_wait_time),
-            HSMState(enabled=True),
+            HSMState(),
         ]
 
     def _act(self, components):

--- a/src/bos/operators/power_off_graceful.py
+++ b/src/bos/operators/power_off_graceful.py
@@ -49,7 +49,7 @@ class GracefulPowerOffOperator(BaseOperator):
     def filters(self):
         return [
             BOSQuery(enabled=True, status=Status.power_off_pending),
-            HSMState(enabled=True),
+            HSMState(),
         ]
 
     def _act(self, components):

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -55,7 +55,7 @@ class PowerOnOperator(BaseOperator):
     def filters(self):
         return [
             BOSQuery(enabled=True, status=Status.power_on_pending),
-            HSMState(enabled=True)
+            HSMState()
         ]
 
     def _act(self, components):

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -184,7 +184,7 @@ class Session:
         valid_archs = set([arch])
         if arch == 'X86':
             valid_archs.add('UNKNOWN')
-        hsm_filter = HSMState(enabled=True)
+        hsm_filter = HSMState()
         return set(hsm_filter.filter_by_arch(nodes, valid_archs))
 
     def _apply_limit(self, nodes):


### PR DESCRIPTION
## Summary and Scope

To truly allow the 'include_disabled' nodes capability, the power operators cannot filter out the disabled nodes. This mod removes that filter. The session's 'include_disabled' nodes attribute will be used in the session setup operator to decide whether the nodes will be enabled in BOS or not. If disabled nodes are not included, then they will never be enabled and never acted upon. Thus, including them in the query to HSM will not hurt anything because they will never be acted upon.

When filtering nodes by architecture, do not also filter by whether the nodes are enabled in HSM. This is done at a later step in the process. Doing this earlier thwarts the later filtering.


_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8835](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8835)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Mug`

### Test description:

I disabled some nodes and launched BOS sessions with the include_disabled attribute set to true. I saw that these nodes were passed along to PCS, which happily rebooted them despite them being disabled in HSM.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

