### PR TITLE
CASMTRIAGE-7147: Create max_component_batch_size option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Create new BOS v2 `max_component_batch_size` option to limit number of components a BOS operator
+  will work on at once.
+
 ### Fixed
 - Fix incorrect exception instantiation arguments in `boot_image_metadata/factory.py`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Global read timeout values for all objects and operations which leverage requests_retry handler.
+- Heartbeat threads now exit when main thread is no longer alive.
+
 ### Changed
 - Create new BOS v2 `max_component_batch_size` option to limit number of components a BOS operator
   will work on at once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.42] - 07-22-2024
 ### Added
 - Global read timeout values for all objects and operations which leverage requests_retry handler.
 - Heartbeat threads now exit when main thread is no longer alive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Global read timeout values for all objects and operations which leverage requests_retry handler.
 - Heartbeat threads now exit when main thread is no longer alive.
+- Add request timeouts to BOS reporter
 
 ### Changed
 - Create new BOS v2 `max_component_batch_size` option to limit number of components a BOS operator

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1672,6 +1672,12 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
           type: integer
           description: The default maximum number attempts per node for failed actions.
           example: 1
+        max_component_batch_size:
+          type: integer
+          description: The maximum number of components that a BOS operator will process at once. 0 means no limit.
+          example: 1000
+          minimum: 0
+          maximum: 131071
       additionalProperties: true
     # Schemas that combine objects of different versions
     SessionTemplateArray:

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -31,7 +31,7 @@ import logging
 import threading
 import os
 import time
-from typing import List, NoReturn, Type
+from typing import Generator, List, NoReturn, Type
 
 from bos.common.utils import exc_type_msg
 from bos.common.values import Status
@@ -74,6 +74,7 @@ class BaseOperator(ABC):
 
     def __init__(self) -> NoReturn:
         self.bos_client = BOSClient()
+        self.__max_batch_size = 0
 
     @property
     @abstractmethod
@@ -108,6 +109,23 @@ class BaseOperator(ABC):
                 LOGGER.exception('Unhandled exception getting polling frequency: {}'.format(e))
                 time.sleep(5)  # A small sleep for when exceptions getting the polling frequency
 
+    @property
+    def max_batch_size(self) -> int:
+        max_batch_size = options.max_component_batch_size
+        if max_batch_size != self.__max_batch_size:
+            LOGGER.info("max_component_batch_size option set to %d", max_batch_size)
+            self.__max_batch_size = max_batch_size
+        return max_batch_size
+
+    def _chunk_components(self, components: List[dict]) -> Generator[List[dict], None, None]:
+        """
+        Break up the components into groups of no more than max_batch_size nodes,
+        and yield each group in turn.
+        If the max size is set to 0, just yield the entire list.
+        """
+        for chunk in chunk_components(components, self.max_batch_size):
+            yield chunk
+
     def _run(self) -> None:
         """ A single pass of detecting and acting on components  """
         components = self._get_components()
@@ -115,6 +133,14 @@ class BaseOperator(ABC):
             LOGGER.debug('Found 0 components that require action')
             return
         LOGGER.info('Found %d components that require action', len(components))
+        for chunk in self._chunk_components(components):
+            self._run_on_chunk(chunk)
+
+    def _run_on_chunk(self, components: List[dict]) -> None:
+        """
+        Acts on a chunk of components
+        """
+        LOGGER.debug("Processing %d components", len(components))
         if self.retry_attempt_field:  # Only check for failed components if we track retries for this operator
             components = self._handle_failed_components(components)
             if not components:
@@ -251,6 +277,19 @@ class BaseOperator(ABC):
         LOGGER.info('Found %d components that require updates', len(data))
         LOGGER.debug(f'Updated components: {data}')
         self.bos_client.components.update_components(data)
+
+
+def chunk_components(components: List[dict],
+                     max_batch_size: int) -> Generator[List[dict], None, None]:
+    """
+    Break up the components into groups of no more than max_batch_size nodes,
+    and yield each group in turn.
+    If the max size is set to 0, just yield the entire list.
+    """
+    chunk_size = max_batch_size if max_batch_size > 0 else len(components)
+    while components:
+        yield components[:chunk_size]
+        components = components[chunk_size:]
 
 
 def _update_log_level() -> None:

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -41,6 +41,7 @@ from bos.operators.utils.clients.bos import BOSClient
 from bos.operators.utils.liveness.timestamp import Timestamp
 
 LOGGER = logging.getLogger('bos.operators.base')
+MAIN_THREAD = threading.current_thread()
 
 
 class BaseOperatorException(Exception):
