### PR TITLE
CASMCMS-9026: Sanitize BOS data during migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Sanitize BOS data during migration to this BOS version, to ensure it complies with the API specification.
+  - For components and sessions, only validate the fields used to identify them (name, id, tenant). Delete them
+    from the database if these fields have problems.
+  - For templates, validate all fields, but do a more complete attempt to automatically clean them up,
+    only deleting them as a last resort.
+- Do not delete migration job after it completes; instead, set a TTL value for it, to allow time for its logs to be
+  collected after it completes.
 
 ## [2.27.0] - 2024-09-05
 ### Changed

--- a/kubernetes/cray-bos/templates/post-upgrade-job.yaml
+++ b/kubernetes/cray-bos/templates/post-upgrade-job.yaml
@@ -34,10 +34,13 @@ metadata:
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 
 
 spec:
+  # Set ttlSecondsAfterFinished to 28 days.
+  # Because the migration can delete BOS data, but logs when it does so,
+  # this allows its logs to be easily accesible for longer post-upgrade
+  ttlSecondsAfterFinished: 2419200
   template:
     metadata:
       name: "{{ .Release.Name }}"

--- a/src/bos/server/migrations/__init__.py
+++ b/src/bos/server/migrations/__init__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,17 +21,3 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import logging
-
-LOGGER = logging.getLogger('bos.server.migration')
-
-
-def perform_migrations():
-    # Not removing this file entirely because we are going to be adding
-    # code here to migrate the previous BOS data to enforce API field
-    # restrictions
-    pass
-
-
-if __name__ == "__main__":
-    perform_migrations()

