### PR TITLE
CASMCMS-8997: v2 logging improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Added more checks to avoid operating on empty lists
+- Compact response bodies to single line before logging them
 
 ## [2.17.6] - 2024-04-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Added more checks to avoid operating on empty lists
 - Compact response bodies to single line before logging them
+- Improve BOS logging of unexpected errors
 
 ## [2.17.6] - 2024-04-19
 ### Fixed

--- a/src/bos/common/utils.py
+++ b/src/bos/common/utils.py
@@ -23,6 +23,7 @@
 #
 import datetime
 import re
+import traceback
 from dateutil.parser import parse
 import requests
 from requests.adapters import HTTPAdapter
@@ -107,3 +108,10 @@ def compact_response_text(response_text: str) -> str:
     if response_text:
         return ' '.join([ line.strip() for line in response_text.split('\n') ])
     return str(response_text)
+
+
+def exc_type_msg(exc: Exception) -> str:
+    """
+    Given an exception, returns a string of its type and its text (e.g. TypeError: 'int' object is not subscriptable)
+    """
+    return ''.join(traceback.format_exception_only(type(exc), exc))

--- a/src/bos/common/utils.py
+++ b/src/bos/common/utils.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -59,6 +59,7 @@ def duration_to_timedelta(timestamp: str):
     seconds = timeval * seconds_table[durationval]
     return datetime.timedelta(seconds=seconds)
 
