### PR TITLE
CASMCMS-8946: Correct two problems with operating on empty node lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Update base operator to handle case where all nodes to act on have exceeded their retry limit
 
 ## [2.0.30] - 03-08-2024
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Update base operator to handle case where all nodes to act on have exceeded their retry limit
+- Fix return value of CAPMC client power function when no nodes specified
 
 ## [2.0.30] - 03-08-2024
 ### Changed

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -116,6 +116,9 @@ class BaseOperator(ABC):
         LOGGER.info('Found {} components that require action'.format(len(components)))
         if self.retry_attempt_field:  # Only check for failed components if we track retries for this operator
             components = self._handle_failed_components(components)
+            if not components:
+                LOGGER.debug('After removing components that exceeded their retry limit, 0 components require action')
+                return
         for component in components:  # Unset old errors components
             component['error'] = ''
         try:

--- a/src/bos/operators/utils/clients/capmc.py
+++ b/src/bos/operators/utils/clients/capmc.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -386,7 +386,9 @@ def power(nodes: List, state: str, force: bool = True, session = None,
     """
     if not nodes:
         LOGGER.warning("power called without nodes; returning without action.")
-        return set(), {}
+        # Instantiating this with an empty dictionary is the equivalent of reporting
+        # no errors
+        return CapmcXnameOnOffReturnedError({})
 
     valid_states = ["off", "on"]
     state = state.lower()


### PR DESCRIPTION
This PR addresses two problems:

1. In the base BOS operator, when it is detecting and acting on components, up front it gets a list of components and returns if it is empty. But then it filters that list to remove any components which have exceeded their retry limits. After doing that, it does not check again to see if the list is empty, even though it may be. This PR adds a check after that filtering.

2. The CAPMC client `power` function is supposed to return a `CapmcXnameOnOffReturnedError` object. The code in the `_power_components` method in the base power operator depends on this, because it assumes the returned object will have an `error_code` attribute. However, if an empty list of nodes is passed into the `power` function, then it returns a tuple of an empty set and an empty dictionary. From the git history, this just looks like an early piece of prototyping code that never got updated. This PR changes it so that it instead returns an "empty" object of the correct kind. (I also verified that no other code calls the `power` function and for some reason depends on the current behavior)

Jira: https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8946
CSM 1.5.1 PR: https://github.com/Cray-HPE/bos/pull/264
CSM 1.6 PR: https://github.com/Cray-HPE/bos/pull/265