### PR TITLE
CASMCMS-8995: v2: Fix bug causing some CAPMC failures to be incompletely interpreted by BOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bug where a single CAPMC operation reports multiple failing nodes, but only one of them
+  has its status correctly updated in BOS v2.
 
 ## [2.0.37] - 04-19-2024
 ### Fixed

--- a/src/bos/operators/power_operator_base.py
+++ b/src/bos/operators/power_operator_base.py
@@ -94,7 +94,6 @@ class PowerOperatorBase(BaseOperator):
                         error = errors.nodes_in_error[component].error_message
                         components[index]['error'] = error
                         components[index]['enabled'] = disable_based_on_error_xname_on_off(error)
-                        break
             else:
                 # Errors could not be associated with a specific node.
                 # Ask CAPMC to act on them one at a time to identify


### PR DESCRIPTION
Remove a `break` statement from the base power operator that prevents component status from being updated on more than one failing node, in the situation where a single CAPMC operation reports failures for multiple specific nodes.

I am making this PR against the `wip-2.0.38` branch because I plan to bundle together a few PRs that will eventually merge into the `support/2.0` branch as `v2.0.38`

This does not need a backport for the CSM 1.5+ BOS versions, because the switch to PCS removed this problematic code.

For posterity, this is the commit which added the code with the `break` statement:
https://github.com/Cray-HPE/bos/commit/ff6a4f0bd5625ae5f4b62c131541e791313e48f9