### PR TITLE
CASMCMS-9015: Instantiate S3 client in a thread-safe manner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.41] - 05-31-2024
 ### Fixed
 - Instantiate S3 client in a thread-safe manner.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Instantiate S3 client in a thread-safe manner.
 
 ## [2.0.40] - 05-30-2024
 ### Changed


### PR DESCRIPTION
Even though using the S3 client is thread-safe, instantiating it is not. If multiple BOS server threads attempt to do this at the same time, they can run into problems. This has been observed multiple times now by Harold during his bringup tests at UKMet. SAT tries to create multiple BOS sessions, and one or two of them will fail to be created because of this bug.

The simplest and most bulletproof fix is just to put a lock around the client instantiation.

Once the client has been instantiated, then this no longer happens, which is why it is only during system bringup that this is reliably seen. I am able to reproduce it on any system just by restarting the BOS pods and then creating multiple sessions simultaneously.
With this fix in place, however, I am unable to recreate the problem.

CSM 1.5 source PR: https://github.com/Cray-HPE/bos/pull/322
CSM 1.6 source PR: https://github.com/Cray-HPE/bos/pull/323