### PR TITLE
CASMCMS-9004: Enforce API restrictions in server code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Require boot sets to have some form of node/group/role list specified
+
 ### Changed
 - Modified API spec to enforce previously-recommended limits
 - Make `BootSetName` a write-only property in a boot set, and require it to be equal to the name mapping to that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modified API spec to enforce previously-recommended limits
 - Make `BootSetName` a write-only property in a boot set, and require it to be equal to the name mapping to that
   boot set inside the session template that contains it.
+- Modified session template creation and patching to validate boot set names.
 
 ### Removed
 - Remove vestigial `BASEKEY` definition from sessions and templates server controller source files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Modified API spec to enforce previously-recommended limits
-- Removed inaccurate docstring from `_sanitize_xnames`; removed unnecessary return value
+- Make `BootSetName` a write-only property in a boot set, and require it to be equal to the name mapping to that
+  boot set inside the session template that contains it.
 
 ### Removed
 - Remove vestigial `BASEKEY` definition from sessions and templates server controller source files
 - Removed unused `BootSetNamePathParam` schema from the API spec (a vestige of BOS v1)
+- Removed inaccurate docstring from `_sanitize_xnames`; removed unnecessary return value
 
 ## [2.20.0] - 2024-06-05
 ### Fixed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -151,6 +151,7 @@ components:
       minLength: 1
       maxLength: 127
       pattern: '^[a-zA-Z0-9](?:[-._a-zA-Z0-9]{0,125}[a-zA-Z0-9])?$'
+      writeOnly: true
     BootSetRootfsProvider:
       type: string
       description: The root file system provider.
@@ -490,6 +491,9 @@ components:
         role, and their logical groupings. This collection of nodes is associated with one
         set of boot artifacts and optional additional records for configuration and root
         filesystem provisioning.
+
+        If specified, the name field must match the key mapping to this boot set in the
+        boot_sets field of the containing V2SessionTemplate.
       type: object
       properties:
         name:

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -485,12 +485,15 @@ components:
             Error which prevented the Session from running.
             A null value means the Session has not encountered an error.
       additionalProperties: false
-    V2BootSet:
+    V2BootSetData:
       description: |
         A Boot Set is a collection of nodes defined by an explicit list, their functional
         role, and their logical groupings. This collection of nodes is associated with one
         set of boot artifacts and optional additional records for configuration and root
         filesystem provisioning.
+
+        A boot set requires at least one of the following fields to be specified:
+        node_list, node_roles_groups, node_groups
 
         If specified, the name field must match the key mapping to this boot set in the
         boot_sets field of the containing V2SessionTemplate.
@@ -528,6 +531,13 @@ components:
           $ref: '#/components/schemas/BootSetRootfsProviderPassthrough'
       additionalProperties: false
       required: [path, type]
+    V2BootSet:
+      allOf:
+        - $ref: '#/components/schemas/V2BootSetData'
+        - anyOf:
+          - required: [node_list]
+          - required: [node_roles_groups]
+          - required: [node_groups]
     V2SessionTemplateArray:
       description: An array of Session Templates.
       type: array

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -38,6 +38,7 @@ from bos.server.controllers.v2.sessiontemplates import get_v2_sessiontemplate
 from bos.server.models.v2_session import V2Session as Session  # noqa: E501
 from bos.server.models.v2_session_create import V2SessionCreate as SessionCreate  # noqa: E501
 from bos.server.models.v2_session_update import V2SessionUpdate as SessionUpdate  # noqa: E501
+from bos.server.utils import ParsingException
 from .boot_set import validate_boot_sets, BOOT_SET_ERROR
 
 LOGGER = logging.getLogger('bos.server.controllers.v2.session')
@@ -377,7 +378,3 @@ def _age_to_timestamp(age):
             delta[interval] = int(result.groups()[0])
     delta = timedelta(**delta)
     return get_current_time() - delta
-
-
-class ParsingException(Exception):
-    pass

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -28,7 +28,7 @@ from bos.common.tenant_utils import get_tenant_from_header, get_tenant_aware_key
 from bos.common.utils import exc_type_msg
 from bos.server.models.v2_session_template import V2SessionTemplate as SessionTemplate  # noqa: E501
 from bos.server import redis_db_utils as dbutils
