### PR TITLE
Casmcms 8778 Add Scalable Boot Provisioning Service (SBPS) support aka iSCSI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Scalable Boot Provisioning Service (SBPS) support
 ### Fixed
 - Fix a broken build caused by PEP-668.
 

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -281,6 +281,14 @@ class Session:
             return state
 
     def _get_state_from_boot_set(self, boot_set):
+        """
+        Returns:
+          state: A dictionary containing two keys 'boot_artifacts' and 'configuration'.
+            'boot_artifacts' is itself a dictionary containing key/value pairs where the keys are the
+            boot artifacts (kernel, initrd, rootfs, and boot parameters) and the values are paths to
+            those artifacts in storage.
+            'configuration' is a string.
+        """
         state = {}
         boot_artifacts = {}
         image_metadata = BootImageMetaDataFactory(boot_set)()
@@ -324,6 +332,12 @@ class Session:
         Warning: We need to ensure that the 'root' parameter exists and is set correctly.
         If any of the parameter locations are empty, they are simply not used.
 
+        Inputs:
+            boot_set: A boot set from the session template data
+            artifact_info: The artifact summary from the boot_set.
+                           This is a dictionary containing keys which are boot artifacts (kernel, initrd, roots, and kernel boot parameters).
+                           The values are the paths to those boot artifacts in S3.
+                           It also contains the etags for the rootfs and kerenl boot parameters.
         Returns:
             A string containing the needed kernel boot parameters
 

--- a/src/bos/operators/utils/boot_image_metadata/s3_boot_image_metadata.py
+++ b/src/bos/operators/utils/boot_image_metadata/s3_boot_image_metadata.py
@@ -88,10 +88,11 @@ class S3BootImageMetaData(BootImageMetaData):
         Get the kernel object
         As an example, the object looks like this
         {'link': {'etag': 'dcaa006fdd460586e62f9ec44e7f61cf',
-                               'path': 's3://boot-images/1fb58f4e-ad23-489b-89b7-95868fca7ee6/boot_parameters',
-                               'type': 's3'},
-                      'md5': 'dcaa006fdd460586e62f9ec44e7f61cf',
-                      'type': 'application/vnd.cray.image.parameters.boot'}
+                  'path': 's3://boot-images/1fb58f4e-ad23-489b-89b7-95868fca7ee6/kernel',
+                  'type': 's3'},
+         'md5': 'dcaa006fdd460586e62f9ec44e7f61cf',
+         'type': 'application/vnd.cray.image.parameters.boot'
+        }
         """
         return self.boot_artifacts.kernel
 
@@ -101,10 +102,11 @@ class S3BootImageMetaData(BootImageMetaData):
         Get the initrd object
         As an example, the object looks like this
         {'link': {'etag': 'be2927a765c88558370ee1c5edf1c50c-3',
-                      'path': 's3://boot-images/1fb58f4e-ad23-489b-89b7-95868fca7ee6/initrd',
-                      'type': 's3'},
-             'md5': 'aa69151d7fe8dcb66d74cbc05ef3e7cc',
-             'type': 'application/vnd.cray.image.initrd'}
+                  'path': 's3://boot-images/1fb58f4e-ad23-489b-89b7-95868fca7ee6/initrd',
+                  'type': 's3'},
+         'md5': 'aa69151d7fe8dcb66d74cbc05ef3e7cc',
+         'type': 'application/vnd.cray.image.initrd'
+        }
         """
         return self.boot_artifacts.initrd
 
@@ -114,10 +116,11 @@ class S3BootImageMetaData(BootImageMetaData):
         Get the boot parameters object
         As an example, the object looks like this
         {'link': {'etag': 'dcaa006fdd460586e62f9ec44e7f61cf',
-                               'path': 's3://boot-images/1fb58f4e-ad23-489b-89b7-95868fca7ee6/boot_parameters',
-                               'type': 's3'},
-                      'md5': 'dcaa006fdd460586e62f9ec44e7f61cf',
-                      'type': 'application/vnd.cray.image.parameters.boot'}
+                  'path': 's3://boot-images/1fb58f4e-ad23-489b-89b7-95868fca7ee6/boot_parameters',
+                  'type': 's3'},
+         'md5': 'dcaa006fdd460586e62f9ec44e7f61cf',
+         'type': 'application/vnd.cray.image.parameters.boot'
+        }
         """
         return self.boot_artifacts.boot_parameters
 
@@ -127,10 +130,11 @@ class S3BootImageMetaData(BootImageMetaData):
         Get the rootfs object
         As an example, the object looks like this
         {'link': {'etag': 'f04af5f34635ae7c507322985e60c00c-131',
-                      'path': 's3://boot-images/1fb58f4e-ad23-489b-89b7-95868fca7ee6/rootfs',
-                      'type': 's3'},
-             'md5': 'e7d60fdcc8a2617b872a12fcf76f9d53',
-             'type': 'application/vnd.cray.image.rootfs.squashfs'}
+                  'path': 's3://boot-images/1fb58f4e-ad23-489b-89b7-95868fca7ee6/rootfs',
+                  'type': 's3'},
+         'md5': 'e7d60fdcc8a2617b872a12fcf76f9d53',
+         'type': 'application/vnd.cray.image.rootfs.squashfs'
+        }
         """
         return self.boot_artifacts.rootfs
 

--- a/src/bos/operators/utils/rootfs/__init__.py
+++ b/src/bos/operators/utils/rootfs/__init__.py
@@ -56,7 +56,7 @@ class RootfsProvider(object):
 
     def __str__(self):
         """
-        The value to add to the boot parameter.
+        The value to add to the 'root=' kernel boot parameter.
         """
         fields = []
         if self.PROTOCOL:

--- a/src/bos/operators/utils/rootfs/baserootfs.py
+++ b/src/bos/operators/utils/rootfs/baserootfs.py
@@ -22,13 +22,36 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 '''
-Provisioning mechanism unique to the ContentProjectionService; this is software
-that is often installed as part of Cray CME images in both standard, enhanced
-and premium offerings; the underlying implementation of CPS may be handled by
-another protocol (iSCSI or DVS) depending on the product.
+Provisioning mechanism, base class
+The assumption is the artifact info contains information about the rootfs.
 '''
 
-from .baserootfs import BaseRootfsProvider
+from . import RootfsProvider
 
-class CPSS3Provider(BaseRootfsProvider):
-    PROTOCOL = 'craycps-s3'
+class BaseRootfsProvider(RootfsProvider):
+
+    PROTOCOL = None
+
+    @property
+    def provider_field(self):
+        return self.artifact_info['rootfs']
+
+    @property
+    def provider_field_id(self):
+        return self.artifact_info['rootfs_etag']
+
+    @property
+    def nmd_field(self):
+        """
+        The value to add to the kernel boot parameters for Node Memory Dump (NMD)
+        parameter.
+        """
+        fields = []
+        if self.provider_field:
+            fields.append("url=%s" % self.provider_field)
+        if self.provider_field_id:
+            fields.append("etag=%s" % self.provider_field_id)
+        if fields:
+            return "nmd_data={}".format(",".join(fields))
+        else:
+            return ''

--- a/src/bos/operators/utils/rootfs/factory.py
+++ b/src/bos/operators/utils/rootfs/factory.py
@@ -34,6 +34,13 @@ class ProviderFactory(object):
     a given agent instance.
     """
     def __init__(self, boot_set, artifact_info):
+        """
+        Inputs:
+            boot_set: A boot set from the session template data
+            artifact_info: The artifact summary from the boot_set.
+                           This is a dictionary containing keys which are boot artifacts (kernel, initrd, roots, and kernel boot parameters)
+                           the values are the paths to those boot artifacts in S3. It also contains the etags for the rootfs and kerenl boot parameters.
+        """
         self.boot_set = boot_set
         self.artifact_info = artifact_info
 

--- a/src/bos/operators/utils/rootfs/sbps.py
+++ b/src/bos/operators/utils/rootfs/sbps.py
@@ -22,13 +22,10 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 '''
-Provisioning mechanism unique to the ContentProjectionService; this is software
-that is often installed as part of Cray CME images in both standard, enhanced
-and premium offerings; the underlying implementation of CPS may be handled by
-another protocol (iSCSI or DVS) depending on the product.
+Provisioning mechanism using the Scalable Boot Provisioning Service
 '''
 
 from .baserootfs import BaseRootfsProvider
 
-class CPSS3Provider(BaseRootfsProvider):
-    PROTOCOL = 'craycps-s3'
+class SBPSProvider(BaseRootfsProvider):
+    PROTOCOL = 'sbps-s3'


### PR DESCRIPTION
## Summary and Scope

Scalable Boot Provisioning Service (SBPS) support added

    To support the Scalable Boot Provisioning Service (SBPS), two new
    classes were created, SBPSProvider and a  base class BaseRootfsProvider.

## Issues and Related PRs


* Resolves [CASMCMS-8778](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8778)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * mug

### Test description:

I booked some nodes with the following session template.
{
  "boot_sets": {
    "name_your_boot_set": {
      "etag": "",
      "kernel_parameters": "console=ttyS0,115200 bad_page=panic crashkernel=512M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu.passthrough=on modprobe.blacklist=amdgpu numa_interleave_omit=headless oops=panic pageblock_order=14 rd.live.ram=1 rd.neednet=1 rd.retry=10 rd.shell split_lock_detect=off systemd.unified_cgroup_hierarchy=1 ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} root=live:s3://boot-images/00d18ed1-20a3-4df2-affb-a88fda00b6f6/rootfs psi=1",
      "node_list": [
        "x3000c0s19b1n0",
        "x3000c0s19b2n0",
        "x3000c0s19b3n0"
      ],
      "path": "s3://boot-images/00d18ed1-20a3-4df2-affb-a88fda00b6f6/manifest.json",
      "rootfs_provider": "sbps",
      "rootfs_provider_passthrough": "sbps:v1:iqn.2023-06.csm.iscsi:_sbps-nmn._tcp.local:300",
      "type": "s3"
    }
  },
  "cfs": {
    "configuration": ""
  },
  "enable_cfs": false
}

The expected kernel parameters were supplied to the node.

      "kernel_parameters": "console=ttyS0,115200 bad_page=panic crashkernel=512M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu.passthrough=on modprobe.blacklist=amdgpu numa_interleave_omit=headless oops=panic pageblo
ck_order=14 rd.live.ram=1 rd.neednet=1 rd.retry=10 rd.shell split_lock_detect=off systemd.unified_cgroup_hierarchy=1 ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} root=sbps-s3:s3://boot-images/00d18ed1-20a3-4df2-affb-a88fda00b6
f6/rootfs:66fc6d45ae64bc57babc976d575498ff-202:sbps:v1:iqn.2023-06.csm.iscsi:_sbps-nmn._tcp.local:300 nmd_data=url=s3://boot-images/00d18ed1-20a3-4df2-affb-a88fda00b6f6/rootfs,etag=66fc6d45ae64bc57babc976d575498ff-202 bos_update_fre
quency=4h"


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Eventually
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations
Low -- if you don't select SBPS as the rootfs provider then it is never used.

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

