### PR TITLE
CASMCMS-8952: Improve handling of no-op situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add code to the beginning of some CFS functions to check if they have been called without
   necessary arguments, and if so, to log a warning and return immediately.
 - Added similar code to some PCS functions.
+- Created `PowerControlComponentsEmptyException`; raise it when some PCS functions receive
+  empty component list arguments.
 
 ### Changed
 - If the status operator `_run` method finds no enabled components, stop immediately, as there is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add code to the beginning of some CFS functions to check if they have been called without
   necessary arguments, and if so, to log a warning and return immediately.
+- Added similar code to some PCS functions.
 
 ### Changed
 - If the status operator `_run` method finds no enabled components, stop immediately, as there is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add code to the beginning of some CFS functions to check if they have been called without
+  necessary arguments, and if so, to log a warning and return immediately.
+
 ### Changed
 - If the status operator `_run` method finds no enabled components, stop immediately, as there is
   nothing to do.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- If the status operator `_run` method finds no enabled components, stop immediately, as there is
+  nothing to do.
 
 ## [2.10.9] - 2024-03-20
 ### Changed

--- a/src/bos/operators/utils/clients/cfs.py
+++ b/src/bos/operators/utils/clients/cfs.py
@@ -55,6 +55,9 @@ def get_components(session=None, **kwargs):
 
 
 def patch_components(data, session=None):
+    if not data:
+        LOGGER.warning("patch_components called without data; returning without action.")
+        return
     if not session:
         session = requests_retry_session()
     LOGGER.debug("PATCH %s with body=%s", COMPONENTS_ENDPOINT, data)
@@ -69,6 +72,9 @@ def patch_components(data, session=None):
 
 
 def get_components_from_id_list(id_list):
+    if not id_list:
+        LOGGER.warning("get_components_from_id_list called without IDs; returning without action.")
+        return []
     LOGGER.debug("get_components_from_id_list called with %d IDs", len(id_list))
     session = requests_retry_session()
     component_list = []
@@ -83,6 +89,9 @@ def get_components_from_id_list(id_list):
 
 
 def patch_desired_config(node_ids, desired_config, enabled=False, tags=None, clear_state=False):
+    if not node_ids:
+        LOGGER.warning("patch_desired_config called without IDs; returning without action.")
+        return
     LOGGER.debug("patch_desired_config called on %d IDs with desired_config=%s enabled=%s tags=%s"
                  " clear_state=%s", len(node_ids), desired_config, enabled, tags, clear_state)
     session = requests_retry_session()
