### PR TITLE
CASMCMS-8916: BOS v2 components patch/put: Fix bug, validate inputs, make spec more precise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated API spec to reflect the actual API behavior: a component filter must have exactly one
+  property specified (`session` or `ids`), but not both.
+- Modified API server for `v2/components`:
+  - Add minor debug logging to match what is done in `v2/sessions` methods
+  - Validate incoming component put/patch requests against the schema
+  - Gracefully handle the case where a components filter includes nonexistent component IDs
+    (instead of returning with a 500 internal server error)
 
 ## [2.14.0] - 2024-02-06
 ### Added

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -225,6 +225,10 @@ components:
       type: string
       description: An empty string value.
       enum: [ '' ]
+    EmptyStringNullable:
+      type: string
+      description: An empty string value.
+      enum: [ '' ]
     EnableCfs:
       type: boolean
       description: |
@@ -1528,10 +1532,9 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/V2Component'
-    V2ComponentsFilter:
+    V2ComponentsFilterByIds:
       description: |
-        Information for patching multiple Components.
-        If a Session name is specified, then all Components part of this Session will be patched.
+        Information for patching multiple Components by listing their IDs.
       type: object
       properties:
         ids:
@@ -1543,8 +1546,23 @@ components:
 
             This restriction is not enforced in this version of BOS, but it is
             targeted to start being enforced in an upcoming BOS version.
+          minLength: 1
+        session:
+          $ref: '#/components/schemas/EmptyStringNullable'
+      required: [ids]
+      additionalProperties: false
+    V2ComponentsFilterBySession:
+      description: |
+        Information for patching multiple Components by Session name.
+        All Components part of this Session will be patched.
+      type: object
+      properties:
+        ids:
+          $ref: '#/components/schemas/EmptyStringNullable'
         session:
           $ref: '#/components/schemas/V2SessionName'
+      required: [session]
+      additionalProperties: false
     V2ComponentsUpdate:
       description: Information for patching multiple Components.
       type: object
@@ -1552,8 +1570,11 @@ components:
         patch:
           $ref: '#/components/schemas/V2Component'
         filters:
-          $ref: '#/components/schemas/V2ComponentsFilter'
+          oneOf:
+            - $ref: '#/components/schemas/V2ComponentsFilterByIds'
+            - $ref: '#/components/schemas/V2ComponentsFilterBySession'
       required: [patch, filters]
+      additionalProperties: false
     V2ApplyStagedComponents:
       description: |
         A list of Components that should have their staged Session applied.

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,6 +30,9 @@ from bos.common.values import Phase, Action, Status, EMPTY_STAGED_STATE, EMPTY_B
 from bos.server import redis_db_utils as dbutils
 from bos.server.controllers.v2.options import get_v2_options_data
 from bos.server.dbs.boot_artifacts import get_boot_artifacts, BssTokenUnknown
+from bos.server.models.v2_component import V2Component as Component  # noqa: E501
+from bos.server.models.v2_component_array import V2ComponentArray as ComponentArray  # noqa: E501
+from bos.server.models.v2_components_update import V2ComponentsUpdate as ComponentsUpdate  # noqa: E501
 
 LOGGER = logging.getLogger('bos.server.controllers.v2.components')
 DB = dbutils.get_wrapper(db='components')
@@ -156,16 +159,34 @@ def _matches_filter(data, enabled, session, staged_session, phase, status):
 def put_v2_components():
     """Used by the PUT /components API operation"""
     LOGGER.debug("PUT /components invoked put_components")
+    if not connexion.request.is_json:
+        msg = "Must be in JSON format"
+        LOGGER.error(msg)
+        return msg, 400
+
+    LOGGER.debug("connexion.request.is_json")
+    data=connexion.request.get_json()
+    LOGGER.debug("type=%s", type(data))
+    LOGGER.debug("Received: %s", data)
+
     try:
