### PR TITLE
CASMCMS-9081: Added the authorization token back into the bos-reporter API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Added the authorization token back into the bos-reporter API requests
+
 ## [2.0.43] - 07-29-2024
 ### Added
 - New BOS v2 option `session_limit_required`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.44] - 08-09-2024
+
 ### Fixed
 - Added the authorization token back into the bos-reporter API requests
 

--- a/src/bos/reporter/client.py
+++ b/src/bos/reporter/client.py
@@ -106,4 +106,7 @@ def requests_retry_session(retries=10, backoff_factor=0.5,
     # Must mount to http://
     # Mounting to only http will not work!
     session.mount("%s://" % protocol, adapter)
+    auth_token = get_auth_token()
+    headers = {'Authorization': f'Bearer {auth_token}'}
+    session.headers.update(headers)
     return session


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/bos/pull/351 for CSM 1.4

The changes are smaller because in CSM 1.4 and CSM 1.5, BOS reporter doesn't call the requests function from the BOS server code, but instead defines its own.

Testing this on wasp currently.