### PR TITLE
CASMCMS-8946: Update base operator to handle case where all nodes to act on have exceeded their retry limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Update base operator to handle case where all nodes to act on have exceeded their retry limit
 
 ## [2.15.3] - 2024-03-08
 ### Changed

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -117,6 +117,9 @@ class BaseOperator(ABC):
         LOGGER.info('Found {} components that require action'.format(len(components)))
         if self.retry_attempt_field:  # Only check for failed components if we track retries for this operator
             components = self._handle_failed_components(components)
+            if not components:
+                LOGGER.debug('After removing components that exceeded their retry limit, 0 components require action')
+                return
         for component in components:  # Unset old errors components
             component['error'] = ''
         try:


### PR DESCRIPTION
CSM 1.6 backport of https://github.com/Cray-HPE/bos/pull/263 (only the base operator part, since the CAPMC client is gone in this BOS version)