+
 class TimeoutHTTPAdapter(HTTPAdapter):
     """
     An HTTP Adapter that allows a session level timeout for both read and connect attributes. This prevents interruption
@@ -95,3 +96,14 @@ def requests_retry_session(retries=10, backoff_factor=0.5,
     # Mounting to only http will not work!
     session.mount("%s://" % protocol, adapter)
     return session
+
+
+def compact_response_text(response_text: str) -> str:
+    """
+    Often JSON is "pretty printed" in response text, which is undesirable for our logging.
+    This function transforms the response text into a single line, stripping leading and trailing whitespace from each line,
+    and then returns it.
+    """
+    if response_text:
+        return ' '.join([ line.strip() for line in response_text.split('\n') ])
+    return str(response_text)

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -33,6 +33,7 @@ import os
 import time
 from typing import List, NoReturn, Type
 
+from bos.common.utils import exc_type_msg
 from bos.common.values import Status
 from bos.operators.filters.base import BaseFilter
 from bos.operators.utils.clients.bos.options import options
@@ -266,7 +267,7 @@ def _update_log_level() -> None:
             LOGGER.log(new_level, 'Logging level changed from {} to {}'.format(
                 logging.getLevelName(current_level), logging.getLevelName(new_level)))
     except Exception as e:
-        LOGGER.error('Error updating logging level: {}'.format(e))
+        LOGGER.error('Error updating logging level: %s', exc_type_msg(e))
 
 
 def _liveliness_heartbeat() -> NoReturn:

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -36,6 +36,7 @@ from bos.operators.utils.boot_image_metadata.factory import BootImageMetaDataFac
 from bos.operators.utils.clients.bos.options import options
 from bos.operators.utils.rootfs.factory import ProviderFactory
 from bos.operators.session_completion import SessionCompletionOperator
+from bos.common.utils import exc_type_msg
 from bos.common.values import Action, EMPTY_ACTUAL_STATE, EMPTY_DESIRED_STATE, EMPTY_STAGED_STATE
 from bos.common.tenant_utils import get_tenant_component_set, InvalidTenantException
 
@@ -135,7 +136,7 @@ class Session:
             if not all_component_ids:
                 raise SessionSetupException("No nodes were found to act upon.")
         except Exception as err:
-            raise SessionSetupException(err)
+            raise SessionSetupException(err) from err
         else:
             self._log(LOGGER.info, 'Found %d components that require updates', len(data))
             self._log(LOGGER.debug, f'Updated components: {data}')
@@ -413,7 +414,7 @@ class Session:
             except (ClientError, UnicodeDecodeError, S3ObjectNotFound) as error:
                 self._log(LOGGER.error, "Unable to read file {}. Thus, no kernel boot parameters obtained "
                              "from image".format(artifact_info['boot_parameters']))
-                LOGGER.error(error)
+                LOGGER.error(exc_type_msg(error))
                 raise
 
         # Parameters from the BOS Session template if the parameters exist.

--- a/src/bos/operators/utils/boot_image_metadata/s3_boot_image_metadata.py
+++ b/src/bos/operators/utils/boot_image_metadata/s3_boot_image_metadata.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,9 @@ import logging
 
 from botocore.exceptions import ClientError
 
-from . import BootImageMetaData, BootImageMetaDataBadRead
-from ..clients.s3 import S3BootArtifacts, S3MissingConfiguration, ArtifactNotFound
+from bos.common.utils import exc_type_msg
+from bos.operators.utils.boot_image_metadata import BootImageMetaData, BootImageMetaDataBadRead
+from bos.operators.utils.clients.s3 import S3BootArtifacts, S3MissingConfiguration, ArtifactNotFound
 
 LOGGER = logging.getLogger('bos.operators.utils.boot_image_metadata.s3_boot_image_metadata')
 
@@ -45,27 +46,27 @@ class S3BootImageMetaData(BootImageMetaData):
         try:
             self.artifact_summary['kernel'] = self.kernel_path
         except ArtifactNotFound as err:
-            LOGGER.warn(err)
+            LOGGER.warn(exc_type_msg(err))
         try:
             self.artifact_summary['initrd'] = self.initrd_path
         except ArtifactNotFound as err:
-            LOGGER.warn(err)
+            LOGGER.warn(exc_type_msg(err))
         try:
             self.artifact_summary['rootfs'] = self.rootfs_path
         except ArtifactNotFound as err:
-            LOGGER.warn(err)
+            LOGGER.warn(exc_type_msg(err))
         try:
             self.artifact_summary['rootfs_etag'] = self.rootfs_etag
         except ArtifactNotFound as err:
-            LOGGER.warn(err)
+            LOGGER.warn(exc_type_msg(err))
         try:
             self.artifact_summary['boot_parameters'] = self.boot_parameters_path
         except ArtifactNotFound as err:
-            LOGGER.warn(err)
+            LOGGER.warn(exc_type_msg(err))
         try:
             self.artifact_summary['boot_parameters_etag'] = self.boot_parameters_etag
         except ArtifactNotFound as err:
-            LOGGER.warn(err)
+            LOGGER.warn(exc_type_msg(err))
 
     @property
     def metadata(self):
@@ -79,7 +80,7 @@ class S3BootImageMetaData(BootImageMetaData):
         try:
             return self.boot_artifacts.manifest_json
         except (ClientError, S3MissingConfiguration) as error:
-            LOGGER.error("Unable to read %s -- Error: %s", self._boot_set.get('path', ''), error)
+            LOGGER.error("Unable to read %s -- Error: %s", self._boot_set.get('path', ''), exc_type_msg(error))
             raise BootImageMetaDataBadRead(error)
 
     @property

--- a/src/bos/operators/utils/clients/bos/base.py
+++ b/src/bos/operators/utils/clients/bos/base.py
@@ -27,7 +27,7 @@ from requests.exceptions import HTTPError, ConnectionError
 from urllib3.exceptions import MaxRetryError
 
 from bos.common.tenant_utils import get_new_tenant_header
-from bos.common.utils import PROTOCOL, requests_retry_session
+from bos.common.utils import PROTOCOL, exc_type_msg, requests_retry_session
 
 LOGGER = logging.getLogger('bos.operators.utils.clients.bos.base')
 
@@ -43,13 +43,13 @@ def log_call_errors(func):
             result = func(*args, **kwargs)
             return result
         except (ConnectionError, MaxRetryError) as e:
-            LOGGER.error("Unable to connect to BOS: {}".format(e))
+            LOGGER.error("Unable to connect to BOS: %s", exc_type_msg(e))
             raise e
         except HTTPError as e:
-            LOGGER.error("Unexpected response from BOS: {}".format(e))
+            LOGGER.error("Unexpected response from BOS: %s", exc_type_msg(e))
             raise e
         except json.JSONDecodeError as e:
-            LOGGER.error("Non-JSON response from BOS: {}".format(e))
+            LOGGER.error("Non-JSON response from BOS: %s", exc_type_msg(e))
             raise e
 
     return wrap

--- a/src/bos/operators/utils/clients/bos/options.py
+++ b/src/bos/operators/utils/clients/bos/options.py
@@ -26,7 +26,7 @@ import json
 from requests.exceptions import HTTPError, ConnectionError
 from urllib3.exceptions import MaxRetryError
 
-from bos.common.utils import requests_retry_session
+from bos.common.utils import exc_type_msg, requests_retry_session
 from bos.operators.utils.clients.bos.base import BASE_ENDPOINT
 
 LOGGER = logging.getLogger('bos.operators.utils.clients.bos.options')
@@ -56,11 +56,11 @@ class Options:
             response.raise_for_status()
             return json.loads(response.text)
         except (ConnectionError, MaxRetryError) as e:
-            LOGGER.error("Unable to connect to BOS: {}".format(e))
+            LOGGER.error("Unable to connect to BOS: %s", exc_type_msg(e))
         except HTTPError as e:
-            LOGGER.error("Unexpected response from BOS: {}".format(e))
+            LOGGER.error("Unexpected response from BOS: %s", exc_type_msg(e))
         except json.JSONDecodeError as e:
-            LOGGER.error("Non-JSON response from BOS: {}".format(e))
+            LOGGER.error("Non-JSON response from BOS: %s", exc_type_msg(e))
         return {}
 
     def get_option(self, key, value_type, default):

--- a/src/bos/operators/utils/clients/bss.py
+++ b/src/bos/operators/utils/clients/bss.py
@@ -25,7 +25,7 @@ from requests.exceptions import HTTPError
 import logging
 import json
 
-from bos.common.utils import requests_retry_session, PROTOCOL
+from bos.common.utils import compact_response_text, requests_retry_session, PROTOCOL
 
 LOGGER = logging.getLogger(__name__)
 SERVICE_NAME = 'cray-bss'
@@ -78,7 +78,7 @@ def set_bss(node_set, kernel_params, kernel, initrd, session=None):
     try:
         resp = session.put(url, data=json.dumps(payload), verify=False)
         LOGGER.debug("Response status code=%d, reason=%s, body=%s", resp.status_code,
-                     resp.reason, resp.text)
+                     resp.reason, compact_response_text(resp.text))
         resp.raise_for_status()
         return resp
     except HTTPError as err:

--- a/src/bos/operators/utils/clients/bss.py
+++ b/src/bos/operators/utils/clients/bss.py
@@ -25,7 +25,7 @@ from requests.exceptions import HTTPError
 import logging
 import json
 
-from bos.common.utils import compact_response_text, requests_retry_session, PROTOCOL
+from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
 
 LOGGER = logging.getLogger(__name__)
 SERVICE_NAME = 'cray-bss'
@@ -82,5 +82,5 @@ def set_bss(node_set, kernel_params, kernel, initrd, session=None):
         resp.raise_for_status()
         return resp
     except HTTPError as err:
-        LOGGER.error("%s" % err)
+        LOGGER.error(exc_type_msg(err))
         raise

--- a/src/bos/operators/utils/clients/cfs.py
+++ b/src/bos/operators/utils/clients/cfs.py
@@ -25,7 +25,7 @@ from collections import defaultdict
 import logging
 from requests.exceptions import HTTPError, ConnectionError
 
-from bos.common.utils import requests_retry_session, PROTOCOL
+from bos.common.utils import compact_response_text, requests_retry_session, PROTOCOL
 
 SERVICE_NAME = 'cray-cfs-api'
 BASE_ENDPOINT = "%s://%s/v3" % (PROTOCOL, SERVICE_NAME)
@@ -51,7 +51,7 @@ def get_components(session=None, **params):
         LOGGER.debug("GET %s with params=%s", COMPONENTS_ENDPOINT, params)
         response = session.get(COMPONENTS_ENDPOINT, params=params)
         LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
-                     response.reason, response.text)
+                     response.reason, compact_response_text(response.text))
         try:
             response.raise_for_status()
         except HTTPError as err:
@@ -75,7 +75,7 @@ def patch_components(data, session=None):
     LOGGER.debug("PATCH %s with body=%s", COMPONENTS_ENDPOINT, data)
     response = session.patch(COMPONENTS_ENDPOINT, json=data)
     LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
-                 response.reason, response.text)
+                 response.reason, compact_response_text(response.text))
     try:
         response.raise_for_status()
     except HTTPError as err:

--- a/src/bos/operators/utils/clients/cfs.py
+++ b/src/bos/operators/utils/clients/cfs.py
@@ -25,7 +25,7 @@ from collections import defaultdict
 import logging
 from requests.exceptions import HTTPError, ConnectionError
 
-from bos.common.utils import compact_response_text, requests_retry_session, PROTOCOL
+from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
 
 SERVICE_NAME = 'cray-cfs-api'
 BASE_ENDPOINT = "%s://%s/v3" % (PROTOCOL, SERVICE_NAME)
@@ -55,7 +55,7 @@ def get_components(session=None, **params):
         try:
             response.raise_for_status()
         except HTTPError as err:
-            LOGGER.error("Failed getting nodes from CFS: %s", err)
+            LOGGER.error("Failed getting nodes from CFS: %s", exc_type_msg(err))
             raise
         response_json = response.json()
         new_components = response_json["components"]
@@ -79,7 +79,7 @@ def patch_components(data, session=None):
     try:
         response.raise_for_status()
     except HTTPError as err:
-        LOGGER.error("Failed asking CFS to configure nodes: %s", err)
+        LOGGER.error("Failed asking CFS to configure nodes: %s", exc_type_msg(err))
         raise
 
 

--- a/src/bos/operators/utils/clients/hsm.py
+++ b/src/bos/operators/utils/clients/hsm.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 from requests.exceptions import HTTPError, ConnectionError
 from urllib3.exceptions import MaxRetryError
 
-from bos.common.utils import requests_retry_session, PROTOCOL
+from bos.common.utils import compact_response_text, requests_retry_session, PROTOCOL
 
 SERVICE_NAME = 'cray-smd'
 BASE_ENDPOINT = "%s://%s/hsm/v2/" % (PROTOCOL, SERVICE_NAME)
@@ -62,7 +62,7 @@ def read_all_node_xnames():
         LOGGER.error("Unable to contact HSM service: %s", ce)
         raise HWStateManagerException(ce) from ce
     LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
-                 response.reason, response.text)
+                 response.reason, compact_response_text(response.text))
     try:
         response.raise_for_status()
     except (HTTPError, MaxRetryError) as hpe:
@@ -131,7 +131,7 @@ def get_components(node_list, enabled=None) -> dict[str,list[dict]]:
         LOGGER.debug("POST %s with body=%s", ENDPOINT, payload)
         response = session.post(ENDPOINT, json=payload)
         LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
-                     response.reason, response.text)
+                     response.reason, compact_response_text(response.text))
         response.raise_for_status()
         components = json.loads(response.text)
     except (ConnectionError, MaxRetryError) as e:
@@ -227,7 +227,7 @@ class Inventory(object):
             LOGGER.debug("HSM Inventory: GET %s with params=%s", url, params)
             response = self._session.get(url, params=params, verify=VERIFY)
             LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
-                         response.reason, response.text)
+                         response.reason, compact_response_text(response.text))
             response.raise_for_status()
         except HTTPError as err:
             LOGGER.error("Failed to get '{}': {}".format(url, err))

--- a/src/bos/operators/utils/clients/hsm.py
+++ b/src/bos/operators/utils/clients/hsm.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 from requests.exceptions import HTTPError, ConnectionError
 from urllib3.exceptions import MaxRetryError
 
-from bos.common.utils import compact_response_text, requests_retry_session, PROTOCOL
+from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
 
 SERVICE_NAME = 'cray-smd'
 BASE_ENDPOINT = "%s://%s/hsm/v2/" % (PROTOCOL, SERVICE_NAME)
@@ -59,14 +59,14 @@ def read_all_node_xnames():
     try:
         response = session.get(endpoint)
     except ConnectionError as ce:
-        LOGGER.error("Unable to contact HSM service: %s", ce)
+        LOGGER.error("Unable to contact HSM service: %s", exc_type_msg(ce))
         raise HWStateManagerException(ce) from ce
     LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
                  response.reason, compact_response_text(response.text))
     try:
         response.raise_for_status()
     except (HTTPError, MaxRetryError) as hpe:
-        LOGGER.error("Unexpected response from HSM: %s", response)
+        LOGGER.error("Unexpected response from HSM: %s (%s)", response, exc_type_msg(hpe))
         raise HWStateManagerException(hpe) from hpe
     try:
         json_body = json.loads(response.text)
@@ -77,7 +77,7 @@ def read_all_node_xnames():
         return set([component['ID'] for component in json_body['Components']
                     if component.get('Type', None) == 'Node'])
     except KeyError as ke:
-        LOGGER.error("Unexpected API response from HSM")
+        LOGGER.error("Unexpected API response from HSM: %s", exc_type_msg(ke))
         raise HWStateManagerException(ke) from ke
 
 
@@ -135,13 +135,13 @@ def get_components(node_list, enabled=None) -> dict[str,list[dict]]:
         response.raise_for_status()
         components = json.loads(response.text)
     except (ConnectionError, MaxRetryError) as e:
-        LOGGER.error("Unable to connect to HSM: {}".format(e))
+        LOGGER.error("Unable to connect to HSM: %s", exc_type_msg(e))
         raise e
     except HTTPError as e:
-        LOGGER.error("Unexpected response from HSM: {}".format(e))
+        LOGGER.error("Unexpected response from HSM: %s", exc_type_msg(e))
         raise e
     except json.JSONDecodeError as e:
-        LOGGER.error("Non-JSON response from HSM: {}".format(e))
+        LOGGER.error("Non-JSON response from HSM: %s", exc_type_msg(e))
         raise e
     return components
 
@@ -230,7 +230,7 @@ class Inventory(object):
                          response.reason, compact_response_text(response.text))
             response.raise_for_status()
         except HTTPError as err:
-            LOGGER.error("Failed to get '{}': {}".format(url, err))
+            LOGGER.error("Failed to get '%s': %s", url, exc_type_msg(err))
             raise
         try:
             return response.json()

--- a/src/bos/operators/utils/clients/pcs.py
+++ b/src/bos/operators/utils/clients/pcs.py
@@ -204,8 +204,8 @@ def _transition_create(xnames, operation, task_deadline_minutes=None, deputy_key
     session = session or requests_retry_session()
     try:
         assert operation in set(['On', 'Off', 'Soft-Off', 'Soft-Restart', 'Hard-Restart', 'Init', 'Force-Off'])
-    except AssertionError:
-        raise PowerControlSyntaxException("Operation '%s' is not supported or implemented." %(operation))
+    except AssertionError as err:
+        raise PowerControlSyntaxException("Operation '%s' is not supported or implemented." %(operation)) from err
     params = {'location': [], 'operation': operation}
     if task_deadline_minutes:
         params['taskDeadlineMinutes'] = int(task_deadline_minutes)

--- a/src/bos/operators/utils/clients/pcs.py
+++ b/src/bos/operators/utils/clients/pcs.py
@@ -30,7 +30,7 @@ import requests
 import json
 from collections import defaultdict
 
-from bos.common.utils import requests_retry_session, PROTOCOL
+from bos.common.utils import compact_response_text, requests_retry_session, PROTOCOL
 
 SERVICE_NAME = 'cray-power-control'
 POWER_CONTROL_VERSION = 'v1'
@@ -103,7 +103,7 @@ def _power_status(xname=None, power_state_filter=None, management_state_filter=N
     LOGGER.debug("POST %s with body=%s", POWER_STATUS_ENDPOINT, params)
     response = session.post(POWER_STATUS_ENDPOINT, json=params)
     LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
-                 response.reason, response.text)
+                 response.reason, compact_response_text(response.text))
     try:
         response.raise_for_status()
         if not response.ok:
@@ -217,7 +217,7 @@ def _transition_create(xnames, operation, task_deadline_minutes=None, deputy_key
     LOGGER.debug("POST %s with body=%s", TRANSITION_ENDPOINT, params)
     response = session.post(TRANSITION_ENDPOINT, json=params)
     LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
-                 response.reason, response.text)
+                 response.reason, compact_response_text(response.text))
     try:
         response.raise_for_status()
         if not response.ok:

--- a/src/bos/reporter/node_identity.py
+++ b/src/bos/reporter/node_identity.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -60,8 +60,8 @@ def identity_from_environment():
     ident_string = 'NODE_IDENTITY'
     try:
         return os.environ[ident_string]
-    except KeyError:
-        raise UnknownIdentity("Node identity not passed in via environment '%s'" % (ident_string))
+    except KeyError as exc:
+        raise UnknownIdentity("Node identity not passed in via environment '%s'" % (ident_string)) from exc
 
 
 def read_identity():

--- a/src/bos/reporter/status_reporter/__main__.py
+++ b/src/bos/reporter/status_reporter/__main__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -28,6 +28,7 @@ import re
 import datetime
 from time import sleep
 
+from bos.common.utils import exc_type_msg
 from bos.reporter.client import requests_retry_session
 from bos.reporter.node_identity import read_identity
 from bos.reporter.components.state import report_state, BOSComponentException, UnknownComponent
@@ -86,7 +87,7 @@ def report_state_until_success(component):
             LOGGER.warning("Unable to contact BOS to report component status: %s" % (cce))
             continue
         except OSError as exc:
-            LOGGER.error("BOS client encountered an %s" % (exc))
+            LOGGER.error("BOS client encountered an error: %s", exc_type_msg(exc))
             continue
         LOGGER.info("Updated the actual_state record for BOS component '%s'." % (component))
         return
@@ -133,7 +134,7 @@ def main():
         try:
             report_state_until_success(component)
         except Exception as exp:
-            LOGGER.error("An error occurred: {}".format(exp))
+            LOGGER.error("An error occurred: %s", exc_type_msg(exp))
         if has_slept_before:
             sleep(sleep_time)
         else:

--- a/src/bos/server/controllers/v2/base.py
+++ b/src/bos/server/controllers/v2/base.py
@@ -26,6 +26,7 @@ import logging
 import subprocess
 import yaml
 
+from bos.common.utils import exc_type_msg
 from bos.server.controllers.utils import url_for
 from bos.server.models import Version, Link
 from os import path
@@ -55,7 +56,7 @@ def calc_version(details):
     try:
         f = open(openapispec_f, 'r')
     except IOError as e:
-        LOGGER.debug('error opening openapi.yaml file: %s' % e)
+        LOGGER.debug('error opening "%s" file: %s', openapispec_f, exc_type_msg(e))
 
     openapispec_map = yaml.safe_load(f)
     f.close()

--- a/src/bos/server/controllers/v2/boot_set.py
+++ b/src/bos/server/controllers/v2/boot_set.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,6 +23,7 @@
 #
 
 import logging
+from bos.common.utils import exc_type_msg
 from bos.operators.utils.boot_image_metadata.factory import BootImageMetaDataFactory
 from bos.operators.utils.clients.s3 import S3Object, ArtifactNotFound
 
@@ -81,7 +82,7 @@ def validate_boot_sets(session_template: dict,
                 image_metadata = BootImageMetaDataFactory(bs)()
             except Exception as err:
                 msg = f"Session template: '{template_name}' boot set: '{bs_name}' " \
-                    f"could not locate its boot artifacts. Error: {err}"
+                    f"could not locate its boot artifacts. Error: " + exc_type_msg(err)
                 LOGGER.error(msg)
                 return BOOT_SET_ERROR, msg
 
@@ -95,7 +96,7 @@ def validate_boot_sets(session_template: dict,
                     _ = obj.object_header
                 except Exception as err:
                     msg = f"Session template: '{template_name}' boot set: '{bs_name}' " \
-                    f"could not locate its {boot_artifact}. Error: {err}"
+                    f"could not locate its {boot_artifact}. Error: " + exc_type_msg(err)
                     LOGGER.error(msg)
                     return BOOT_SET_ERROR, msg
 
@@ -113,7 +114,7 @@ def validate_boot_sets(session_template: dict,
                     _ = obj.object_header
                 except Exception as err:
                     msg = f"Session template: '{template_name}' boot set: '{bs_name}' " \
-                    f"could not locate its {boot_artifact}. Warning: {err}"
+                    f"could not locate its {boot_artifact}. Warning: " + exc_type_msg(err)
                     LOGGER.warn(msg)
                     warning_flag = True
                     warn_msg = warn_msg + msg

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -24,7 +24,7 @@
 import connexion
 import logging
 
-from bos.common.utils import get_current_timestamp
+from bos.common.utils import exc_type_msg, get_current_timestamp
 from bos.common.tenant_utils import get_tenant_from_header, get_tenant_component_set, tenant_error_handler
 from bos.common.values import Phase, Action, Status, EMPTY_STAGED_STATE, EMPTY_BOOT_ARTIFACTS
 from bos.server import redis_db_utils as dbutils
@@ -54,6 +54,7 @@ def get_v2_components(ids="", enabled=None, session=None, staged_session=None, p
         try:
             id_list = ids.split(',')
         except Exception as err:
+            LOGGER.error("Error parsing component IDs: %s", exc_type_msg(err))
             return connexion.problem(
                 status=400, title="Error parsing the ids provided.",
                 detail=str(err))
@@ -179,7 +180,7 @@ def put_v2_components():
         ComponentArray.from_dict(data)  # noqa: E501
     except Exception as err:
         msg="Provided data does not follow API spec"
-        LOGGER.exception(msg)
+        LOGGER.error("%s: %s", msg, exc_type_msg(err))
         return connexion.problem(status=400, title=msg,detail=str(err))
 
     components = []
@@ -220,7 +221,7 @@ def patch_v2_components():
             ComponentArray.from_dict(data)  # noqa: E501
         except Exception as err:
             msg="Provided data does not follow API spec"
-            LOGGER.exception(msg)
+            LOGGER.error("%s: %s", msg, exc_type_msg(err))
             return connexion.problem(status=400, title=msg,detail=str(err))
         return patch_v2_components_list(data)
     elif type(data) == dict:
@@ -230,13 +231,14 @@ def patch_v2_components():
             ComponentsUpdate.from_dict(data)  # noqa: E501
         except Exception as err:
             msg="Provided data does not follow API spec"
-            LOGGER.exception(msg)
+            LOGGER.error("%s: %s", msg, exc_type_msg(err))
             return connexion.problem(status=400, title=msg,detail=str(err))
         return patch_v2_components_dict(data)
 
+    LOGGER.error("Unexpected data type %s", str(type(data)))
     return connexion.problem(
-        status=400, title="Error parsing the data provided.",
-        detail="Unexpected data type {}".format(str(type(data))))
+       status=400, title="Error parsing the data provided.",
+       detail="Unexpected data type {}".format(str(type(data))))
 
 
 def patch_v2_components_list(data):
@@ -246,11 +248,13 @@ def patch_v2_components_list(data):
         for component_data in data:
             component_id = component_data['id']
             if component_id not in DB or not _is_valid_tenant_component(component_id):
+                LOGGER.warning("Component %s could not be found", component_id)
                 return connexion.problem(
                     status=404, title="Component not found.",
                     detail="Component {} could not be found".format(component_id))
             components.append((component_id, component_data))
     except Exception as err:
+        LOGGER.error("Error loading component data: %s", exc_type_msg(err))
         return connexion.problem(
             status=400, title="Error parsing the data provided.",
             detail=str(err))
@@ -268,6 +272,7 @@ def patch_v2_components_dict(data):
     ids = filters.get("ids", None)
     session = filters.get("session", None)
     if ids and session:
+        LOGGER.warning("Multiple filters provided")
         return connexion.problem(
             status=400, title="Only one filter may be provided.",
             detail="Only one filter may be provided.")
@@ -275,6 +280,7 @@ def patch_v2_components_dict(data):
         try:
             id_list = ids.split(',')
         except Exception as err:
+            LOGGER.error("Error parsing the IDs provided: %s", exc_type_msg(err))
             return connexion.problem(
                 status=400, title="Error parsing the ids provided.",
                 detail=str(err))
@@ -289,6 +295,7 @@ def patch_v2_components_dict(data):
         id_list = [component["id"] for component in get_v2_components_data(session=session, tenant=get_tenant_from_header())]
         LOGGER.debug("patch_v2_components_dict: %d IDs found for specified session", len(id_list))
     else:
+        LOGGER.warning("No filter provided")
         return connexion.problem(
             status=400, title="Exactly one filter must be provided.",
             detail="Exactly one filter may be provided.")
@@ -308,6 +315,7 @@ def get_v2_component(component_id):
     """Used by the GET /components/{component_id} API operation"""
     LOGGER.debug("GET /v2/components/%s invoked get_v2_component", component_id)
     if component_id not in DB or not _is_valid_tenant_component(component_id):
+        LOGGER.warning("Component %s could not be found", component_id)
         return connexion.problem(
             status=404, title="Component not found.",
             detail="Component {} could not be found".format(component_id))
@@ -337,7 +345,7 @@ def put_v2_component(component_id):
         Component.from_dict(data)  # noqa: E501
     except Exception as err:
         msg="Provided data does not follow API spec"
-        LOGGER.exception(msg)
+        LOGGER.error("%s: %s", msg, exc_type_msg(err))
         return connexion.problem(status=400, title=msg,detail=str(err))
     data['id'] = component_id
     data = _set_auto_fields(data)
@@ -365,14 +373,16 @@ def patch_v2_component(component_id):
         Component.from_dict(data)  # noqa: E501
     except Exception as err:
         msg="Provided data does not follow API spec"
-        LOGGER.exception(msg)
+        LOGGER.error("%s: %s", msg, exc_type_msg(err))
         return connexion.problem(status=400, title=msg,detail=str(err))
 
     if component_id not in DB or not _is_valid_tenant_component(component_id):
+        LOGGER.warning("Component %s could not be found", component_id)
         return connexion.problem(
             status=404, title="Component not found.",
             detail="Component {} could not be found".format(component_id))
     if "actual_state" in data and not validate_actual_state_change_is_allowed(component_id):
+        LOGGER.warning("Not able to update actual state")
         return connexion.problem(
             status=409, title="Actual state can not be updated.",
             detail="BOS is currently changing the state of the node,"
@@ -407,6 +417,7 @@ def delete_v2_component(component_id):
     """Used by the DELETE /components/{component_id} API operation"""
     LOGGER.debug("DELETE /v2/components/%s invoked delete_v2_component", component_id)
     if component_id not in DB or not _is_valid_tenant_component(component_id):
+        LOGGER.warning("Component %s could not be found", component_id)
         return connexion.problem(
             status=404, title="Component not found.",
             detail="Component {} could not be found".format(component_id))
@@ -433,10 +444,11 @@ def post_v2_apply_staged():
                     response["succeeded"].append(xname)
                 else:
                     response["ignored"].append(xname)
-            except Exception as err:
-                LOGGER.error(f"An error was encountered while attempting to apply stage for node {xname}: {err}")
+            except Exception:
+                LOGGER.exception("An error was encountered while attempting to apply stage for node %s", xname)
                 response["failed"].append(xname)
     except Exception as err:
+        LOGGER.error("Error parsing request data: %s", exc_type_msg(err))
         return connexion.problem(
             status=400, title="Error parsing the data provided.",
             detail=str(err))

--- a/src/bos/server/controllers/v2/healthz.py
+++ b/src/bos/server/controllers/v2/healthz.py
@@ -23,6 +23,7 @@
 #
 import logging
 
+from bos.common.utils import exc_type_msg
 from bos.server.models.healthz import Healthz as Healthz
 from bos.server import redis_db_utils
 
@@ -37,7 +38,7 @@ def _get_db_status():
         if DB.info():
             available = True
     except Exception as e:
-        LOGGER.error(e)
+        LOGGER.error(exc_type_msg(e))
 
     if available:
         return 'ok'

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -26,6 +26,7 @@ import connexion
 import threading
 import time
 
+from bos.common.utils import exc_type_msg
 from bos.server import redis_db_utils as dbutils
 from bos.server.models.v2_options import V2Options as Options
 
@@ -60,8 +61,8 @@ def _init():
         try:
             data = DB.get(OPTIONS_KEY)
             break
-        except Exception:
-            LOGGER.info('Database is not yet available')
+        except Exception as err:
+            LOGGER.info('Database is not yet available (%s)', exc_type_msg(err))
             time.sleep(1)
     if not data:
         return
@@ -116,6 +117,7 @@ def patch_v2_options():
     try:
         data = connexion.request.get_json()
     except Exception as err:
+        LOGGER.error("Error parsing request data: %s", exc_type_msg(err))
         return connexion.problem(
             status=400, title="Error parsing the data provided.",
             detail=str(err))
@@ -142,6 +144,6 @@ def check_v2_logging_level():
             data = get_v2_options_data()
             if 'logging_level' in data:
                 update_log_level(data['logging_level'])
-        except Exception as e:
-            LOGGER.debug(e)
+        except Exception as err:
+            LOGGER.debug("Error checking or updating log level: %s", exc_type_msg(err))
         time.sleep(5)

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -25,6 +25,7 @@ import logging
 import connexion
 
 from bos.common.tenant_utils import get_tenant_from_header, get_tenant_aware_key, reject_invalid_tenant
+from bos.common.utils import exc_type_msg
 from bos.server.models.v2_session_template import V2SessionTemplate as SessionTemplate  # noqa: E501
 from bos.server import redis_db_utils as dbutils
 from bos.server.utils import _canonize_xname
@@ -92,6 +93,7 @@ def put_v2_sessiontemplate(session_template_id):  # noqa: E501
     try:
         data = connexion.request.get_json()
     except Exception as err:
+        LOGGER.error("Error parsing request data: %s", exc_type_msg(err))
         return connexion.problem(
             status=400, title="Error parsing the data provided.",
             detail=str(err))
@@ -108,6 +110,7 @@ def put_v2_sessiontemplate(session_template_id):  # noqa: E501
         """
         SessionTemplate.from_dict(template_data)
     except Exception as err:
