### PR TITLE
CASMCMS-8951: Use POST instead of GET when querying PCS for node power status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use POST instead of GET when requesting node power status from PCS, to avoid
+  size limitations on the GET parameters.
 
 ## [2.10.10] - 2024-03-27
 ### Added


### PR DESCRIPTION
## Summary and Scope

This just replaces the GET call to PCS with an equivalent POST call. The POST operation is being added with [CASMHMS-6156](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6156).

I tested this on mug with my PCS changes from [CASMHMS-6156](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6156) and it all works swimmingly. I can confirm from the BOS logs that it's happily using the POST operation.