--- a/src/bos/server/migrations/__main__.py
+++ b/src/bos/server/migrations/__main__.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Starting in CSM 1.6, BOS is enforcing many API restrictions for the first time.
+When migrating to this BOS version, this tool will attempt to clean up the BOS
+data so that it complies with the spec (like modifying boot sets so that
+rootfs_providers mapping to empty strings instead are not included in the boot set).
+It will only delete BOS resources in two cases:
+
+1. Cases where ID fields are in violation. For example, if a
+session template has an invalid name. The reason this is deleted is because
+that template would be inaccessible using the API or CLI, since incoming
+requests would be rejected for not following the spec. For session templates
+specifically, however, an attempt will be made to modify the name to comply
+with the requirements. Only if that fails will the template be deleted.
+
+2. Cases where the ID fields inside the data structure conflicts with the
+database key. That is, if generating the DB key based on the fields in the
+actual data result in a different database key than the one used to look it up.
+This is not something that is likely to happen, but given the lack of spec
+enforcement that existed in the past, we can't rule it out. In this case,
+for session templates, if the expected database key is not in use, then
+the resource will be moved to the expected key. Otherwise, or for
+non-session templates, it will be deleted.
+
+The CSM upgrade code for 1.6 has been modified to include a BOS backup
+before the BOS service is updated. In addition, this migration tool will
+log all data that is deleted. And the migration pod has been modified
+so that it stays around for much longer after completing.
+"""
+
+import logging
+
+from .db import COMP_DB, SESS_DB, TEMP_DB
+from .sanitize import sanitize_component, sanitize_session, sanitize_session_template
+
+
+LOGGER = logging.getLogger('bos.server.migration')
+
+
+def main():
+    LOGGER.info("Sanitizing session templates")
+    for key, data in TEMP_DB.get_all_as_dict().items():
+        sanitize_session_template(key, data)
+    LOGGER.info("Done sanitizing session templates")
+
+    LOGGER.info("Sanitizing sessions")
+    for key, data in SESS_DB.get_all_as_dict().items():
+        sanitize_session(key, data)
+    LOGGER.info("Done sanitizing sessions")
+
+    LOGGER.info("Sanitizing components")
+    for key, data in COMP_DB.get_all_as_dict().items():
+        sanitize_component(key, data)
+    LOGGER.info("Done sanitizing components")
+
+
+if __name__ == "__main__":
+    log_level = logging.getLevelName('INFO')
+    logging.basicConfig(level=log_level)
+
+    LOGGER.info("Beginning post-upgrade BOS data migration")
+    main()
+    LOGGER.info("Completed post-upgrade BOS data migration")

--- a/src/bos/server/migrations/db.py
+++ b/src/bos/server/migrations/db.py
@@ -1,0 +1,60 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import logging
+
+import bos.server.redis_db_utils as dbutils
+
+LOGGER = logging.getLogger('bos.server.migration')
+
+TEMP_DB=dbutils.get_wrapper(db='session_templates')
+SESS_DB=dbutils.get_wrapper(db='sessions')
+STAT_DB=dbutils.get_wrapper(db='session_status')
+COMP_DB=dbutils.get_wrapper(db='components')
+
+
+def delete_from_db(db: dbutils.DBWrapper, key: str, err_msg: str|None=None) -> None:
+    if err_msg is None:
+        LOGGER.warning("Deleting %s under DB key '%s'", db.db_string, key)
+    else:
+        LOGGER.error("%s; Deleting %s under DB key '%s'", err_msg, db.db_string, key)
+    data = db.get_and_delete(key)
+    if data:
+        LOGGER.info("Deleted %s '%s': %s", db.db_string, key, data)
+    else:
+        LOGGER.warning("Could not delete %s '%s' -- does not exist", db.db_string, key)
+
+
+def delete_component(key: str, err_msg: str|None=None) -> None:
+    delete_from_db(COMP_DB, key, err_msg)
+
+
+def delete_template(key: str, err_msg: str|None=None) -> None:
+    delete_from_db(TEMP_DB, key, err_msg)
+
+
+def delete_session(key: str, err_msg: str|None=None) -> None:
+    delete_from_db(SESS_DB, key, err_msg)
+    LOGGER.info("Deleting associated session status, if it exists")
+    delete_from_db(STAT_DB, key, err_msg)

--- a/src/bos/server/migrations/sanitize.py
+++ b/src/bos/server/migrations/sanitize.py
@@ -1,0 +1,346 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import copy
+import itertools
+import logging
+import string
+
+from bos.common.tenant_utils import get_tenant_aware_key
+from bos.server.controllers.v2.boot_set import HARDWARE_SPECIFIER_FIELDS
+from bos.server.schema import validator
+
+from .db import TEMP_DB, delete_component, delete_session, delete_template
+from .validate import ValidationError, check_component, check_session, check_keys, \
+                      get_required_field, get_validate_tenant, is_valid_available_template_name, \
+                      validate_bootset_path, validate_against_schema
+
+
+LOGGER = logging.getLogger('bos.server.migration')
+
+ALPHANUMERIC = string.ascii_letters + string.digits
+TEMPLATE_NAME_CHARACTERS = ALPHANUMERIC + '-._'
+
+
+def sanitize_component(key: str|bytes, data: dict) -> None:
+    """
+    If the id field is missing or invalid, delete the component
+    """
+    try:
+        check_component(key, data)
+    except ValidationError as exc:
+        delete_component(key, str(exc))
+
+
+def sanitize_session(key: str|bytes, data: dict) -> None:
+    """
+    If the name field is missing, or if the name or tenant fields are invalid, delete the session.
+    """
+    try:
+        check_session(key, data)
+    except ValidationError as exc:
+        delete_session(key, str(exc))
+
+
+def sanitize_session_template(key: str|bytes, data: dict) -> None:
+    """
+    Session templates are the things most likely to run afoul of the API spec.
+    This attempts to automatically fix them if at all possible, only deleting them
+    as a last resort.
+    """
+    try:
+        _sanitize_session_template(key, data)
+    except ValidationError as exc:
+        delete_template(key, str(exc))
+
+
+def _sanitize_session_template(key: str|bytes, data: dict) -> None:
+    """
+    Validates and tries to sanitize the session template.
+    If there are correctable errors, the function will update the database
+    to fix them.
+    If there are uncorrectable errors, the function deletes the template.
+    """
+    # Validate presence of required name and boot_sets fields
+    name = get_required_field("name", data)
+    boot_sets = get_required_field("boot_sets", data)
+
+    # Validate that if there is a non-None tenant field, it follows the schema
+    tenant = get_validate_tenant(data)
+
+    # Make sure that the boot_set field is not empty and correct type
+    if not isinstance(boot_sets, dict):
+        raise ValidationError("'boot_sets' field value has invalid type")
+    if not boot_sets:
+        raise ValidationError("'boot_sets' field value is empty")
+
+    # Make a copy of the session template. If we identify problems, we will see if we can correct
+    # them in the copy. While copying, remove any fields that are no longer in the spec
+    new_data = { k: copy.deepcopy(v) for k,v in data.items()
+                 if k in validator.session_template_fields }
+
+    # Check and sanitize each boot set
+    for bsname, bsdata in new_data["boot_sets"].items():
+        sanitize_bootset(bsname, bsdata)
+
+    sanitize_description_field(new_data)
+    sanitize_cfs_field(new_data)
+
+    new_name = get_unused_legal_template_name(name, tenant)
+
+    if new_name == name:
+        # Name did not change
+        check_keys(key, get_tenant_aware_key(name, tenant))
+
+        validate_against_schema(new_data, "V2SessionTemplate")
+
+        if data == new_data:
+            # Data did not change, so nothing to do
+            return
+
+        # This means the data changed, so we need to update the entry under the existing key
+        LOGGER.warning("Updating session template to comply with the BOS API schema")
+        LOGGER.warning("Old template data: %s", data)
+        LOGGER.warning("New template data: %s", new_data)
+        TEMP_DB.put(key, new_data)
+        return
+
+    # Name changed
+    base_msg = f"Renaming session template '{name}' (tenant: {tenant}) to new name '{new_name}'"
+    if data == new_data:
+        LOGGER.warning(base_msg)
+    else:
+        LOGGER.warning("%s and updating it to comply with the BOS API schema", base_msg)
+
+    delete_template(key, data)
+
+    new_key = get_tenant_aware_key(name, tenant)
+    LOGGER.info("Old DB key = '%s', new DB key = '%s'", key, new_key)
+
+    new_data["name"] = new_name
+    log_rename_in_template_description(name, new_data)
+
+    LOGGER.warning("Old template data: %s", data)
+    LOGGER.warning("New template data: %s", new_data)
+    try:
+        validate_against_schema(new_data, "V2SessionTemplate")
+    except ValidationError:
+        LOGGER.error("New session template does not follow schema -- it will not be saved")
+        return
+
+    TEMP_DB.put(new_key, new_data)
+
+
+def sanitize_description_field(data: dict) -> None:
+    """
+    Ensure that the description field (if present) is a string that is <= 1023 characters long.
+    Delete or truncate it as needed.
+    """
+    try:
+        description = data["description"]
+    except KeyError:
+        # If there is no description field, nothing for us to do
+        return
+
+    # Delete it if it is empty
+    if not description:
+        del data["description"]
+        return
+
+    # Log a warning and delete it if it is not a string
+    if not isinstance(description, str):
+        LOGGER.warning("Removing non-string 'description' field from session template")
+        del data["description"]
+        return
+
+    # Truncate it if it is too long
+    if len(description) > 1023:
+        data["description"] = description[:1023]
+
+
+def sanitize_bootset(bsname: str, bsdata: dict) -> str|None:
+    """
+    Corrects in-place bsdata.
+    Returns an error message if this proves impossible.
+    Otherwise returns None.
+    """
+    # Every boot_set must have a valid path set
+    validate_bootset_path(bsname, bsdata)
+
+    # The type field is required and 's3' is its only legal value
+    # So rather than even checking it, just set it to 's3'
+    bsdata["type"] = "s3"
+
+    # Delete the name field, if it is present -- it is redundant and should not
+    # be stored inside the boot set under the current API spec
+    bsdata.pop("name", None)
+
+    # Remove any fields that are no longer in the spec
+    bad_fields = [ field for field in bsdata if field not in validator.boot_set_fields ]
+    for field in bad_fields:
+        del bsdata[field]
+
+    # Sanitize the cfs field, if any
+    try:
+        sanitize_cfs_field(bsdata)
+    except ValidationError as exc:
+        raise ValidationError(f"Boot set '{bsname}' {exc}") from exc
+
+    nonempty_node_field_found = False
+
+    # Use list() since we will be modifying the dict while iterating over its contents
+    for field, value in list(bsdata.items()):
+        # We have already dealt with 'cfs', 'path', and 'type', so we can skip those
+        if field in { 'cfs', 'path', 'type' }:
+            continue
+
+        # Delete None-valued fields that are not nullable (No boot set fields are nullable)
+        if value is None:
+            del bsdata[field]
+            continue
+
+        if field != 'rootfs_provider' and field not in HARDWARE_SPECIFIER_FIELDS:
+            continue
+
+        # rootfs_provider and the node-specifier fields are optional* but if present,
+        # are not allowed to have an empty value.
+        # So if we find any set to an empty values, delete it.
+        #
+        # * The node-specifier fields are each individually optional, but one of them must
+        #   be set
+        if not value:
+            del bsdata[field]
+        elif field in HARDWARE_SPECIFIER_FIELDS:
+            nonempty_node_field_found = True
+
+    # Validate that at least one of the required node-specified fields is present
+    if nonempty_node_field_found:
+        return
+
+    raise ValidationError(
+        f"Boot set '{bsname}' has no non-empty node fields ({HARDWARE_SPECIFIER_FIELDS})")
+
+
+def sanitize_cfs_field(data: dict) -> None:
+    """
+    If the 'cfs' field is present:
+    * If it's mapped to None, remove it
+    * If it isn't a dict, raise a ValidationError
+    * Remove any invalid fields from it
+    * Delete the configuration field if it is empty or null
+    * If (after the above) the cfs dict is empty, remove it.
+    """
+    try:
+        cfs = data["cfs"]
+    except KeyError:
+        # If no CFS field, nothing to sanitize
+        return
+
+    # The CFS field is not nullable, so if it is mapped to None, delete it
+    # Also delete it if it is empty, since that is the same effect as it not being present
+    if not cfs:
+        del data["cfs"]
+        return
+
+    # If it does not map to a dictionary, raise an exception
+    if not isinstance(cfs, dict):
+        raise ValidationError("'cfs' field value has invalid type")
+
+    # Remove any fields that are no longer in the spec
+    bad_fields = [ field for field in cfs if field not in validator.cfs_fields ]
+    for field in bad_fields:
+        del cfs[field]
+
+    if "configuration" in cfs:
+        # The configuration field is not nullable, so if it maps to None, delete it
+        # Also delete it if it is empty, since that is the same effect as it not being present
+        if not cfs["configuration"]:
+            del cfs["configuration"]
+
+    # If this results in the cfs field being empty now, delete it
+    if not cfs:
+        del data["cfs"]
+
+
+def get_unused_legal_template_name(name: str, tenant: str|None) -> str:
+    """
+    If the current name is legal, return it unchanged.
+    Otherwise, try to find a name which is not in use and which is legal per the spec.
+    Returns the new name if successful, otherwise raises ValidationError
+    """
+    try:
+        validate_against_schema(name, "SessionTemplateName")
+        return name
+    except ValidationError:
+        # If the name has no legal characters at all, or in the (hopefully unlikely) case that it
+        # is 0 length, make no attempt to salvage it. Otherwise, we will try to find a good name
+        if not name or not any(c in TEMPLATE_NAME_CHARACTERS for c in name):
+            raise
+
+    LOGGER.warning("Session template name '%s' (tenant: %s) does not follow schema. "
+                   "Will attempt to rename to a legal name", name, tenant)
+
+    # Strip out illegal characters, but replace spaces with underscores and prepend 'auto_renamed_'
+    new_name_base = 'auto_renamed_' + ''.join([ c for c in name.replace(' ','_')
+                                                if c in TEMPLATE_NAME_CHARACTERS ])
+
+    # Trim to 127 characters, if it exceeds that
+    new_name = new_name_base[:127]
+
+    # At this point the only thing preventing this from being a legal name would be if the final
+    # character is not alphanumeric
+    if new_name[-1] in ALPHANUMERIC:
+        if is_valid_available_template_name(new_name, tenant):
+            return new_name
+
+    # Trying all 2 character alphanumeric suffixes gives 1953 options, which is enough of an effort
+    # for us to make here.
+    for suffix_length in range(1, 3):
+        for suffix in itertools.combinations_with_replacement(ALPHANUMERIC, suffix_length):
+            new_name = f'{new_name_base[:126-suffix_length]}_{suffix}'
+            if is_valid_available_template_name(new_name, tenant):
+                return new_name
+
+    LOGGER.error("Unable to find unused valid new name for session template '%s' (tenant: %s)",
+                 name, tenant)
+    raise ValidationError("Name does not follow schema")
+
+
+def log_rename_in_template_description(old_name: str, data: dict) -> None:
+    """
+    If possible, update the session template description field to record the previous name of this
+    template. Failing that, if possible, at least record that it was renamed.
+    """
+    rename_messages = [
+        f"Former name: {old_name}",
+        "Renamed during BOS upgrade",
+        "Auto-renamed",
+        "Renamed" ]
+
+    current_description = data.get("description", "")
+    for msg in rename_messages:
+        new_description = f"{current_description}; {msg}" if current_description else msg
+        if len(new_description) <= 1023:
+            data["description"] = new_description
+            return

--- a/src/bos/server/migrations/validate.py
+++ b/src/bos/server/migrations/validate.py
@@ -1,0 +1,130 @@
+#
+# MIT License
+#
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import logging
+from typing import Any
+
+from bos.common.tenant_utils import get_tenant_aware_key
+from bos.common.utils import exc_type_msg
+from bos.server.schema import validator
+
+from .db import TEMP_DB
+
+
+LOGGER = logging.getLogger('bos.server.migration')
+
+
+class ValidationError(Exception):
+    """
+    Raised by validation functions when they find problems
+    """
+
+
+def check_session(key: str|bytes, data: dict) -> None:
+    """
+    Raises a ValidationError if the data contains fatal errors.
+    """
+    name = get_required_field("name", data)
+    validate_against_schema(name, "V2SessionName")
+    tenant = get_validate_tenant(data)
+    expected_db_key = get_tenant_aware_key(name, tenant)
+    check_keys(key, expected_db_key)
+
+
+def check_component(key: str|bytes, data: dict) -> None:
+    """
+    Raises a ValidationError if the data contains fatal errors.
+    """
+    compid = get_required_field("id", data)
+    validate_against_schema(compid, "V2ComponentId")
+    check_keys(key, compid)
+
+
+def get_validate_tenant(data: dict) -> str|None:
+    """
+    If no tenant field present, return None.
+    If the tenant field value is valid, return it.
+    Otherwise, raise ValidationError
+    """
+    tenant = data.get("tenant", None)
+    if tenant is not None:
+        validate_against_schema(tenant, "V2TenantName")
+    return tenant
+
+
+def validate_bootset_path(bsname: str, bsdata: dict) -> None:
+    try:
+        path = get_required_field("path", bsdata)
+    except ValidationError as exc:
+        raise ValidationError(f"Boot set '{bsname}': {exc}") from exc
+    try:
+        validate_against_schema(path, "BootManifestPath")
+    except ValidationError as exc:
+        raise ValidationError(f"Boot set '{bsname}' has invalid 'path' field: {exc}") from exc
+
+
+def check_keys(actual: str|bytes, expected: str|bytes) -> str|None:
+    """
+    Converts both keys to strings.
+    Raises ValidationError if the strings do not match
+    """
+    if isinstance(actual, bytes):
+        actual = actual.decode()
+    if isinstance(expected, bytes):
+        expected = expected.decode()
+    if actual != expected:
+        raise ValidationError(
+            f"Actual DB key ('{actual}') does not match expected key ('{expected}')")
+
+
+def is_valid_available_template_name(name: str, tenant: str|None) -> bool:
+    if get_tenant_aware_key(name, tenant) in TEMP_DB:
+        return False
+    try:
+        validate_against_schema(name, "SessionTemplateName")
+    except ValidationError:
+        return False
+    return True
+
+
+def validate_against_schema(obj: Any, schema_name: str) -> None:
+    """
+    Raises a ValidationError if it does not follow the schema
+    """
+    try:
+        validator.validate(obj, schema_name)
+    except Exception as exc:
+        LOGGER.error(exc_type_msg(exc))
+        raise ValidationError(f"Does not follow {schema_name} schema: {obj}") from exc
+
+
+def get_required_field(field: str, data: dict) -> Any:
+    """
+    Returns the value of the field in the dict
+    Raises ValiationError otherwise
+    """
+    try:
+        return data[field]
+    except KeyError as exc:
+        raise ValidationError(f"Missing required '{field}' field") from exc

--- a/src/bos/server/schema.py
+++ b/src/bos/server/schema.py
@@ -58,4 +58,19 @@ class Validator:
     def validate_session_template(self, data):
         self.validate(data, "V2SessionTemplate")
 
+    def get_schema_fields(self, schema_name: str):
+        return set(self.api_schema[schema_name]["properties"])
+
+    @property
+    def session_template_fields(self):
+        return self.get_schema_fields("V2SessionTemplate")
+
+    @property
+    def boot_set_fields(self):
+        return self.get_schema_fields("V2BootSet")
+
+    @property
+    def cfs_fields(self):
+        return self.get_schema_fields("V2CfsParameters")
+
 validator = Validator()


### PR DESCRIPTION
New in CSM 1.6, BOS now enforces several things in the API spec that previously were unenforced. Notably, some names for session templates were previously allowed, but now are illegal. As things stand, these templates are essentially inaccessible via the API or CLI in CSM 1.6, because BOS will reject the requests due to the schema violation.

This PR changes what happens during the migration to a new BOS version to avoid that. Specifically, for all fields that are used in the API and CLI to reference BOS resources (their id/name field and, in some cases, the tenant field), it checks if they are legal. For components and sessions, if the fields are illegal, the associated resource is deleted, and a message is logged. I do not think this is likely to happen, because BOS had been validating session names already, and under normal circumstances, it was the only thing creating components.

For session templates, I do expect there to be cases where the API spec is not being followed, both in terms of the name and in other fields. For session templates, the migration code attempts to automatically fix them and make them compliant with the updated spec. Only when it is not able to do this does it give up and delete them. I think the logic I've added to do this should prevent any functioning session templates from being deleted.

This PR also changes the migration pod so that it is not automatically deleted for 30 days after completing, allowing for plenty of time to look at its logs.

In addition, a separate PR has already been made that performs a backup of BOS data before the upgrade to CSM 1.6. This will ensure that nobody loses data because of this pruning process.

I tested this on fanta, populating the BOS data with various kinds of errors, and verifying that the migration code handled them properly. There is some room for improvement on the readability of the migration pod logs, but that doesn't need to be handled in this PR, necessarily.