### PR TITLE
CASMTRIAGE-7019: BOS reporter RPM: Add bos.common dependency, remove __pycache__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.18.1] - 2024-05-30
+### Changed
+- Remove `__pycache__` directories from BOS reporter RPM
+
+### Fixed
+- Include `bos.common` dependency in BOS reporter RPM
+
 ## [2.18.0] - 2024-05-22
 ### Changed
 - Increase memory requests and limits for BOS pods, to prevent OOM kill issues seen at scale.

--- a/bos-reporter.spec.in
+++ b/bos-reporter.spec.in
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -67,6 +67,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_systemdsvcdir}
 cp bos/reporter/etc/bos-reporter.service %{buildroot}/%{_systemdsvcdir}/bos-reporter.service
 chmod +x %{buildroot}/%{python3_sitelib}/bos/reporter/status_reporter/__main__.py
 popd
+# Remove __pycache__ directories that we don't want in the RPM
+find %{buildroot}/%{python3_sitelib}/bos -type d -name __pycache__ -exec rm -rvf {} \; -prune
 
 %clean
 rm -rf %{buildroot}
@@ -75,6 +77,8 @@ rm -rf %{buildroot}
 %defattr(-,root,root)
 
 %dir %{python3_sitelib}/bos
+%{python3_sitelib}/bos/__init__.py
+%{python3_sitelib}/bos/common
 %{python3_sitelib}/bos/reporter
 %{_systemdsvcdir}/bos-reporter.service
 


### PR DESCRIPTION
One of my recent code changes started making a call to `bos.common` from BOS reporter. Turns out we don't package up `bos.common` into the BOS reporter RPM. This PR corrects that (and also stops including the large superfluous `__pycache__` files inside the RPM).

This will be backported to CSM 1.5.2 and CSM 1.4.5 as well.

I verified on starlord that this modification results in the necessary `bos.common` module being included in the RPM.