### PR TITLE
CASMCMS-8953: Use CFS v3 instead of v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Make BOS be more efficient when patching CFS components.
 
+### Fixed
+- Switch from CFS v2 to v3 to avoid running afoul of page size limitations
+
 ## [2.10.11] - 2024-03-28
 ### Changed
 - Use POST instead of GET when requesting node power status from PCS, to avoid

--- a/src/bos/operators/filters/filters.py
+++ b/src/bos/operators/filters/filters.py
@@ -220,9 +220,9 @@ class DesiredConfigurationSetInCFS(LocalFilter):
         # which sets/updates the cfs_components_dict attribute.
         desired_configuration = component.get('desired_state', {}).get('configuration')
         if cfs_component is None:
-            set_configuration = self.cfs_components_dict[component['id']].get('desiredConfig')
+            set_configuration = self.cfs_components_dict[component['id']].get('desired_config')
         else:
-            set_configuration = cfs_component.get('desiredConfig')
+            set_configuration = cfs_component.get('desired_config')
         return desired_configuration == set_configuration
 
 

--- a/src/bos/operators/status.py
+++ b/src/bos/operators/status.py
@@ -200,7 +200,7 @@ class StatusOperator(BaseOperator):
                     phase = Phase.none
                     disable = True  # Successful state - booted with the correct artifacts, no configuration necessary
                 else:
-                    cfs_status = cfs_component.get('configurationStatus', '').lower()
+                    cfs_status = cfs_component.get('configuration_status', '').lower()
                     if cfs_status == 'configured':
                         phase = Phase.none
                         disable = True  # Successful state - booted with the correct artifacts and configured

--- a/src/bos/operators/utils/clients/cfs.py
+++ b/src/bos/operators/utils/clients/cfs.py
@@ -28,7 +28,7 @@ from requests.exceptions import HTTPError, ConnectionError
 from bos.common.utils import requests_retry_session, PROTOCOL
 
 SERVICE_NAME = 'cray-cfs-api'
-BASE_ENDPOINT = "%s://%s/v2" % (PROTOCOL, SERVICE_NAME)
+BASE_ENDPOINT = "%s://%s/v3" % (PROTOCOL, SERVICE_NAME)
 COMPONENTS_ENDPOINT = "%s/components" % BASE_ENDPOINT
 
 LOGGER = logging.getLogger('bos.operators.utils.clients.cfs')
@@ -37,19 +37,31 @@ GET_BATCH_SIZE = 200
 PATCH_BATCH_SIZE = 1000
 
 
-def get_components(session=None, **kwargs):
+def get_components(session=None, **params):
+    """
+    Makes GET request for CFS components.
+    Performs additional requests to get additional pages of components, if
+    needed.
+    Returns the list of CFS components
+    """
     if not session:
         session = requests_retry_session()
-    LOGGER.debug("GET %s with params=%s", COMPONENTS_ENDPOINT, kwargs)
-    response = session.get(COMPONENTS_ENDPOINT, params=kwargs)
-    LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
-                 response.reason, response.text)
-    try:
-        response.raise_for_status()
-    except HTTPError as err:
-        LOGGER.error("Failed getting nodes from cfs: %s", err)
-        raise
-    component_list = response.json()
+    component_list = []
+    while params is not None:
+        LOGGER.debug("GET %s with params=%s", COMPONENTS_ENDPOINT, params)
+        response = session.get(COMPONENTS_ENDPOINT, params=params)
+        LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
+                     response.reason, response.text)
+        try:
+            response.raise_for_status()
+        except HTTPError as err:
+            LOGGER.error("Failed getting nodes from CFS: %s", err)
+            raise
+        response_json = response.json()
+        new_components = response_json["components"]
+        LOGGER.debug("Query returned %d components", len(new_components))
+        component_list.extend(new_components)
+        params = response_json["next"]
     LOGGER.debug("Returning %d components from CFS", len(component_list))
     return component_list
 
@@ -97,7 +109,7 @@ def patch_desired_config(node_ids, desired_config, enabled=False, tags=None, cle
     session = requests_retry_session()
     node_patch = {
         'enabled': enabled,
-        'desiredConfig': desired_config,
+        'desired_config': desired_config,
         'tags': tags if tags else {}
     }
     data={ "patch": node_patch, "filters": {} }


### PR DESCRIPTION
## Summary

This changes BOS v2 so that it uses CFS v3 instead of CFS v2. This involves changing the endpoint URIs, changing a couple of the field names, and adding support for pagination on the GET components requests.

## Testing

I tested this on mug and verified that it works as expected (and verified in the debug logs that it was appropriately hitting the v3 endpoints). I also lowered the CFS page size option and verified that it caused BOS v2 to properly paginate.

Additionally, the pagination logic used here is essentially the same as what I implemented for a Python tool used in the `docs-csm` repo to query CFS v3, and that has been in the CSM builds for a while now.

## Gory Details

By default, BOS v2 is broken on CSM 1.5+ systems with more than 1000 nodes. In CSM 1.5, CFS v3 was introduced. It added support for paging, to help handle requests that return large amounts of data. The paging support was only added to CFS v3 endpoints. By default, the page size is 1000, meaning that requests to paging-enabled CFS v3 endpoints that would return more than 1000 items instead just return the first 1000, and give tokens that can be used to retrieve the next batch.

That's all fine, and doesn't matter to BOS, because it still uses CFS v2, which does not have paging support. HOWEVER, there is a fly in the ointment. While CFS v2 does not support paging, it also does not ignore it. Starting in CSM 1.5, if a request is made to a CFS v2 endpoint, and the v3 version of that endpoint has paging enabled, and the request would return more items than the configured page size, then CFS v2 will instead just return an error. It will state that the response is too large, and that you should use CFS v3 instead, so you can page through the results.

That is what breaks BOS v2. It periodically queries CFS v2 and asks for ALL of the components on the system. And so on systems with more than 1000 nodes, this exceeds the default CFS page size, and thus the request will fail. A customer can workaround the problem by increasing their CFS v3 default page size to a value that is >= the number of nodes in the system.

This problem isn't limited to systems with 1000+ nodes. It could be hit on any system, provided the admins change the CFS v3 page size to a low enough value. However, I think that is not likely. I think the big concern here is that out of the box, on CSM 1.5+, BOS v2 just won't work on 1000+ node systems.

Fortunately, the fix is pretty easy. Modify BOS to use the CFS v3 endpoint, and add code so it knows how to page through the results.

And to be clear, this bug impacts BOS v2 on all such systems, whether or not they are creating BOS v2 sessions with that many nodes. The BOS v2 status operator is going to barf on such systems every time it tries to run, so no BOS v2 sessions will work, even if they have only target a single node.
