### PR TITLE
CASMCMS-8905: Removed unintended ability to update v2 session fields other than status and components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Scalable Boot Provisioning Service (SBPS) support
 
+### Changed
+- Removed unintended ability to update v2 session fields other than `status` and `components`.
+
 ## [2.13.0] - 2024-01-10
 ### Fixed
 - Fix a broken build caused by PEP-668. Pin Alpine version to 3. This is less restrictive.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1268,6 +1268,24 @@ components:
         status:
           $ref: '#/components/schemas/V2SessionStatus'
       additionalProperties: false
+    V2SessionUpdate:
+      description: |
+        A Session update object
+
+        ## Link Relationships
+
+        * self : The Session object
+      type: object
+      properties:
+        components:
+          type: string
+          description: |
+            A comma-separated list of nodes, representing the initial list of nodes
+            the Session should operate against.  The list will remain even if
+            other Sessions have taken over management of the nodes.
+        status:
+          $ref: '#/components/schemas/V2SessionStatus'
+      additionalProperties: false
     V2SessionArray:
       description: An array of Sessions.
       type: array
@@ -1674,7 +1692,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/V2Session'
+            $ref: '#/components/schemas/V2SessionUpdate'
     V2applyStagedRequest:
       description: A list of xnames that should have their staged Session applied.
       required: true
@@ -2611,8 +2629,10 @@ paths:
         404:
           $ref: '#/components/responses/ResourceNotFound'
     patch:
-      summary: Update a single Session
-      description: Update the state for a given Session in the BOS database
+      summary: Update status of a single Session
+      description: |
+        Update the state for a given Session in the BOS database.
+        This is intended only for internal use by the BOS service.
       tags:
         - v2
         - sessions


### PR DESCRIPTION
## Summary and Scope

The current API (in both spec and actual behavior) allows the v2 sessions PATCH call to modify pretty much any field of the session. This is not the intended behavior. In practice, this call should only be used by BOS internally, and even then it should only ever be modifying the `components` and `status` fields.

This PR modifies the API spec to reflect this, as well as the actual API behavior.

I have also made a PR to the CLI (linked in next section) to remove the sessions update path, as it is not intended to be used by administrators.

## Issues and Related PRs

* Resolves [CASMCMS-8905](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8905)
* [Cray CLI PR](https://github.com/Cray-HPE/craycli/pull/135)

## Testing

I tested the change on mug and verified that changing other fields no longer works, but that the status and components lists can still be updated. I also verified that when I created a BOS v2 session, BOS itself was still able to do the updates it needed to do.

## Risks and Mitigations

Low-ish risk. This is only going into CSM 1.6 at this point, so given that, I think that if this does cause some problem that my testing did not reveal, we should have time to catch it before we ship.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