+        LOGGER.error("Error creating session template: %s", exc_type_msg(err))
         return connexion.problem(
             status=400, title="The session template could not be created.",
             detail=str(err))
@@ -143,6 +146,7 @@ def get_v2_sessiontemplate(session_template_id):
     LOGGER.debug("GET /v2/sessiontemplates/%s invoked get_v2_sessiontemplate", session_template_id)
     template_key = get_tenant_aware_key(session_template_id, get_tenant_from_header())
     if template_key not in DB:
+        LOGGER.warning("Session template not found: %s", session_template_id)
         return connexion.problem(
             status=404, title="Sessiontemplate could not found.",
             detail="Sessiontemplate {} could not be found".format(session_template_id))
@@ -171,6 +175,7 @@ def delete_v2_sessiontemplate(session_template_id):
     LOGGER.debug("DELETE /v2/sessiontemplates/%s invoked delete_v2_sessiontemplate", session_template_id)
     template_key = get_tenant_aware_key(session_template_id, get_tenant_from_header())
     if template_key not in DB:
+        LOGGER.warning("Session template not found: %s", session_template_id)
         return connexion.problem(
             status=404, title="Sessiontemplate could not found.",
             detail="Sessiontemplate {} could not be found".format(session_template_id))
@@ -187,6 +192,7 @@ def patch_v2_sessiontemplate(session_template_id):
     LOGGER.debug("PATCH /v2/sessiontemplates/%s invoked patch_v2_sessiontemplate", session_template_id)
     template_key = get_tenant_aware_key(session_template_id, get_tenant_from_header())
     if template_key not in DB:
