### PR TITLE
CASMCMS-8879: Fix build issue caused by PEP-668

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Fix a broken build caused by PEP-668.
+
 ## [2.11.0] - 2023-12-04
 ### Changed
 - Sessions that specify nodes that aren't in the current tenant will fail

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,13 @@ COPY constraints.txt requirements.txt /app/
 RUN apk add --upgrade --no-cache apk-tools busybox && \
     apk update && \
     apk add --no-cache gcc g++ python3-dev py3-pip musl-dev libffi-dev openssl-dev && \
-    apk -U upgrade --no-cache && \
-    pip3 install --no-cache-dir -U pip
+    apk -U upgrade --no-cache
+# Create a virtual environment in which we can install Python packages. This
+# isolates our installation from the system installation.
+ENV VIRTUAL_ENV=/app/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip3 install --no-cache-dir -U pip
 RUN --mount=type=secret,id=netrc,target=/root/.netrc pip3 install --no-cache-dir -r requirements.txt
 RUN cd lib && pip3 install --no-cache-dir .
 
@@ -87,7 +92,7 @@ CMD [ "./docker_api_test_entry.sh" ]
 FROM base as intermediate
 WORKDIR /app
 EXPOSE 9000
-RUN apk add --no-cache uwsgi-python3
+RUN pip3 install --no-cache-dir uWSGI
 COPY config/uwsgi.ini ./
 ENTRYPOINT ["uwsgi", "--ini", "/app/uwsgi.ini"]
 


### PR DESCRIPTION
## Summary and Scope

PEP-668 allows file systems to be labeled as 'externally managed'. Pip will see this label and refuse to install into any directory thusly labeled. The idea is to prevent pip from installing its packages into a directory that the operating system owns.

To install files correctly, I utilize a virtual environment and install them into there. The PATH variable is modified to point first at this virtual environment.

uwsgi is installed into this virtual environment and run out of there rather than being run from the operating system.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8879](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8879)
* Change will also be needed in `master`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`
  * Build pipeline

### Test description:

First and foremost, it successfully built. Second, I imported it onto mug and ran it there where it successfully ran.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? Yes, I did a helm upgrade.
- Was downgrade tested? If not, why? Yes, I did a helm downgrade.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations
Low. It didn't build before. Now it does. It doesn't get less broken than that.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

