### PR TITLE
CASMCMS-9067: Add session_limit_required option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New BOS v2 option `session_limit_required`
+  - If set, new sessions must have a limit specified
+  - When creating a BOS session, specifying a limit value of `*` has the effect of not limiting
+    the session, which is one way to create a non-limited session if `session_limit_required` is set.
+
 ### Changed
 - List Python packages after installing, for build log purposes
 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -363,6 +363,8 @@ components:
         will be limited. Components are treated as OR operations unless
         preceded by "&" for AND or "!" for NOT.
 
+        Alternatively, the limit can be set to "*", which means no limit.
+
         It is recommended that this should be 1-65535 characters in length.
 
         This restriction is not enforced in this version of BOS, but it is
@@ -517,7 +519,8 @@ components:
             Shutdown             Power down Components that are on.
     V2SessionCreate:
       description: |
-        A Session Creation object. A UUID name is generated if a name is not provided.
+        A Session Creation object. A UUID name is generated if a name is not provided. The limit parameter is
+        required if the session_limit_required option is true.
       type: object
       properties:
         name:
@@ -1049,10 +1052,13 @@ components:
           maximum: 1048576
         max_component_batch_size:
           type: integer
-          description: The maximum number of components that a BOS operator will process at once. 0 means no limit.
+          description: The maximum number of Components that a BOS operator will process at once. 0 means no limit.
           example: 1000
           minimum: 0
           maximum: 131071
+        session_limit_required:
+          type: boolean
+          description: If true, Sessions cannot be created without specifying the limit parameter.
       additionalProperties: true
 
   requestBodies:

--- a/src/bos/operators/utils/clients/bos/options.py
+++ b/src/bos/operators/utils/clients/bos/options.py
@@ -120,5 +120,8 @@ class Options:
     def max_component_batch_size(self):
         return self.get_option('max_component_batch_size', int, 2800)
 
+    @property
+    def session_limit_required(self):
+        return self.get_option('session_limit_required', bool, False)
 
 options = Options()

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -49,7 +49,8 @@ DEFAULTS = {
     'max_power_off_wait_time': 300,
     'polling_frequency': 15,
     'default_retry_policy': 3,
-    'max_component_batch_size': 2800
+    'max_component_batch_size': 2800,
+    "session_limit_required": False
 }
 
 

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -36,6 +36,7 @@ from bos.common.utils import exc_type_msg, get_current_time, get_current_timesta
 from bos.common.values import Phase, Status
 from bos.server import redis_db_utils as dbutils
 from bos.server.controllers.v2.components import get_v2_components_data
+from bos.server.controllers.v2.options import get_v2_options_data
 from bos.server.controllers.v2.sessiontemplates import get_v2_sessiontemplate
 from bos.server.models.v2_session import V2Session as Session  # noqa: E501
 from bos.server.models.v2_session_create import V2SessionCreate as SessionCreate  # noqa: E501
@@ -70,6 +71,13 @@ def post_v2_session():  # noqa: E501
         msg = "Post must be in JSON format"
         LOGGER.error(msg)
         return msg, 400
+
+    # If no limit is specified, check to see if we require one
+    if not session_create.limit and get_v2_options_data().get('session_limit_required', False):
+        msg = "session_limit_required option is set, but this session has no limit specified"
+        LOGGER.error(msg)
+        return msg, 400
+
     template_name = session_create.template_name
     LOGGER.debug("Template Name: %s operation: %s", template_name, session_create.operation)
     # Check that the template_name exists.


### PR DESCRIPTION
## Summary and Scope

This adds a new BOS v2 option (`session_limit_required`) at the request of UKMet. This option is disabled by default. If it is disabled, then BOS works exactly as it does currently.

If the option is enabled, then attempts to create a BOS v2 session without specifying a limit will fail. For cases when the user actually wants to create a session without a limit, they can specify a limit of `*`.

I tested this on mug, along with the corresponding CLI changes.

Backports:
* https://github.com/Cray-HPE/bos/pull/347
* https://github.com/Cray-HPE/bos/pull/348

Cray CLI PRs:
* https://github.com/Cray-HPE/craycli/pull/158
* https://github.com/Cray-HPE/craycli/pull/159
* https://github.com/Cray-HPE/craycli/pull/160