### PR TITLE
CASMCMS-9125: Update TAPMS endpoint for CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.26.3] - 2024-08-28
+### Fixed
+- Update TAPMS endpoint for CSM 1.6.
+
 ## [2.26.2] - 2024-08-23
 ### Dependencies
 - Simplify how latest patch version of `liveness` is determined

--- a/src/bos/common/tenant_utils.py
+++ b/src/bos/common/tenant_utils.py
@@ -33,7 +33,9 @@ from bos.common.utils import exc_type_msg, requests_retry_session, PROTOCOL
 LOGGER = logging.getLogger('bos.common.tenant_utils')
 
 TENANT_HEADER = "Cray-Tenant-Name"
-SERVICE_NAME = 'cray-tapms/v1alpha2'
+SERVICE_NAME = 'cray-tapms/v1alpha3' # CASMCMS-9125: Currently when TAPMS bumps this version, it
+                                     # breaks backwards compatiblity, so BOS needs to update this
+                                     # whenever TAPMS does.
 BASE_ENDPOINT = f"{PROTOCOL}://{SERVICE_NAME}"
 TENANT_ENDPOINT = f"{BASE_ENDPOINT}/tenants" # CASMPET-6433 changed this from tenant to tenants
 


### PR DESCRIPTION
This updates the TAPMS endpoint to the correct value for CSM 1.6. No backports needed, because CSM 1.5 used the current value.

I tested this on fanta to verify that it works.

Before this PR:
```
# cmsdev test -q bos
Starting main run, version: 1.24.0, tag: YZ6kQ
Starting sub-run, tag: YZ6kQ-bos
ERROR (run tag YZ6kQ-bos): GET https://api-gw-service-nmn.local/apis/bos/v2/components (tenant: vcluster-blue): expected status code 200, got 400
ERROR (run tag YZ6kQ-bos): CLI command on behalf of tenant 'vcluster-blue' (bos v2 components list --format json) failed with exit code 2
ERROR (run tag YZ6kQ-bos): CLI command on behalf of tenant 'vcluster-blue' (bos components list --format json) failed with exit code 2
Ended sub-run, tag: YZ6kQ-bos (duration: 33.103587971s)
Ended run, tag: YZ6kQ (duration: 33.128497402s)
FAILURE: 1 service tests FAILED (bos), 0 passed
```

After this PR:
```
# cmsdev test -q bos
Starting main run, version: 1.24.0, tag: oUPLk
Starting sub-run, tag: oUPLk-bos
Ended sub-run, tag: oUPLk-bos (duration: 34.007621563s)
Ended run, tag: oUPLk (duration: 34.031062217s)
SUCCESS: All 1 service tests passed: bos
```