### PR TITLE
CASMCMS-8954: Make BOS more efficient when patching CFS components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make BOS be more efficient when patching CFS components.
 
 ## [2.0.33] - 03-27-2024
 ### Added


### PR DESCRIPTION
When reviewing the BOS v2 code as part of the UKMet scale testing, I noticed that the CFS patch function is less efficient than it could be. Most notably, for its [components update request](https://github.com/Cray-HPE/config-framework-service/blob/7efb10b44cd9c58ebdd4671e6f03f5922bf20d03/api/openapi.yaml#L130) it chooses to use the [component state array format](https://github.com/Cray-HPE/config-framework-service/blob/7efb10b44cd9c58ebdd4671e6f03f5922bf20d03/api/openapi.yaml#L762), even though that is only efficient when each component is being patched with different data. BOS always patches all of the components in the request with the same data, so it makes more sense to use the [component patch filter format](https://github.com/Cray-HPE/config-framework-service/blob/7efb10b44cd9c58ebdd4671e6f03f5922bf20d03/api/openapi.yaml#L788), in which you only specify the component patch data a single time, and then provide a separate argument for which components should receive the patch.

In a case where BOS is making a patch request for 1000 nodes, the current method generates a payload body size of around 180k, whereas the more efficient method only uses 14k. Not only is it less data to send, but the method to generate it is faster.

It isn't going to add up to a heap of savings, but it's definitely measurable, and it's a very simple change.

I have tested this on wasp and verified that it works as expected.