### PR TITLE
CASMCMS-8880: Update etcd base chart version; Pin Alpine version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.2] - 2024-01-02
+### Changed
+- Specify `~1.0.0` for the version of `cray-etcd-base` chart.
+- Pin Alpine version to `3.18` (to avoid build failures with `3.19`)
+
 ## [2.10.1] - 2023-10-31
 ### Fixed
 - Update delete_v2_sessions function to use tenant-aware database keys (so that it actually

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023  Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 # Upstream Build Args
 ARG OPENAPI_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/openapitools/openapi-generator-cli:v6.6.0
-ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3
+ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.18
 
 # Generate Code
 FROM $OPENAPI_IMAGE as codegen

--- a/kubernetes/cray-bos/Chart.yaml.in
+++ b/kubernetes/cray-bos/Chart.yaml.in
@@ -14,7 +14,7 @@ dependencies:
   version: "~10.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 - name: cray-etcd-base
-  version: "~1.0"
+  version: "~1.0.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 description: "Kubernetes resources for the Boot Orchestration Service (BOS)"
 home: "https://github.com/Cray-HPE/bos"


### PR DESCRIPTION
CSM 1.5 backport of https://github.com/Cray-HPE/bos/pull/237