### PR TITLE
CASMCMS-8438: Reduced v2 default polling frequency, reconciled discrepancies in default v2 option values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Reduced v2 default polling frequency from 60 seconds to 15 seconds, to improve performance
+- Reconciled discrepancies in default v2 option values between `src/bos/operators/utils/clients/bos/options.py`
+  and `src/bos/server/controllers/v2/options.py`
 
 ## [2.10.13] - 2024-04-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.10.14] - 2024-04-19
 ### Changed
 - Reduced v2 default polling frequency from 60 seconds to 15 seconds, to improve performance
 - Reconciled discrepancies in default v2 option values between `src/bos/operators/utils/clients/bos/options.py`

--- a/src/bos/operators/utils/clients/bos/options.py
+++ b/src/bos/operators/utils/clients/bos/options.py
@@ -77,7 +77,7 @@ class Options:
 
     @property
     def polling_frequency(self):
-        return self.get_option('polling_frequency', int, 60)
+        return self.get_option('polling_frequency', int, 15)
 
     @property
     def discovery_frequency(self):
@@ -85,15 +85,15 @@ class Options:
 
     @property
     def max_boot_wait_time(self):
-        return self.get_option('max_boot_wait_time', int, 600)
+        return self.get_option('max_boot_wait_time', int, 1200)
 
     @property
     def max_power_on_wait_time(self):
-        return self.get_option('max_power_on_wait_time', int, 30)
+        return self.get_option('max_power_on_wait_time', int, 120)
 
     @property
     def max_power_off_wait_time(self):
-        return self.get_option('max_power_off_wait_time', int, 180)
+        return self.get_option('max_power_off_wait_time', int, 300)
 
     @property
     def disable_components_on_completion(self):

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -45,7 +45,7 @@ DEFAULTS = {
     'max_boot_wait_time': 1200,
     'max_power_on_wait_time': 120,
     'max_power_off_wait_time': 300,
-    'polling_frequency': 60,
+    'polling_frequency': 15,
     'default_retry_policy': 3,
 }
 


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/bos/pull/298

Because this is just a change in the default, including this in CSM 1.5.1 will only benefit customers who directly fresh install that version (instead of upgrading to it). But surely some folks will, so we may as well allow them to take advantage of the better default.