@@ -107,6 +116,9 @@ def patch_desired_config(node_ids, desired_config, enabled=False, tags=None, cle
 
 
 def set_cfs(components, enabled, clear_state=False):
+    if not components:
+        LOGGER.warning("set_cfs called without components; returning without action.")
+        return
     LOGGER.debug("set_cfs called on %d components with enabled=%s clear_state=%s", len(components),
                  enabled, clear_state)
     configurations = defaultdict(list)

--- a/src/bos/operators/utils/clients/pcs.py
+++ b/src/bos/operators/utils/clients/pcs.py
@@ -125,7 +125,7 @@ def status(nodes, session=None, **kwargs):
     session = session or requests_retry_session()
     power_status_all = _power_status(xname=list(nodes), session=session, **kwargs)
     for power_status_entry in power_status_all['status']:
-        # IF the returned xname has an error, it itself is the status regardless of
+        # If the returned xname has an error, it itself is the status regardless of
         # what the powerState field suggests. This is a major departure from how CAPMC handled errors.
         xname = power_status_entry.get('xname', '')
         if power_status_entry['error']:

--- a/src/bos/operators/utils/clients/pcs.py
+++ b/src/bos/operators/utils/clients/pcs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -118,9 +118,12 @@ def status(nodes, session=None, **kwargs):
       PowerControlException: Any non-nominal response from PCS.
       JSONDecodeError: Error decoding the PCS response
     """
+    status_bucket = defaultdict(set)
+    if not nodes:
+        LOGGER.warning("status called without nodes; returning without action.")
+        return status_bucket
     session = session or requests_retry_session()
     power_status_all = _power_status(xname=list(nodes), session=session, **kwargs)
-    status_bucket = defaultdict(set)
     for power_status_entry in power_status_all['status']:
         # IF the returned xname has an error, it itself is the status regardless of
         # what the powerState field suggests. This is a major departure from how CAPMC handled errors.
@@ -139,12 +142,16 @@ def node_to_powerstate(nodes, session=None, **kwargs):
     For an iterable of nodes <nodes>; return a dictionary that maps to the current power state for the node in question.
     """
     power_states = {}
+    if not nodes:
+        LOGGER.warning("node_to_powerstate called without nodes; returning without action.")
+        return power_states
     session = session or requests_retry_session()
     status_bucket = status(nodes, session, **kwargs)
     for pstatus, nodeset in status_bucket.items():
         for node in nodeset:
             power_states[node] = pstatus
     return power_states
+
 def _transition_create(xnames, operation, task_deadline_minutes=None, deputy_key=None, session=None):
     """
     Interact with PCS to create a request to transition one or more xnames. The transition
@@ -202,6 +209,10 @@ def power_on(nodes, session=None, task_deadline_minutes=1, **kwargs):
     Sends a request to PCS for transitioning nodes in question to a powered on state.
     Returns: A JSON parsed object response from PCS, which includes the created request ID.
     """
+    if not nodes:
+        # Should probably raise an exception here, since we don't want to actually call PCS
+        # with an empty node list. Suggestions welcome for what to raise.
+        LOGGER.error("power_on called with no nodes!")
     session = session or requests_retry_session()
     return _transition_create(xnames=nodes, operation='On', task_deadline_minutes=task_deadline_minutes,
                               session=session, **kwargs)
@@ -210,6 +221,10 @@ def power_off(nodes, session=None, task_deadline_minutes=1, **kwargs):
     Sends a request to PCS for transitioning nodes in question to a powered off state (graceful).
     Returns: A JSON parsed object response from PCS, which includes the created request ID.
     """
+    if not nodes:
+        # Should probably raise an exception here, since we don't want to actually call PCS
+        # with an empty node list. Suggestions welcome for what to raise.
+        LOGGER.error("power_off called with no nodes!")
     session = session or requests_retry_session()
     return _transition_create(xnames=nodes, operation='Off', task_deadline_minutes=task_deadline_minutes,
                               session=session, **kwargs)
@@ -218,6 +233,10 @@ def soft_off(nodes, session=None, task_deadline_minutes=1, **kwargs):
     Sends a request to PCS for transitioning nodes in question to a powered off state (graceful).
     Returns: A JSON parsed object response from PCS, which includes the created request ID.
     """
+    if not nodes:
+        # Should probably raise an exception here, since we don't want to actually call PCS
+        # with an empty node list. Suggestions welcome for what to raise.
+        LOGGER.error("soft_off called with no nodes!")
     session = session or requests_retry_session()
     return _transition_create(xnames=nodes, operation='Soft-Off', task_deadline_minutes=task_deadline_minutes,
                               session=session, **kwargs)
@@ -226,6 +245,10 @@ def force_off(nodes, session=None, task_deadline_minutes=1, **kwargs):
     Sends a request to PCS for transitioning nodes in question to a powered off state (forceful).
     Returns: A JSON parsed object response from PCS, which includes the created request ID.
     """
+    if not nodes:
+        # Should probably raise an exception here, since we don't want to actually call PCS
+        # with an empty node list. Suggestions welcome for what to raise.
+        LOGGER.error("force_off called with no nodes!")
     session = session or requests_retry_session()
     return _transition_create(xnames=nodes, operation='Force-Off', task_deadline_minutes=task_deadline_minutes,
                               session=session, **kwargs)


### PR DESCRIPTION
CSM 1.5.1 version of https://github.com/Cray-HPE/bos/pull/281

One thing to note is that this PR contains similar "empty node list" checks for some PCS functions, but in those cases, it didn't seem as obvious how to return an "empty" value to reflect that it was a no op. Currently this PR just logs an error. I did that instead of a warning because I am pretty sure the subsequent call to PCS is guaranteed to fail if we don't give it any nodes. Ultimately if we are in this situation, it means there is a bug in BOS, so the question just is how can we fail in a way to make it easiest to debug. Personally I think it should raise an Exception of some kind if it sees that the node list is empty. I just wasn't sure what kind of exception.

But even as is, this PR hopefully would make the debugging a little easier than it otherwise would be, since the logged errors would point to why the subsequent PCS call failed.