### PR TITLE
CASMCMS-8880: Update etcd base chart version; Pin Alpine version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [2.12.0] - 2024-01-02
+### Changed
+- Specify `~1.1.0` for the version of `cray-etcd-base` chart.
+- Pin Alpine version to `3.18` (to avoid build failures with `3.19`)
+
 ## [2.11.0] - 2023-12-04
 ### Changed
 - Sessions that specify nodes that aren't in the current tenant will fail

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023  Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 # Upstream Build Args
 ARG OPENAPI_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/openapitools/openapi-generator-cli:v6.6.0
-ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3
+ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.18
 
 # Generate Code
 FROM $OPENAPI_IMAGE as codegen

--- a/kubernetes/cray-bos/Chart.yaml.in
+++ b/kubernetes/cray-bos/Chart.yaml.in
@@ -14,7 +14,7 @@ dependencies:
   version: "~10.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 - name: cray-etcd-base
-  version: "~1.0"
+  version: "~1.1.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 description: "Kubernetes resources for the Boot Orchestration Service (BOS)"
 home: "https://github.com/Cray-HPE/bos"


### PR DESCRIPTION
## Summary and Scope

BOS builds started failing when it started using Alpine 3.19 as the base image instead of Alpine 3.18. This was happening because the Dockerfile just said to use the most recent v3 Alpine. If we eventually want to move up to Alpine 3.19 or later, we can do so after we resolve the build issues.

This PR also changes the version of the etcd base chart, to address [CASMPET-6876](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6876).

## Issues and Related PRs

* Resolves [CASMCMS-8880](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8880) (which is the BOS portion of [CASMPET-6876](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6876).)
* [CSM 1.5 backport PR](https://github.com/Cray-HPE/bos/pull/238)
* The Alpine issue exists in other CMS repos as well. I'm going to handle it in those repos using [CASMCMS-8884](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8884)

## Risks and Mitigations

Low risk -- the new etcd base chart is being used by all services, not just BOS. And BOS was already using Alpine 3.18, and has never built successfully with 3.19, so this PR just allows it to continue building as it already had been.
