### PR TITLE
CASMCMS-8879: Unpin the Alpine version from 3.18 back to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix a broken build caused by PEP-668.
+- Fix a broken build caused by PEP-668. Pin Alpine version to 3. This is less restrictive.
 
 ## [2.12.0] - 2024-01-02
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 
 # Upstream Build Args
 ARG OPENAPI_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/openapitools/openapi-generator-cli:v6.6.0
-ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.18
+ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3
 
 # Generate Code
 FROM $OPENAPI_IMAGE as codegen


### PR DESCRIPTION
## Summary and Scope

The python virtual environment change should enable us to move ahead to later versions of Alpine 3 beyond 3.18. These later versions should not cause problems due PEP-668 because the resolution to CASMCMS-8879 fixed that issue. Pinning the version to 3.18 prevented us from encountering the PEP-668 problem because it pinned to a version of Alpine that did not introduce the issue.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS_8879]
## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Mug

### Test description:

  * The first test was that this built successfully. That is probably all that was needed, but I went further.
  * I tested this on `Mug` by installing it and seeing that the BOS operators all launched successfully.  I did not reboot any nodes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

