### PR TITLE
CASMCMS-9020: Bump Flask from 2.1.1 to 2.2.5 to resolve CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Dependencies
 - Bumped `certifi` from 2022.12.7 to 2023.7.22 to resolve [SNYK-PYTHON-CERTIFI-5805047 CVE](https://security.snyk.io/vuln/SNYK-PYTHON-CERTIFI-5805047)
+- Bumped `Flask` from 2.1.1 to 2.2.5 to resolve [SNYK-PYTHON-FLASK-5490129 CVE](https://snyk.io/vuln/SNYK-PYTHON-FLASK-5490129)
 
 ## [2.18.2] - 2024-05-31
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,12 @@ COPY --from=codegen /app/lib/ /app/lib
 # additional required libraries necessary for developer authored controller/database
 # code.
 RUN mv lib/requirements.txt lib/bos/server/requirements.txt
+# The openapi-generator creates a requirements file that specifies exactly Flask==2.1.1
+# However, using Flask 2.2.5 is also compatible, and resolves a CVE.
+# Accordingly, we relax their requirements file.
+RUN cat lib/bos/server/requirements.txt && \
+    sed -i 's/Flask == 2\(.*\)$/Flask >= 2\1\nFlask < 3/' lib/bos/server/requirements.txt && \
+    cat lib/bos/server/requirements.txt
 # Then copy all src into the base image
 COPY src/bos/ /app/lib/bos/
 COPY constraints.txt requirements.txt /app/

--- a/constraints.txt.in
+++ b/constraints.txt.in
@@ -10,7 +10,7 @@ click==8.1.7
 clickclick==20.10.2
 connexion==2.14.2
 etcd3==0.12.0
-Flask==2.1.1
+Flask==2.2.5
 google-auth==2.16.3
 grpcio==1.51.3
 idna==3.4


### PR DESCRIPTION
This was slightly more involved than just bumping the version in the constraints file, because the openapi-generator-provided requirements.txt file specifies an exact version requirement for Flask. I've confirmed that (based on the changelogs and examining the generated code) Flask 2.2.5 should also work fine, so I added code to tweak the provided requirements file to allow this.