### PR TITLE
CASMCMS-8957: Update BOS v1 API spec to confirm with how BOA actually uses it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Updated API spec to reflect that BOA updates the boot set status by using the phase `boot_set`.
 
 ## [2.0.34] - 03-28-2024
 ### Changed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -854,10 +854,10 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
     V1PhaseName:
       type: string
       description: |
-        The phase that this data belongs to (boot, shutdown, or configure). If blank,
-        it belongs to the Boot Set itself, which only applies to the GenericMetadata type.
+        The phase that this data belongs to (boot, shutdown, or configure). Or it can
+        be set to "boot_set" to indicate that it belongs to the Boot Set itself.
       example: "Boot"
-      pattern: '^($|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
+      pattern: '^([bB][oO][oO][tT]_[sS][eE][tT]$|[sS][hH][uU][tT][dD][oO][wW][nN]$|[bB][oO][oO][tT]$|[cC][oO][nN][fF][iI][gG][uU][rR][eE]$)'
     V1NodeChangeList:
       type: object
       description: |


### PR DESCRIPTION
The BOS API spec states that when BOA is posting status updates intended to apply to the bootset itself, they will have an empty phase string. However, BOA itself disagrees, and always specified the phase as "boot_set" in such cases. This results in some 400 errors being logged in BOA sessions, because the phase does not match what BOS expects.

I looked at the BOA code and the simplest solution here is to update the BOS API. Changing the API would ordinarily have concerns about breaking users, except in this case the only user is BOA, and we're doing the opposite of breaking it.

I've tested this on wasp and once the API spec update is in place, BOA is able to post its updates.

(I suspect that this got broken when we fixed the regex strings in the spec with [CASMTRIAGE-5367](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5367))