-from bos.server.utils import _canonize_xname
+from bos.server.utils import _canonize_xname, _get_request_json, ParsingException
 from .boot_set import validate_boot_sets
 
 LOGGER = logging.getLogger('bos.server.controllers.v2.sessiontemplates')
@@ -63,12 +63,50 @@ def _sanitize_xnames(st_json):
     Returns:
       Nothing
     """
-    if 'boot_sets' in st_json:
-        for boot_set in st_json['boot_sets']:
-            if 'node_list' in st_json['boot_sets'][boot_set]:
-                clean_nl = [_canonize_xname(node) for node in
-                            st_json['boot_sets'][boot_set]['node_list']]
-                st_json['boot_sets'][boot_set]['node_list'] = clean_nl
+    # There should always be a boot_sets field -- this function
+    # is only called after the template has been verified
+    for boot_set in st_json['boot_sets'].values():
+        if 'node_list' not in boot_set:
+            continue
+        boot_set['node_list'] = [_canonize_xname(node) for node in boot_set['node_list']]
+
+
+def _validate_sanitize_session_template(session_template_id, template_data):
+    """
+    Used when creating or patching session templates
+    """
+    # The boot_sets field is required.
+    if "boot_sets" not in template_data:
+            raise ParsingException("Missing required 'boot_sets' field")
+
+    """All keys in the boot_sets mapping must match the 'name' fields in the
+      boot sets to which they map (if they contain a 'name' field).
+    """
+    for bs_name, bs in template_data["boot_sets"].items():
+        if "name" not in bs:
+            # Set the field here -- this allows the name to be validated
+            # per the schema later
+            bs["name"] = bs_name
+        elif bs["name"] != bs_name:
+            raise ParsingException(f"boot_sets key ({bs_name}) does not match 'name' "
+                                   f"field of corresponding boot set ({bs["name"]})")
+
+    """Convert the JSON request data into a SessionTemplate object.
+       Any exceptions raised here would be generated from the model
+       (i.e. bos.server.models.v2_session_template).
+    """
+    SessionTemplate.from_dict(template_data)
+
+    """
+    We do not bother storing the boot set names inside the boot sets, so delete them.
+    We know every boot set has a name field because we verified that earlier.
+    """
+    for bs in template_data["boot_sets"].values():
+        del bs["name"]
+
+    _sanitize_xnames(template_data)
+    template_data['name'] = session_template_id
+    return
 
 
 @reject_invalid_tenant
@@ -79,39 +117,25 @@ def put_v2_sessiontemplate(session_template_id):  # noqa: E501
     Creates a new session template. # noqa: E501
     """
     LOGGER.debug("PUT /v2/sessiontemplates/%s invoked put_v2_sessiontemplate", session_template_id)
-    if connexion.request.is_json:
-        LOGGER.debug("connexion.request.is_json")
-        LOGGER.debug("type=%s", type(connexion.request.get_json()))
-        LOGGER.debug("Received: %s", connexion.request.get_json())
-    else:
-        return "PUT must be in JSON format", 400
-
     try:
-        data = connexion.request.get_json()
+        template_data = _get_request_json()
     except Exception as err:
-        LOGGER.error("Error parsing request data: %s", exc_type_msg(err))
+        LOGGER.error("Error parsing PUT '%s' request data: %s", session_template_id, exc_type_msg(err))
         return connexion.problem(
             status=400, title="Error parsing the data provided.",
             detail=str(err))
-
-    template_data = data
+    LOGGER.debug("type=%s", type(template_data))
+    LOGGER.debug("Received: %s", template_data)
 
     try:
-        """Convert the JSON request data into a SessionTemplate object.
-           Any exceptions caught here would be generated from the model
-           (i.e. bos.server.models.v2_session_template).
-           In this case return 400 with a description of the specific error.
-        """
-        SessionTemplate.from_dict(template_data)
+        _validate_sanitize_session_template(session_template_id, template_data)
     except Exception as err:
-        LOGGER.error("Error creating session template: %s", exc_type_msg(err))
+        LOGGER.error("Error creating session template '%s': %s", session_template_id, exc_type_msg(err))
         return connexion.problem(
             status=400, title="The session template could not be created.",
             detail=str(err))
 
-    _sanitize_xnames(template_data)
     tenant = get_tenant_from_header()
-    template_data['name'] = session_template_id
     template_data['tenant'] = tenant
     template_key = get_tenant_aware_key(session_template_id, tenant)
     return DB.put(template_key, template_data), 200
