### PR TITLE
CASMCMS-9052: Add request timeouts to BOS reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add request timeouts to BOS reporter API calls
 
 ### Changed
 - Code linting (no functional changes)
@@ -13,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Handle case where no path value is set in boot set in `boot_image_metadata/factory.py`
 - Raise exception when there is an error getting the service version
+
+### Removed
+- Removed redundant `duration_to_timedelta` function definition from BOS reporter source.
 
 ## [2.21.0]
 

--- a/src/bos/reporter/client.py
+++ b/src/bos/reporter/client.py
@@ -30,10 +30,9 @@ import os
 import logging
 import subprocess
 import time
+from functools import partial
 
-import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from bos.common.utils import requests_retry_session as common_requests_retry_session
 
 from . import PROTOCOL
 
@@ -74,22 +73,4 @@ def get_auth_token(path='/opt/cray/auth-utils/bin/get-auth-token'):
         time.sleep(2)
 
 
-def requests_retry_session(retries=10, connect=10, backoff_factor=0.5,
-                           status_forcelist=(500, 502, 503, 504),
-                           session=None):
-    """
-    Returns a session with retries built into it.
-    """
-    session = session or requests.Session()
-    retry = Retry(
-        total=retries,
-        read=retries,
-        connect=retries,
-        backoff_factor=backoff_factor,
-        status_forcelist=status_forcelist,
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount(PROTOCOL, adapter)
-    auth_token = get_auth_token()
-    session.headers.update({'Authorization': f'Bearer {auth_token}'})
-    return session
+requests_retry_session = partial(common_requests_retry_session, protocol=PROTOCOL)

--- a/src/bos/reporter/status_reporter/__main__.py
+++ b/src/bos/reporter/status_reporter/__main__.py
@@ -28,7 +28,7 @@ import re
 import datetime
 from time import sleep
 
-from bos.common.utils import exc_type_msg
+from bos.common.utils import duration_to_timedelta, exc_type_msg
 from bos.reporter.client import requests_retry_session
 from bos.reporter.node_identity import read_identity
 from bos.reporter.components.state import report_state, BOSComponentException, UnknownComponent
@@ -91,22 +91,6 @@ def report_state_until_success(component):
             continue
         LOGGER.info("Updated the actual_state record for BOS component '%s'.", component)
         return
-
-
-def duration_to_timedelta(timestamp: str):
-    """
-    Converts a <digit><duration string> to a timedelta object.
-    """
-    # Calculate the corresponding multiplier for each time value
-    seconds_table = {'s': 1,
-                     'm': 60,
-                     'h': 60 * 60,
-                     'd': 60 * 60 * 24,
-                     'w': 60 * 60 * 24 * 7}
-    timeval, durationval = TIME_DURATION_PATTERN.search(timestamp).groups()
-    timeval = float(timeval)
-    seconds = timeval * seconds_table[durationval]
-    return datetime.timedelta(seconds = seconds)
 
 
 def main():


### PR DESCRIPTION
Remove redundant function definitions in BOS reporter -- use the `bos.common.util` functions instead.