### PR TITLE
CASMCMS-9039: Fix applystage to work under multi-tenancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.10.21]
 ### Fixed
 - The applystage operation works again. It was broken when multi-tenancy support was added.
+- Fix incorrect exception instantiation arguments in `boot_image_metadata/factory.py`
 
 ## [2.10.20] - 2024-06-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.10.21]
+## [Unreleased]
+
+## [2.10.21] - 2024-07-12
 ### Fixed
 - The applystage operation works again. It was broken when multi-tenancy support was added.
 - Fix incorrect exception instantiation arguments in `boot_image_metadata/factory.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.10.21]
+### Fixed
+- The applystage operation works again. It was broken when multi-tenancy support was added.
 
 ## [2.10.20] - 2024-06-05
 ### Fixed

--- a/src/bos/operators/utils/boot_image_metadata/factory.py
+++ b/src/bos/operators/utils/boot_image_metadata/factory.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -48,5 +48,4 @@ class BootImageMetaDataFactory(object):
             if path_type == 's3':
                 return S3BootImageMetaData(self.boot_set)
             else:
-                raise BootImageMetaDataUnknown("No BootImageMetaData class for "
-                                                      "type %s", path_type)
+                raise BootImageMetaDataUnknown(f"No BootImageMetaData class for type {path_type}")


### PR DESCRIPTION
When executing the applystage operation, BOS needs to look up the session ID using the tenant. The code has been changed to do this.

(cherry picked from commit 21f039dc4b6d29c05d8546e77ceb742339e062ae)

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

