### PR TITLE
CASMCMS-9039: Fix applystage to work under multi-tenancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The applystage operation works again. It was broken when multi-tenancy support was added.
+
 ### Removed
 - Remove vestigial `BASEKEY` definition from sessions and templates server controller source files
 - Remove unnecessary (and invalid) `__all__` assignment from `__init__.py` in filters module


### PR DESCRIPTION
## Summary and Scope

When executing the applystage operation, BOS needs to look up the session ID using the tenant. The code has been changed to do this.

## Issues and Related PRs


* Resolves [CASMCMS-9039]
* Change will also be needed in `master`

## Testing

### Tested on:

  * `drax`

### Test description:

I applystage'd to a node to see if it effectively can do it. It could. I didn't experience the error I ran into before.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low, it's already broken.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

