### PR TITLE
CASMCMS-9116: Fix boot set schema validation bug preventing valid session templates from being created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.26.1] - 2024-08-22
+### Fixed
+- Fix boot set schema validation bug preventing valid session templates from being created
+
 ## [2.26.0] - 2024-08-20
 ### Added
 - BOS automatically tags IMS images with the 'sbps-project: true' tag when using SBPS as the rootfs provider.

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -497,7 +497,7 @@ components:
             A null value means the Session has not encountered an error.
           maxLength: 65536
       additionalProperties: false
-    V2BootSetData:
+    V2BootSet:
       description: |
         A Boot Set is a collection of nodes defined by an explicit list, their functional
         role, and their logical groupings. This collection of nodes is associated with one
@@ -543,13 +543,6 @@ components:
           $ref: '#/components/schemas/BootSetRootfsProviderPassthrough'
       additionalProperties: false
       required: [path, type]
-    V2BootSet:
-      allOf:
-        - $ref: '#/components/schemas/V2BootSetData'
-        - anyOf:
-          - required: [node_list]
-          - required: [node_roles_groups]
-          - required: [node_groups]
     V2SessionTemplateArray:
       description: An array of Session Templates.
       type: array


### PR DESCRIPTION
The models generated by the openapi-generator are not able to handle the complicated schema used to enforce the requirement that BOS boot sets contain at least one of three possible node fields. The result is that even valid session templates are failing when attempting to create them.

This PR does two things to fix this:
1. Returns the API spec to a simpler form, where the above requirement is only found in the description field, but not enforced in the schema itself.
2. Modify the BOS session template validation code to instead validate this requirement "manually"

I tested this on mug and verified that it allows me to create a legal session template, but gives me an error if I try to create one with none of the node fields specified:

```
ncn-m001:~ # cray bos v2 sessiontemplates create --file a.json test
Usage: cray bos v2 sessiontemplates create [OPTIONS] SESSION_TEMPLATE_ID
Try 'cray bos v2 sessiontemplates create -h' for help.

Error: The session template could not be created.: Boot set compute has none of the following fields: ['node_list', 'node_roles_groups', 'node_groups']
```

This bug was introduced with this commit: 948d06173fd84fcdb4b194c3e218dfb3cf5ddaad