@@ -318,6 +319,9 @@ def _liveliness_heartbeat() -> NoReturn:
     period of time.
     """
     while True:
+        if not MAIN_THREAD.is_alive():
+            # All hope abandon ye who enter here
+            return
         Timestamp()
         time.sleep(10)
 

--- a/src/bos/operators/discovery.py
+++ b/src/bos/operators/discovery.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -78,8 +78,9 @@ class DiscoveryOperator(BaseOperator):
             LOGGER.info("No new component(s) discovered.")
             return
         LOGGER.info("%s new component(s) from HSM." %(len(components_to_add)))
-        self.bos_client.components.put_components(components_to_add)
-        LOGGER.info("%s new component(s) added to BOS!" %(len(components_to_add)))
+        for chunk in self._chunk_components(components_to_add):
+            self.bos_client.components.put_components(chunk)
+            LOGGER.info("%s new component(s) added to BOS!" %(len(chunk)))
 
     @property
     def bos_components(self) -> Set[str]:

--- a/src/bos/operators/status.py
+++ b/src/bos/operators/status.py
@@ -74,6 +74,15 @@ class StatusOperator(BaseOperator):
         if not components:
             LOGGER.debug('No enabled components found')
             return
+        LOGGER.debug('Found %d components that require action', len(components))
+        for chunk in self._chunk_components(components):
+            self._run_on_chunk(chunk)
+
+    def _run_on_chunk(self, components) -> None:
+        """
+        Acts on a chunk of components
+        """
+        LOGGER.debug("Processing %d components", len(components))
         component_ids = [component['id'] for component in components]
         power_states, xname_status_failures = get_power_states(component_ids)
         cfs_states = self._get_cfs_components()

--- a/src/bos/operators/utils/clients/bos/options.py
+++ b/src/bos/operators/utils/clients/bos/options.py
@@ -116,6 +116,9 @@ class Options:
     def default_retry_policy(self):
         return self.get_option('default_retry_policy', int, 3)
 
+    @property
+    def max_component_batch_size(self):
+        return self.get_option('max_component_batch_size', int, 2800)
 
 
 options = Options()

--- a/src/bos/reporter/client.py
+++ b/src/bos/reporter/client.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -71,12 +71,29 @@ def get_auth_token(path='/opt/cray/auth-utils/bin/get-auth-token'):
         time.sleep(2)
 
 
-def requests_retry_session(retries=10, connect=10, backoff_factor=0.5,
+class TimeoutHTTPAdapter(HTTPAdapter):
+    """
+    An HTTP Adapter that allows a session level timeout for both read and connect attributes. This prevents interruption
+    to reads that happen as a function of time or istio resets that causes our applications to sit and wait forever on
+    a half open socket.
+    """
+    def __init__(self, *args, **kwargs):
+        if "timeout" in kwargs:
+            self.timeout = kwargs["timeout"]
+            del kwargs["timeout"]
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        timeout = kwargs.get("timeout")
+        if timeout is None and hasattr(self, 'timeout'):
+            kwargs["timeout"] = self.timeout
+        return super().send(request, **kwargs)
+
+
+def requests_retry_session(retries=10, backoff_factor=0.5,
                            status_forcelist=(500, 502, 503, 504),
-                           session=None):
-    """
-    Returns a session with retries built into it.
-    """
+                           connect_timeout=3, read_timeout=10,
+                           session=None, protocol=PROTOCOL):
     session = session or requests.Session()
     retry = Retry(
         total=retries,
@@ -85,7 +102,8 @@ def requests_retry_session(retries=10, connect=10, backoff_factor=0.5,
         backoff_factor=backoff_factor,
         status_forcelist=status_forcelist,
     )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount(PROTOCOL, adapter)
-    session.headers.update({'Authorization': 'Bearer %s' % (get_auth_token())})
+    adapter = TimeoutHTTPAdapter(max_retries=retry, timeout=(connect_timeout, read_timeout))
+    # Must mount to http://
+    # Mounting to only http will not work!
+    session.mount("%s://" % protocol, adapter)
     return session

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -48,6 +48,7 @@ DEFAULTS = {
     'max_power_off_wait_time': 300,
     'polling_frequency': 15,
     'default_retry_policy': 3,
+    'max_component_batch_size': 2800
 }
 
 


### PR DESCRIPTION
The LANL Crossroads system was experiencing BOSv2 failures, and the root cause turned out to be that PCS was trying to perform database transactions that were too large. Ideally PCS itself should be fixed, but in the meantime, this PR to BOS avoids the issue.

This creates a new BOS v2 option -- `max_component_batch_size_option`. Generally speaking, this will limit the number of components that a BOS operator will work on at a single time. This isn't exactly true -- for example, the discovery operator builds up its entire list of new components, even if that list exceeds this limit. But then when making the API call to BOS to create the new components, they are done in groups that do not exceed this size.

Similarly, the session setup operator figures out all of the components to be updated, but then does the updates in batches that do not exceed this limit.

Basically, the goal is to make sure that any API calls that the operators are making will not explicitly list more than this many nodes. They may still make query calls which return more lists that exceed this limit. So far in the testing at Crossroads, this has not been a problem.

Crossroads is running a first draft of this patch already. This PR is for a more refined patch (the original one used a Kubernetes environment variable to set the option, but obviously it makes more sense to make it an actual option.

The default value for the option was set based on the fact that UKMet has a little over 2800 nodes, and they have not seen issues. Crossroads had over 6000 nodes, so probably the value could be higher and still be okay, but I don't have any good way to test it. And since most customers probably have under 2800 nodes anyway, it won't make a difference to them.

## Related PRs

CSM 1.5 backport: https://github.com/Cray-HPE/bos/pull/340
CSM 1.6 backport: https://github.com/Cray-HPE/bos/pull/341

Add new option to CLI
CSM 1.4: https://github.com/Cray-HPE/craycli/pull/155
CSM 1.5: https://github.com/Cray-HPE/craycli/pull/156
CSM 1.6: https://github.com/Cray-HPE/craycli/pull/157

This also pulls in this backport PR:
https://github.com/Cray-HPE/bos/pull/342