### PR TITLE
CASMCMS-9051: Backport CASMCMS-8752 changes to CSM 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.42] - 07-17-2024
+### Added
+- Global read timeout values for all objects and operations which leverage requests_retry handler.
+- Heartbeat threads now exit when main thread is no longer alive.
+
 ### Changed
 - Create new BOS v2 `max_component_batch_size` option to limit number of components a BOS operator
   will work on at once.

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -42,6 +42,7 @@ from bos.operators.utils.clients.bos import BOSClient
 from bos.operators.utils.liveness.timestamp import Timestamp
 
 LOGGER = logging.getLogger('bos.operators.base')
+MAIN_THREAD = threading.current_thread()
 
 
 class BaseOperatorException(Exception):
@@ -333,6 +334,9 @@ def _liveliness_heartbeat() -> NoReturn:
     period of time.
     """
     while True:
+        if not MAIN_THREAD.is_alive():
+            # All hope abandon ye who enter here
+            return
         Timestamp()
         time.sleep(10)
 


### PR DESCRIPTION
CASMCMS-8752 added timeouts to the API requests made by the BOS operators, preventing hangs that had been observed. We are seeing similar hangs at UKMet, and I see that these changes were never backported to CSM 1.4. This PR just backports those changes.

I am making this PR against the other CSM 1.4 BOS development branch I have going.

I tested this on wasp and found no issues.