### PR TITLE
CASMCMS-9081: Added the authorization token back into the bos-reporter API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.24] - 2024-08-09
+
 ### Fixed
 - Added the authorization token back into the bos-reporter API requests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Added the authorization token back into the bos-reporter API requests
+
 ## [2.10.23] - 2024-07-29
 ### Added
 - New BOS v2 option `session_limit_required`

--- a/src/bos/reporter/client.py
+++ b/src/bos/reporter/client.py
@@ -106,4 +106,7 @@ def requests_retry_session(retries=10, backoff_factor=0.5,
     # Must mount to http://
     # Mounting to only http will not work!
     session.mount("%s://" % protocol, adapter)
+    auth_token = get_auth_token()
+    headers = {'Authorization': f'Bearer {auth_token}'}
+    session.headers.update(headers)
     return session


### PR DESCRIPTION
https://github.com/Cray-HPE/bos/pull/352 for CSM 1.5