### PR TITLE
CASMCMS-8944: Reduce superfluous S3 calls during BOSv2 session creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Reduce superfluous S3 calls during BOSv2 session creation.
 
 ## [2.0.29] - 03-07-2024
 ### Fixed

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,6 +22,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+import copy
 import logging
 from botocore.exceptions import ClientError
 from typing import Set
@@ -113,11 +114,18 @@ class Session:
     def _setup_components(self):
         all_component_ids = []
         data = []
+        stage = self.session_data.get("stage", False)
         try:
             for _, boot_set in self.template.get('boot_sets', {}).items():
                 components = self._get_boot_set_component_list(boot_set)
+                if not components:
+                    continue
+                if stage:
+                    state = self._generate_desired_state(boot_set, staged=True)
+                else:
+                    state = self._generate_desired_state(boot_set)
                 for component_id in components:
-                    data.append(self._operate(component_id, boot_set))
+                    data.append(self._operate(component_id, copy.deepcopy(state)))
                 all_component_ids += components
         except Exception as err:
             raise SessionSetupException(err)
@@ -199,14 +207,14 @@ class Session:
         logger('Session {}: {}'.format(self.name, message))
 
     # Operations
-    def _operate(self, component_id, boot_set):
+    def _operate(self, component_id, state):
         stage = self.session_data.get("stage", False)
         data = {"id": component_id}
         if stage:
-            data["staged_state"] = self._generate_desired_state(boot_set, staged=True)
+            data["staged_state"] = state
             data["staged_state"]["session"] = self.name
         else:
-            data["desired_state"] = self._generate_desired_state(boot_set)
+            data["desired_state"] = state
             if self.operation_type == "reboot" :
                 data["actual_state"] = EMPTY_ACTUAL_STATE
             data["session"] = self.name


### PR DESCRIPTION
When the BOS v2 session-setup operator is operating on a session with a large number of nodes, it ends up making a lot of S3 calls unnecessarily. The calls to S3 depend only on the boot sets in the session, but the current code makes the calls once per node, even if all the nodes belong to the same boot set.

This PR changes it so that the boot sets are parsed for this just once, rather than once per node.

I've tested these changes on wasp.

https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8944

Backports:
https://github.com/Cray-HPE/bos/pull/260
https://github.com/Cray-HPE/bos/pull/261