### PR TITLE
CASMCMS-9078: BOS tags SBPS images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- BOS automatically tags IMS images with the 'sbps-project: true' tag when using SBPS as the rootfs provider.
 
 ## [2.25.0] - 2024-08-15
 ### Changed

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -154,7 +154,7 @@ class BaseOperator(ABC):
             components = self._act(components)
         except Exception as e:
             LOGGER.error("An unhandled exception was caught while trying to act on components: %s",
-                         e, exec_info=True)
+                         e, exc_info=True)
             for component in components:
                 component["error"] = str(e)
         self._update_database(components)

--- a/src/bos/operators/utils/clients/ims.py
+++ b/src/bos/operators/utils/clients/ims.py
@@ -1,0 +1,84 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import logging
+from requests.exceptions import HTTPError
+
+from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
+
+SERVICE_NAME = 'cray-ims'
+IMS_VERSION = 'v3'
+BASE_ENDPOINT = f"{PROTOCOL}://{SERVICE_NAME}/{IMS_VERSION}"
+IMAGES_ENDPOINT = f"{BASE_ENDPOINT}/images"
+
+LOGGER = logging.getLogger('bos.operators.utils.clients.ims')
+IMS_TAG_OPERATIONS = ['set', 'remove']
+
+class TagFailure(Exception):
+    pass
+
+def patch_image(image_id, data, session=None):
+    if not data:
+        LOGGER.warning("patch_image called without data; returning without action.")
+        return
+    if not session:
+        session = requests_retry_session()
+    LOGGER.debug("PATCH %s with body=%s", IMAGES_ENDPOINT, data)
+    response = session.patch(f"{IMAGES_ENDPOINT}/{image_id}", json=data)
+    LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
+                 response.reason, compact_response_text(response.text))
+    try:
+        response.raise_for_status()
+    except HTTPError as err:
+        LOGGER.error("Failed asking IMS to tag image: %s", exc_type_msg(err))
+        raise
+
+def tag_image(image_id: str, operation: str, key: str, value: str = None, session=None) -> None:
+    if operation not in IMS_TAG_OPERATIONS:
+        msg = f"{operation} not valid. Expecting one of {IMS_TAG_OPERATIONS}"
+        LOGGER.error(msg)
+        raise TagFailure(msg)
+
+    if not key:
+        msg = f"key must exist: {key}"
+        LOGGER.error(msg)
+        raise TagFailure(msg)
+
+    if value:
+        LOGGER.debug(f"Patching image {image_id} {operation}ing key: {key} value: {value}")
+    else:
+        LOGGER.debug(f"Patching image {image_id} {operation}ing key: {key}")
+
+    if not session:
+        session = requests_retry_session()
+
+    data = {
+        "metadata": {
+            "operation": operation,
+            "key": key,
+            "value": value
+            }
+    }
+    patch_image(image_id=image_id, data=data, session=session)
+


### PR DESCRIPTION
## Summary and Scope

The Scalable Boot Provisioning Service (SBPS) provides root filesystems to nodes when they boot. The images containing these root filesystems need to be tagged in the Image Management Service with 'sbps-project: true' before SBPS projects them to the nodes. With this mod, BOS tags any rootfs it is booting a node with with this key/value tag to ensure that it is projected during booting. This relieves the admin from needing to manually tag the image. This is a quality of life mod.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-9078]
* Change will also be needed in `master`
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `starlord`

### Test description:

[CASMCMS-9078-Testing.docx](https://github.com/user-attachments/files/16630131/CASMCMS-9078-Testing.docx)



_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