+        LOGGER.warning("Session template not found: %s", session_template_id)
         return connexion.problem(
             status=404, title="Sessiontemplate could not found.",
             detail="Sessiontemplate {} could not be found".format(session_template_id))
@@ -201,6 +207,7 @@ def patch_v2_sessiontemplate(session_template_id):
     try:
         data = connexion.request.get_json()
     except Exception as err:
+        LOGGER.error("Error parsing request data: %s", exc_type_msg(err))
         return connexion.problem(
             status=400, title="Error parsing the data provided.",
             detail=str(err))
@@ -217,8 +224,9 @@ def patch_v2_sessiontemplate(session_template_id):
         """
         SessionTemplate.from_dict(template_data)
     except Exception as err:
+        LOGGER.error("Error patching session template: %s", exc_type_msg(err))
         return connexion.problem(
-            status=400, title="The session template could not be created.",
+            status=400, title="The session template could not be patched.",
             detail=str(err))
 
     template_data = _sanitize_xnames(template_data)

--- a/src/bos/server/redis_db_utils.py
+++ b/src/bos/server/redis_db_utils.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,6 +26,8 @@ import functools
 import json
 import logging
 import redis
+
+from bos.common.utils import exc_type_msg
 
 LOGGER = logging.getLogger(__name__)
 DATABASES = ["options", "components", "session_templates", "sessions", "bss_tokens_boot_artifacts", "session_status"]  # Index is the db id.
@@ -67,7 +69,7 @@ class DBWrapper():
             return redis.Redis(host=DB_HOST, port=DB_PORT, db=db_id)
         except Exception as err:
             LOGGER.error("Failed to connect to database %s : %s",
-                         db_id, err)
+                         db_id, exc_type_msg(err))
             raise
 
     # The following methods act like REST calls for single items


### PR DESCRIPTION
This PR mainly makes 3 types of changes:
1. Currently some JSON responses are logged in "pretty" format with a ton of whitespace added, which makes the logs much larger than necessary. This compacts the JSON data before logging it.
2. A lot of exceptions are logged only printing their text but not their type. In some cases the type is obvious, but in other cases it is not, and knowing it could provide a helpful clue.
3, In many places when the BOS API is returning an error response to the caller, it also logs something related to this. In some cases, it does not. I've added debug logging calls to those places where they are missing.

Additionally, I found a handful of places where exceptions should be raised from other exceptions, to provide additional traceability. This PR adds that.

Finally, in some places I switched logging calls from using f-strings over to using string interpolation, as the linter always loves to point out to me that this is the proper form (and avoids string operations if the log level is such that the message is not being logged). I generally only did this for logging calls that I was modifying anyway as part of the above effort.

I tested this on wasp.