### PR TITLE
CASMTRIAGE-6176: Fix error when filtering for architecture on an empty node list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Make the include_disabled option work as intended.
 - Return the correct object from hsm's get_components call when there are no nodes in the session.
+- Fixed session setup errors when there are no valid nodes before filtering for architecture.
 
 ## [2.9.0] - 09-29-2023
 ### Changed

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -181,6 +181,8 @@ class Session:
         returns:
           A set representing the subset of nodes that match arch, or the logical arch from HSM.
         """
+        if not nodes:
+            return nodes
         valid_archs = set([arch])
         if arch == 'X86':
             valid_archs.add('UNKNOWN')


### PR DESCRIPTION
## Summary and Scope

Filtering on architecture was throwing an error when filtering an empty list because HSM doesn't return the same data structure when you ask for an empty list of nodes.

## Issues and Related PRs

* Resolves CASMTRIAGE-6176

## Testing

### Tested on:

Mug

### Test description:

Ran a session with no valid nodes and validated the output

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

