### PR TITLE
CASMCMS-8865: Modify delete_v2_sessions function to use tenant-aware DB key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.10.1] - 2023-10-31
 ### Fixed
-- Update delete_v2_sessions function to use template-aware database keys (so that it actually
+- Update delete_v2_sessions function to use tenant-aware database keys (so that it actually
   deletes sessions)
 
 ## [2.10.0] - 2023-10-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
-## [2.10.0] - 10-18-2023
+## [2.10.1] - 2023-10-31
+### Fixed
+- Update delete_v2_sessions function to use template-aware database keys (so that it actually
+  deletes sessions)
+
+## [2.10.0] - 2023-10-18
 ### Fixed
 - Make the include_disabled option work as intended.
 - Return the correct object from hsm's get_components call when there are no nodes in the session.
 - Fixed session setup errors when there are no valid nodes before filtering for architecture.
 
-## [2.9.0] - 09-29-2023
+## [2.9.0] - 2023-09-29
 ### Changed
 - Update the spire-agent path
 
-## [2.8.0] - 09-18-2023
+## [2.8.0] - 2023-09-18
 ### Changed
 - Update the changes made for `2.7.0` below to include the deprecated sub-fields of the `cfs`
   field in v1 session templates.
@@ -30,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   such (`partition`, `boot_ordinal`, `network`, and `shutdown_ordinal`). These fields already had no
   effect and thus were effectively deprecated anyway.
 
-## [2.7.0] - 09-12-2023
+## [2.7.0] - 2023-09-12
 ### Changed
 - Removed non-v2 fields from v1 session template template
 - Provide more useful example values in v1 and v2 session template templates
@@ -42,23 +47,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update BOS migration code to properly convert v1 session templates to v2, both from old Etcd database and within
   current redis DB.
 
-## [2.6.3] - 08-22-2023
+## [2.6.3] - 2023-08-22
 ### Changed
 Updated `bos-reporter` spec file to reflect the fact that it should not be installed without `spire-agent` being present.
 
-## [2.6.2] - 08-14-2023
+## [2.6.2] - 2023-08-14
 ### Fixed
 Fixed HSM query handling to prevent errors from querying with an empty list nodes.
 
-## [2.6.1] - 08-10-2023
+## [2.6.1] - 2023-08-10
 ### Fixed
 Fixed database key migration when upgrading from newer versions of BOS.
 
-## [2.6.0] - 08-09-2023
+## [2.6.0] - 2023-08-09
 ### Changed
 - Build `bos-reporter` RPM as `noos`
 
-## [2.5.6] - 08-08-2023
+## [2.5.6] - 2023-08-08
 ### Changed
 - IsAlive attribute look-up.
 ### Added


### PR DESCRIPTION
## Summary and Scope

When the v2 sessions database was modified to use tenant-aware keys, the delete_v2_sessions function was overlooked. It still used the session name as the database key. As a consequence, it no longer deleted any sessions when it was called, regardless of the filters that were set.

This PR corrects the above, and also makes a couple of other small adjustments to that function:
* Modifies it so that it more closely mirrors the behavior of the regular delete_v2_session function (in terms of its order of operations -- deleting the status DB entry first, then the regular DB entry).
* Removes redundant calls to the get_tenant_from_header function
* Relocates code from the try: clause which is not really part of it (since the try clause is only looking for exceptions related to parsing the filter strings)
* Adds a logger message to the top of the function, to match similar functions in the module

## Issues and Related PRs

* This change should have gone in with commit 501ea3174b5f7a4422f6ec80a735594094ea2d14 (when tenant-aware keys were implemented)

## Testing

I have tested the changes on mug (where I originally found the bug) and validated that the function now behaves as it should.

## Risks and Mitigations

Without this change, this will be a regression bug in CSM 1.5

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