-        data = connexion.request.get_json()
-        components = []
-        for component_data in data:
-            component_id = component_data['id']
-            components.append((component_id, component_data))
+        # This call is just to ensure that the data
+        # coming in is valid per the API schema
+        ComponentArray.from_dict(data)  # noqa: E501
     except Exception as err:
-        return connexion.problem(
-            status=400, title="Error parsing the data provided.",
-            detail=str(err))
+        msg="Provided data does not follow API spec"
+        LOGGER.exception(msg)
+        return connexion.problem(status=400, title=msg,detail=str(err))
+
+    components = []
+    for component_data in data:
+        try:
+            component_id = component_data['id']
+        except KeyError:
+            return connexion.problem(
+                status=400, title="Required field missing.",
+                detail="At least one component is missing the required 'id' field")
+        components.append((component_id, component_data))
     response = []
     for component_id, component_data in components:
         component_data = _set_auto_fields(component_data)
@@ -178,15 +199,40 @@ def put_v2_components():
 def patch_v2_components():
     """Used by the PATCH /components API operation"""
     LOGGER.debug("PATCH /components invoked patch_components")
-    data = connexion.request.get_json()
+    if not connexion.request.is_json:
+        msg = "Must be in JSON format"
+        LOGGER.error(msg)
+        return msg, 400
+
+    LOGGER.debug("connexion.request.is_json")
+    data=connexion.request.get_json()
+    LOGGER.debug("type=%s", type(data))
+    LOGGER.debug("Received: %s", data)
+
     if type(data) == list:
+        try:
+            # This call is just to ensure that the data
+            # coming in is valid per the API schema
+            ComponentArray.from_dict(data)  # noqa: E501
+        except Exception as err:
+            msg="Provided data does not follow API spec"
+            LOGGER.exception(msg)
+            return connexion.problem(status=400, title=msg,detail=str(err))
         return patch_v2_components_list(data)
     elif type(data) == dict:
+        try:
+            # This call is just to ensure that the data
+            # coming in is valid per the API schema
+            ComponentsUpdate.from_dict(data)  # noqa: E501
+        except Exception as err:
+            msg="Provided data does not follow API spec"
+            LOGGER.exception(msg)
+            return connexion.problem(status=400, title=msg,detail=str(err))
         return patch_v2_components_dict(data)
-    else:
-        return connexion.problem(
-           status=400, title="Error parsing the data provided.",
-           detail="Unexpected data type {}".format(str(type(data))))
+
+    return connexion.problem(
+        status=400, title="Error parsing the data provided.",
+        detail="Unexpected data type {}".format(str(type(data))))
 
 
 def patch_v2_components_list(data):
@@ -227,18 +273,23 @@ def patch_v2_components_dict(data):
             return connexion.problem(
                 status=400, title="Error parsing the ids provided.",
                 detail=str(err))
+        # Make sure all of the components exist and belong to this tenant (if any)
+        for component_id in id_list:
+            if component_id not in DB or not _is_valid_tenant_component(component_id):
+                return connexion.problem(
+                    status=404, title="Component not found.",
+                    detail="Component {} could not be found".format(component_id))
     elif session:
-        id_list = [component["id"] for component in get_v2_components_data(session=session)]
+        id_list = [component["id"] for component in get_v2_components_data(session=session, tenant=get_tenant_from_header())]
     else:
         return connexion.problem(
-            status=400, title="One filter must be provided.",
-            detail="Only one filter may be provided.")
+            status=400, title="Exactly one filter must be provided.",
+            detail="Exactly one filter may be provided.")
     response = []
     patch = data.get("patch")
     if "id" in patch:
         del patch["id"]
     patch = _set_auto_fields(patch)
-    id_list, _ = _apply_tenant_limit(id_list)
     for component_id in id_list:
         response.append(DB.patch(component_id, patch, _update_handler))
     return response, 200
@@ -263,12 +314,24 @@ def get_v2_component(component_id):
 def put_v2_component(component_id):
     """Used by the PUT /components/{component_id} API operation"""
     LOGGER.debug("PUT /components/id invoked put_component")
