### PR TITLE
CASMCMS-8952: Improve handling of no-op situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- If CAPMC `status` function is called with an empty node list, log a warning and return without
+  calling CAPMC.
 
 ## [2.0.32] - 03-21-2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- If the status operator `_run` method finds no enabled components, stop immediately, as there is
+  nothing to do.
+
 ### Fixed
 - If CAPMC `status` function is called with an empty node list, log a warning and return without
   calling CAPMC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add code to the beginning of some CFS functions to check if they have been called without
+  necessary arguments, and if so, to log a warning and return immediately.
+
 ### Changed
 - If the status operator `_run` method finds no enabled components, stop immediately, as there is
   nothing to do.

--- a/src/bos/operators/status.py
+++ b/src/bos/operators/status.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -71,14 +71,16 @@ class StatusOperator(BaseOperator):
     def _run(self) -> None:
         """ A single pass of detecting and acting on components  """
         components = self.bos_client.components.get_components(enabled=True)
+        if not components:
+            LOGGER.debug('No enabled components found')
+            return
         component_ids = [component['id'] for component in components]
         power_states, xname_status_failures = get_power_states(component_ids)
         cfs_states = self._get_cfs_components()
         updated_components = []
-        if components:
-            # Recreate these filters to pull in the latest options values
-            self.boot_wait_time_elapsed = TimeSinceLastAction(seconds=options.max_boot_wait_time)._match
-            self.power_on_wait_time_elapsed = TimeSinceLastAction(seconds=options.max_power_on_wait_time)._match
+        # Recreate these filters to pull in the latest options values
+        self.boot_wait_time_elapsed = TimeSinceLastAction(seconds=options.max_boot_wait_time)._match
+        self.power_on_wait_time_elapsed = TimeSinceLastAction(seconds=options.max_power_on_wait_time)._match
         for component in components:
             error_string = None
             node_error = xname_status_failures.nodes_in_error.get(component['id'],{})

--- a/src/bos/operators/utils/clients/capmc.py
+++ b/src/bos/operators/utils/clients/capmc.py
@@ -316,6 +316,12 @@ def status(nodes, filtertype = 'show_all', session = None):
     Raises:
       JSONDecodeError -- error decoding the CAPMC response
     """
+    if not nodes:
+        LOGGER.warning("status called without nodes; returning without action.")
+        # Instantiating CapmcXnameStatusReturnedError with an empty dictionary is
+        # the equivalent of reporting no errors
+        return {}, CapmcXnameStatusReturnedError({})
+
     endpoint = '%s/get_xname_status' % (ENDPOINT)
     status_bucket = defaultdict(set)
     session = session or requests_retry_session()

--- a/src/bos/operators/utils/clients/cfs.py
+++ b/src/bos/operators/utils/clients/cfs.py
@@ -55,6 +55,9 @@ def get_components(session=None, **kwargs):
 
 
 def patch_components(data, session=None):
+    if not data:
+        LOGGER.warning("patch_components called without data; returning without action.")
+        return
     if not session:
         session = requests_retry_session()
     LOGGER.debug("PATCH %s with body=%s", COMPONENTS_ENDPOINT, data)
@@ -69,6 +72,9 @@ def patch_components(data, session=None):
 
 
 def get_components_from_id_list(id_list):
+    if not id_list:
+        LOGGER.warning("get_components_from_id_list called without IDs; returning without action.")
+        return []
     LOGGER.debug("get_components_from_id_list called with %d IDs", len(id_list))
     session = requests_retry_session()
     component_list = []
@@ -83,6 +89,9 @@ def get_components_from_id_list(id_list):
 
 
 def patch_desired_config(node_ids, desired_config, enabled=False, tags=None, clear_state=False):
+    if not node_ids:
+        LOGGER.warning("patch_desired_config called without IDs; returning without action.")
+        return
     LOGGER.debug("patch_desired_config called on %d IDs with desired_config=%s enabled=%s tags=%s"
                  " clear_state=%s", len(node_ids), desired_config, enabled, tags, clear_state)
     session = requests_retry_session()
@@ -107,6 +116,9 @@ def patch_desired_config(node_ids, desired_config, enabled=False, tags=None, cle
 
 
 def set_cfs(components, enabled, clear_state=False):
+    if not components:
+        LOGGER.warning("set_cfs called without components; returning without action.")
+        return
     LOGGER.debug("set_cfs called on %d components with enabled=%s clear_state=%s", len(components),
                  enabled, clear_state)
     configurations = defaultdict(list)


### PR DESCRIPTION
## Summary and Scope

This PR consists of 3 parts:
1. The `_run` method of the status operator always ends up doing nothing if there are no enabled components. But currently it still ends up querying both CAPMC and CFS before it figures this out. This PR changes it so that if there are no enabled components, it just DEBUG logs that fact, and returns.
2. Add a check to the beginning of the CAPMC `status` function for the case when it is called with no nodes listed. Similar code already exists in the `power` function, and this PR basically makes equivalent code for `status`. The "empty" return values are slightly different, since the expected return values of the functions differ, but otherwise it's the same thing.
3. Adds similar checks to the beginning of a few CFS client functions. Pretty much every other client function has code like this, and I noticed that the CFS ones do not.

None of these should end up changing the actual behavior of BOS, beyond removing time consuming steps which have no purpose (which should be a bigger help on large scale systems, where some of those ultimately useless calls do take a fair amount of time to perform).

I tested this on wasp and ran through a BOS v2 session. This hits all of the good path code changes, and they look fine.
