### PR TITLE
CASMCMS-8948: Backport selected BOSv2 fixes/improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failed components are no longer reported in the session status phase percentages.
 - Components requiring phase updates are no longer reported in the session status phase percentages.
 - Return the correct object from HSM's get_components call when there are no nodes in the session.
+- Make the include_disabled option work as intended.
 
 ## [2.0.31] - 03-12-2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Failed components are no longer reported in the session status phase percentages.
 - Components requiring phase updates are no longer reported in the session status phase percentages.
+- Return the correct object from HSM's get_components call when there are no nodes in the session.
 
 ## [2.0.31] - 03-12-2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Failed components are no longer reported in the session status phase percentages.
+- Components requiring phase updates are no longer reported in the session status phase percentages.
 
 ## [2.0.31] - 03-12-2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Failed components are no longer reported in the session status phase percentages.
 
 ## [2.0.31] - 03-12-2024
 ### Fixed

--- a/src/bos/operators/power_off_forceful.py
+++ b/src/bos/operators/power_off_forceful.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -54,7 +54,7 @@ class ForcefulPowerOffOperator(PowerOperatorBase):
             BOSQuery(enabled=True, status=','.join([Status.power_off_forcefully_called,
                                                     Status.power_off_gracefully_called])),
             TimeSinceLastAction(seconds=options.max_power_off_wait_time),
-            HSMState(enabled=True),
+            HSMState(),
         ]
 
     def _my_power(self, component_ids):

--- a/src/bos/operators/power_off_graceful.py
+++ b/src/bos/operators/power_off_graceful.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -50,7 +50,7 @@ class GracefulPowerOffOperator(PowerOperatorBase):
     def filters(self):
         return [
             BOSQuery(enabled=True, status=Status.power_off_pending),
-            HSMState(enabled=True),
+            HSMState(),
         ]
 
     def _my_power(self, component_ids):

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -56,7 +56,7 @@ class PowerOnOperator(PowerOperatorBase):
     def filters(self):
         return [
             BOSQuery(enabled=True, status=Status.power_on_pending),
-            HSMState(enabled=True)
+            HSMState()
         ]
 
     def _act(self, components):

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -127,6 +127,8 @@ class Session:
                 for component_id in components:
                     data.append(self._operate(component_id, copy.deepcopy(state)))
                 all_component_ids += components
+            if not all_component_ids:
+                raise SessionSetupException("No nodes were found to act upon.")
         except Exception as err:
             raise SessionSetupException(err)
         else:
@@ -158,7 +160,7 @@ class Session:
             hsmfilter = HSMState(enabled=True)
             nodes = set(hsmfilter._filter(list(nodes)))
         if not nodes:
-            self._log(LOGGER.warning, "No nodes were found to act on.")
+            self._log(LOGGER.warning, "No nodes were found to act upon.")
         return nodes
 
     def _apply_limit(self, nodes):

--- a/src/bos/operators/utils/clients/hsm.py
+++ b/src/bos/operators/utils/clients/hsm.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -78,10 +78,47 @@ def read_all_node_xnames():
         raise HWStateManagerException(ke) from ke
 
 
-def get_components(node_list, enabled=None):
-    """Get information for all list components HSM"""
+def get_components(node_list, enabled=None) -> dict[str,list[dict]]:
+    """
+    Get information for all list components HSM
+
+    :return the HSM components
+    :rtype Dictionary containing a 'Components' key whose value is a list
+    containing each component, where each component is itself represented by a
+    dictionary.
+
+    Here is an example of the returned values.
+    {
+    "Components": [
+        {
+        "ID": "x3000c0s19b1n0",
+        "Type": "Node",
+        "State": "Ready",
+        "Flag": "OK",
+        "Enabled": true,
+        "Role": "Compute",
+        "NID": 1,
+        "NetType": "Sling",
+        "Arch": "X86",
+        "Class": "River"
+        },
+        {
+        "ID": "x3000c0s19b2n0",
+        "Type": "Node",
+        "State": "Ready",
+        "Flag": "OK",
+        "Enabled": true,
+        "Role": "Compute",
+        "NID": 1,
+        "NetType": "Sling",
+        "Arch": "X86",
+        "Class": "River"
+        }
+    ]
+    }
+    """
     if not node_list:
-        return []
+        return {'Components': []}
     session = requests_retry_session()
     try:
         payload = {'ComponentIDs': node_list}

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -274,7 +274,7 @@ def _get_v2_session_status(session_id, session=None):
     staged_components = get_v2_components_data(staged_session=session_id)
     num_managed_components = len(components) + len(staged_components)
     if num_managed_components:
-        component_phase_counts = Counter([c.get('status', {}).get('phase') for c in components])
+        component_phase_counts = Counter([c.get('status', {}).get('phase') for c in components if c.get('enabled')])
         component_phase_counts['successful'] = len([c for c in components if c.get('status', {}).get('status') == Status.stable])
         component_phase_counts['failed'] = len([c for c in components if c.get('status', {}).get('status') == Status.failed])
         component_phase_counts['staged'] = len(staged_components)

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -274,7 +274,7 @@ def _get_v2_session_status(session_id, session=None):
     staged_components = get_v2_components_data(staged_session=session_id)
     num_managed_components = len(components) + len(staged_components)
     if num_managed_components:
-        component_phase_counts = Counter([c.get('status', {}).get('phase') for c in components if c.get('enabled')])
+        component_phase_counts = Counter([c.get('status', {}).get('phase') for c in components if (c.get('enabled') and c.get('status').get('status_override') != Status.on_hold)])
         component_phase_counts['successful'] = len([c for c in components if c.get('status', {}).get('status') == Status.stable])
         component_phase_counts['failed'] = len([c for c in components if c.get('status', {}).get('status') == Status.failed])
         component_phase_counts['staged'] = len(staged_components)


### PR DESCRIPTION
Specifically, this backports the following:
* [CASMCMS-8617](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8617): Remove failed nodes from session status phase ([source commit](https://github.com/Cray-HPE/bos/commit/c7dcfead50c5991d179c9a31f3568d083abf7372))
* [CASMCMS-8614](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8614): Remove on_hold components from session status phases ([source commit](https://github.com/Cray-HPE/bos/commit/a8d596b6e77c34da366a88664374ff8a49392b0d))
* [CASMCMS-8830](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8830): Fix return type error ([source commit](https://github.com/Cray-HPE/bos/commit/ffd36b5791bcac5806e9591d7efad709a359759b))
* [CASMCMS-8835](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8835): Do not prematurely filter out disabled nodes ([source commit](https://github.com/Cray-HPE/bos/commit/a6e9380d98c69a9ed6e801eee30d21adef8c4b59))

Some of these commits also contained changes that did not apply to BOS in CSM 1.4, such as additional architectures and multi-tenancy, so I was careful to only cherry-pick the appropriate changes.

These changes are all pretty small and confined in scope.

I tested this on wasp and did not see any problems.