+    if not connexion.request.is_json:
+        msg = "Must be in JSON format"
+        LOGGER.error(msg)
+        return msg, 400
+
+    LOGGER.debug("connexion.request.is_json")
+    data=connexion.request.get_json()
+    LOGGER.debug("type=%s", type(data))
+    LOGGER.debug("Received: %s", data)
+
     try:
-        data = connexion.request.get_json()
+        # This call is just to ensure that the data
+        # coming in is valid per the API schema
+        Component.from_dict(data)  # noqa: E501
     except Exception as err:
-        return connexion.problem(
-            status=400, title="Error parsing the data provided.",
-            detail=str(err))
+        msg="Provided data does not follow API spec"
+        LOGGER.exception(msg)
+        return connexion.problem(status=400, title=msg,detail=str(err))
     data['id'] = component_id
     data = _set_auto_fields(data)
     return DB.put(component_id, data), 200
@@ -279,16 +342,29 @@ def put_v2_component(component_id):
 def patch_v2_component(component_id):
     """Used by the PATCH /components/{component_id} API operation"""
     LOGGER.debug("PATCH /components/id invoked patch_component")
+    if not connexion.request.is_json:
+        msg = "Must be in JSON format"
+        LOGGER.error(msg)
+        return msg, 400
+
+    LOGGER.debug("connexion.request.is_json")
+    data=connexion.request.get_json()
+    LOGGER.debug("type=%s", type(data))
+    LOGGER.debug("Received: %s", data)
+
+    try:
+        # This call is just to ensure that the data
+        # coming in is valid per the API schema
+        Component.from_dict(data)  # noqa: E501
+    except Exception as err:
+        msg="Provided data does not follow API spec"
+        LOGGER.exception(msg)
+        return connexion.problem(status=400, title=msg,detail=str(err))
+
     if component_id not in DB or not _is_valid_tenant_component(component_id):
         return connexion.problem(
             status=404, title="Component not found.",
             detail="Component {} could not be found".format(component_id))
-    try:
-        data = connexion.request.get_json()
-    except Exception as err:
-        return connexion.problem(
-            status=400, title="Error parsing the data provided.",
-            detail=str(err))
     if "actual_state" in data and not validate_actual_state_change_is_allowed(component_id):
         return connexion.problem(
             status=409, title="Actual state can not be updated.",


### PR DESCRIPTION
## Summary and Scope

This PR addresses a few issues with BOS v2 components PATCH/PUTs:

1. Currently if a PATCH request is made to the `v2/components` endpoint using a filter that includes a component ID that does not exist, BOS will respond with an internal server error. This is because on this code path, it does no validation to ensure that the IDs actually exist. This is different from if the user sends a PATCH request which is just a list of components. In that case, if any one of the components has a nonexistent ID, BOS will gracefully respond with a 404.
2. When making a PATCH request to the `v2/components` endpoint using a filter, the BOS server code requires that this filter have exactly one non-empty property specified -- either `session` or `ids`. However, this requirement is not communicated by the spec, either verbally or via the schemas.
3. The BOS server code does very little validation of the inputs that it receives for PATCH/PUT requests for v2 components (either singly or bulk operations).

This PR addresses these as follows:

1. Add code to validate that the IDs exist. If any do not, or if any belong to the wrong tenant, then return with 404 (just as the patch endpoint does when given a list of components rather than a list of IDs).
2. Update the API spec to reflect that the filter must consist of either an empty or nonexistent value for one of the two properties, and a non-empty value for the other.
3. Modify the server code so that it validates the inputs against the API spec.

## Issues and Related PRs

[CASMCMS-8916](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8916)

## Testing

I ran the updated API spec through a validator to make sure there were no syntax errors.
I deployed the updated BOS on mug and verified that the 500 server error no longer happens, and other component patch/put operations still work as expected.

## Risks and Mitigations

Risk should be fairly low. The changes to the API spec reflect only what the actual API behavior is currently enforcing. Plus, my plan is to only drop this into 1.6 and 1.5.1. In both cases, there will be ample time to find problems on live systems before anything ships.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
