### PR TITLE
CASMCMS-8947: Adjust uWSGI configuration to avoid plugin errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.0] - 2024-03-15
+### Changed
+- Install uWSGI using `apk` instead of `pip`; update uWSGI config file to point to Python virtualenv
+
 ## [2.15.4] - 2024-03-12
 ### Fixed
 - Update base operator to handle case where all nodes to act on have exceeded their retry limit

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ CMD [ "./docker_api_test_entry.sh" ]
 FROM base as intermediate
 WORKDIR /app
 EXPOSE 9000
-RUN pip3 install --no-cache-dir uWSGI
+RUN apk add --no-cache uwsgi uwsgi-python3
 COPY config/uwsgi.ini ./
 ENTRYPOINT ["uwsgi", "--ini", "/app/uwsgi.ini"]
 

--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -10,3 +10,4 @@ module=bos.server.__main__
 callable=app
 processes=8
 threads=16
+virtualenv=/app/venv


### PR DESCRIPTION
## Summary and Scope

On the CSM 1.6 builds of BOS (which are the first to use Alpine 3.19), I noticed that the BOS server log an error on startup:

```text
open("./python3_plugin.so"): No such file or directory [core/utils.c line 3731]
!!! UNABLE to load uWSGI plugin: Error loading shared library ./python3_plugin.so: No such file or directory !!!
```

These errors do not show up in Alpine 3.18 versions of BOS, even with the same version of uWSGI.

I don't see any obvious BOS malfunctions as a consequence of these errors, but they make me uneasy. 

After doing some research and testing, this PR correct the problem by:
1. Installing uwsgi using apk rather than pip
2. Modifying the config file to point to the Python virtual environment where BOS is installed

With these changes, the plugin error is not logged, and all of my BOS regression tests still pass.
