### PR TITLE
CASMCMS-8996: Improve scalability of how BOS v2 handles vague CAPMC operation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added more checks to avoid operating on empty lists
 - Compact response bodies to single line before logging them
 - Improve BOS logging of unexpected errors
+- Improve scalability of how BOS v2 handles vague CAPMC operation failures
 
 ## [2.0.37] - 04-19-2024
 ### Fixed


### PR DESCRIPTION
Instead of immediately resorting to "one at a time" retries in the case of a vague CAPMC error, instead subdivide the list of components into smaller chunks, and only retry individually as a last resort.

I tested this on wasp. First I did a regular test, just making sure that nothing broke for a normal v2 session on there. Then I added some code so that it would pretend it was acting on 2800 nodes, 2 of which were bad. I basically just had code in the base power operator that told it to act on this big list of nodes, and then code in the capmc client to generate my fake CAPMC responses. I confirmed that the modified algorithm behaved as intended. I also added assertions afterward to check that the bad nodes were marked as such, and none of the others were.