### PR TITLE
CASMCMS-8451: Fail sessions that specify nodes that are not in the tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Sessions the specify nodes that aren't in the current tenant will fail
+- Sessions that specify nodes that aren't in the current tenant will fail
 
 ## [2.10.1] - 2023-10-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Sessions the specify nodes that aren't in the current tenant will fail
 
 ## [2.10.1] - 2023-10-31
 ### Fixed

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -137,6 +137,13 @@ class Session:
         # Populate from nodelist
         for node_name in boot_set.get('node_list', []):
             nodes.add(node_name)
+        if nodes:
+            tenant_nodes = self._apply_tenant_limit(nodes)
+            if nodes != tenant_nodes:
+                invalid_nodes = ",".join(list(nodes.difference(tenant_nodes)))
+                raise SessionSetupException(
+                    f"The session template includes nodes which do not exist"
+                    f" or are not available to this tenant: {invalid_nodes}")
         # Populate from node_groups
         for group_name in boot_set.get('node_groups', []):
             if group_name not in self.inventory.groups:

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -196,7 +196,7 @@ def patch_v2_components_list(data):
             component_id = component_data['id']
             if component_id not in DB or not _is_valid_tenant_component(component_id):
                 return connexion.problem(
-                    status=404, title="Component could not found.",
+                    status=404, title="Component not found.",
                     detail="Component {} could not be found".format(component_id))
             components.append((component_id, component_data))
     except Exception as err:
@@ -251,7 +251,7 @@ def get_v2_component(component_id):
     LOGGER.debug("GET /components/id invoked get_component")
     if component_id not in DB or not _is_valid_tenant_component(component_id):
         return connexion.problem(
-            status=404, title="Component could not found.",
+            status=404, title="Component not found.",
             detail="Component {} could not be found".format(component_id))
     component = DB.get(component_id)
     component = _set_status(component)
@@ -281,7 +281,7 @@ def patch_v2_component(component_id):
     LOGGER.debug("PATCH /components/id invoked patch_component")
     if component_id not in DB or not _is_valid_tenant_component(component_id):
         return connexion.problem(
-            status=404, title="Component could not found.",
+            status=404, title="Component not found.",
             detail="Component {} could not be found".format(component_id))
     try:
         data = connexion.request.get_json()
@@ -325,7 +325,7 @@ def delete_v2_component(component_id):
     LOGGER.debug("DELETE /components/id invoked delete_component")
     if component_id not in DB or not _is_valid_tenant_component(component_id):
         return connexion.problem(
-            status=404, title="Component could not found.",
+            status=404, title="Component not found.",
             detail="Component {} could not be found".format(component_id))
     return DB.delete(component_id), 204
 


### PR DESCRIPTION
## Summary and Scope

Sessions that specify nodes in the node list that are not available to that tenant will now fail with an appropriate error message and the list of bad nodes.
* Only nodes in the node_list are considered.  groups and roles containing other nodes are still considered valid and will just filter out the invalid nodes
* There is no error if the limit includes invalid nodes.  The limit is a way of filtering down nodes and cannot add nodes so it is not considered to be requesting a specific node.

Also fixes some grammar in other error messages

## Issues and Related PRs

* Resolves CASMCMS-8451

## Testing

### Tested on:

  * mug

### Test description:

Tested sessions with valid and invalid nodes

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

