### PR TITLE
CASMCMS-9022: Fix incorrect uses of format keyword in API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.20.0] - 2024-06-05
 ### Fixed
 - Some schemas in the API used the `format` keyword to mean `pattern`, and thus the patterns they specified were not being
   interpreted or enforced. This fixes that.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Some schemas in the API used the `format` keyword to mean `pattern`, and thus the patterns they specified were not being
+  interpreted or enforced. This fixes that.
 
 ## [2.19.0] - 2024-06-05
 ### Dependencies

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -108,7 +108,7 @@ components:
       type: string
       description: Age in minutes (e.g. "3m"), hours (e.g. "5h"), days (e.g. "10d"), or weeks (e.g. "2w").
       example: 3d
-      format: '^(0|0[mMhHdDwW]|[1-9][0-9]*[mMhHdDwW])$'
+      pattern: '^(0|0[mMhHdDwW]|[1-9][0-9]*[mMhHdDwW])$'
       minLength: 1
       # This allows for over 10 years using the smallest units (minutes)
       maxLength: 8
@@ -986,7 +986,7 @@ components:
             Delete complete Sessions that are older than cleanup_completed_session_ttl (in minutes, hours, days, or weeks).
             0 disables cleanup behavior.
           example: 3d
-          format: '^(0|0[mMhHdDwW]|[1-9][0-9]*[mMhHdDwW])$'
+          pattern: '^(0|0[mMhHdDwW]|[1-9][0-9]*[mMhHdDwW])$'
           minLength: 1
           # This allows for over 10 years using the smallest units (minutes)
           maxLength: 8
@@ -999,7 +999,7 @@ components:
             The maximum amount of time a Component's actual state is considered valid (in minutes, hours, days, or weeks).
             0 disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically.
           example: 6h
-          format: '^(0|0[mMhHdDwW]|[1-9][0-9]*[mMhHdDwW])$'
+          pattern: '^(0|0[mMhHdDwW]|[1-9][0-9]*[mMhHdDwW])$'
           minLength: 1
           # This allows for over 10 years using the smallest units (minutes)
           maxLength: 8


### PR DESCRIPTION
A couple of places in the BOS API spec incorrectly used the `format` keyword when they meant to use the `pattern` keyword. This meant that the specified patterns were not being interpreted or enforced. This corrects that.