### PR TITLE
CASMCMS-9143: When validating boot sets, check all boot sets for severe errors before returning only warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Marked PATCH session status endpoint to be ignored by the CLI.
 - Eliminate redundancies in API spec by defining `V2SessionNameOrEmpty` schema.
 
+### Fixed
+- When validating boot sets, check all boot sets for severe errors before returning only warnings
+
 ## [2.28.0] - 2024-09-11
 ### Added
 - Added `reject_nids` BOS option, to reject Sessions and Session Template which appear to reference NIDs.

--- a/src/bos/server/controllers/v2/boot_set.py
+++ b/src/bos/server/controllers/v2/boot_set.py
@@ -80,8 +80,8 @@ def validate_boot_sets(session_template: dict,
     if reject_nids is None:
         reject_nids = get_v2_options_data().get('reject_nids', False)
 
-    for bs_name, bs in session_template['boot_sets'].items():
-        warning_msgs = []
+    warning_msgs = []
+    for bs_name, bs in session_template['boot_sets'].items():        
         bs_msg = partial(_bs_msg, template_name=template_name, bs_name=bs_name)
 
         # Verify that the hardware is specified
@@ -140,8 +140,9 @@ def validate_boot_sets(session_template: dict,
                     msg = bs_msg(f"Can't locate its {boot_artifact}. Warning: {exc_type_msg(err)}")
                     LOGGER.warning(msg)
                     warning_msgs.append(msg)
-            if warning_msgs:
-                return BOOT_SET_WARNING, "; ".join(warning_msgs)
+
+    if warning_msgs:
+        return BOOT_SET_WARNING, "; ".join(warning_msgs)
 
     return BOOT_SET_SUCCESS, "Valid"
 


### PR DESCRIPTION
When BOS is validating a session template, it includes a validation of all of its boot sets.
Currently, if the first boot set contains no fatal errors but does contain a warning, then this warning is returned immediately, skipping any check of the remaining boot sets (if any). Thus, if one of those remaining boot sets has a fatal error, it will be overlooked.

This PR changes the validation code so that it will only return a warning after checking all of the boot sets for more severe errors.

This bug probably has not been reported to us because most of our templates have a single boot set (and hopefully warnings are uncommon anyway). But with ARM support, probably more session templates will have multiple boot sets, increasing the likelihood of a customer seeing this. And regardless of that, the fix is simple and low risk.