@@ -191,40 +215,23 @@ def patch_v2_sessiontemplate(session_template_id):
             status=404, title="Sessiontemplate could not found.",
             detail="Sessiontemplate {} could not be found".format(session_template_id))
 
-    if connexion.request.is_json:
-        LOGGER.debug("connexion.request.is_json")
-        LOGGER.debug("type=%s", type(connexion.request.get_json()))
-        LOGGER.debug("Received: %s", connexion.request.get_json())
-    else:
-        return "Patch must be in JSON format", 400
-
     try:
-        data = connexion.request.get_json()
+        template_data = _get_request_json()
     except Exception as err:
-        LOGGER.error("Error parsing request data: %s", exc_type_msg(err))
+        LOGGER.error("Error parsing PATCH '%s' request data: %s", session_template_id, exc_type_msg(err))
         return connexion.problem(
             status=400, title="Error parsing the data provided.",
             detail=str(err))
-
-    template_data = data
+    LOGGER.debug("type=%s", type(template_data))
+    LOGGER.debug("Received: %s", template_data)
 
     try:
-        """Convert the JSON request data into a SessionTemplate object.
-           Any exceptions caught here would be generated from the model
-           (i.e. bos.server.models.v2_session_template).
-           An example is an exception for a session template name that
-           does not confirm to Kubernetes naming convention.
-           In this case return 400 with a description of the specific error.
-        """
-        SessionTemplate.from_dict(template_data)
+        _validate_sanitize_session_template(session_template_id, template_data)
     except Exception as err:
-        LOGGER.error("Error patching session template: %s", exc_type_msg(err))
+        LOGGER.error("Error patching session template '%s': %s", session_template_id, exc_type_msg(err))
         return connexion.problem(
             status=400, title="The session template could not be patched.",
             detail=str(err))
-
-    _sanitize_xnames(template_data)
-    template_data['name'] = session_template_id
 
     return DB.patch(template_key, template_data), 200
 

--- a/src/bos/server/utils.py
+++ b/src/bos/server/utils.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019, 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019, 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,6 +23,11 @@
 #
 import re
 
+import connexion
+
+class ParsingException(Exception):
+    pass
+
 
 def _canonize_xname(xname):
     """Ensure the xname is canonical.
@@ -36,3 +41,14 @@ def _canonize_xname(xname):
     :rtype: string
     """
     return re.sub(r'x0*(\d+)c0*(\d+)s0*(\d+)b0*(\d+)n0*(\d+)', r'x\1c\2s\3b\4n\5', xname.lower())
+
+
+def _get_request_json():
+    """
+    Used by endpoints which are expecting a JSON payload in the request body.
+    Returns the JSON payload.
+    Raises an Exception otherwise
+    """
+    if not connexion.request.is_json:
+        raise ParsingException("Non-JSON request received")
+    return connexion.request.get_json()


### PR DESCRIPTION
Note: This PR is against a feature branch, not develop. I'll make the final PR to develop once I've completed work on the feature. I wanted to allow PR reviews at a more granular level in the meantime, hence this PR.

Modifications (mostly in the server code) to ensure that API restrictions are enforced (for things that are not automatically enforced by the generated API server code)

API spec changes:
* Require boot sets to have some form of node/group/role list specified (since they are useless without that)
* Make `BootSetName` a write-only property in a boot set (none of the server code ever gets the boot set name from the field inside the boot set --it only ever uses the key in the boot sets map. In truth, I think doesn't make sense to have the name field present in the boot set at all. But if I removed it entirely, then this would require code changes for anyone who happens to be including that field when creating session templates. The change I make here lets them still specify it when creating, but it won't be stored inside the boot set internally in BOS.
* Removed unused `BootSetNamePathParam` schema (a vestige of BOS v1)

Server code changes:
* Require `BootSetName` to be equal to the name mapping to that boot set inside the session template that contains it. In other words, don't let someone have a session template where `BootSetNameA` maps to a boot set whose name field is `BootSetNameB`.
* Modified session template creation and patching to validate boot set names, per above.

I may end up wanting to make further changes beyond these, but it looks like for most things, the changes I've made to the API spec should already prevent non-compliant stuff from making it into the database, even without server-side changes. Note that I am still working on [CASMCMS-9026](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9026), which will sanitize the existing BOS data when upgrading to CSM 1.6, to make sure that it complies with the now-enforced restrictions.