### PR TITLE
CASMCMS-9002: Bump openapi-generator-cli to v7.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Dependencies
+- Bump `openapi-generator-cli` from v6.6.0 to v7.6.0, in preparation for moving the API
+  spec to OAS 3.1
 
 ## [2.17.7] - 2024-05-16
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # Dockerfile for Cray Boot Orchestration Service (BOS)
 
 # Upstream Build Args
-ARG OPENAPI_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/openapitools/openapi-generator-cli:v6.6.0
+ARG OPENAPI_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/openapitools/openapi-generator-cli:v7.6.0
 ARG ALPINE_BASE_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3
 
 # Generate Code


### PR DESCRIPTION
I am working on adding the input enforcement for BOS for the various limits that are currently only listed as being recommended. Doing this will be much easier using OAS 3.1. So this PR moves `openapi-generator-cli` to v7.6.0 in order to support that.