### PR TITLE
CASMCMS-9143: When validating boot sets, check all boot sets for severe errors before returning only warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.26] - 2024-09-26
+### Fixed
+- When validating boot sets, check all boot sets for severe errors before returning only warnings
+
 ## [2.10.25] - 2024-08-25
 ### Dependencies
 - Simplify how latest patch version of `liveness` is determined

--- a/src/bos/server/controllers/v2/boot_set.py
+++ b/src/bos/server/controllers/v2/boot_set.py
@@ -65,6 +65,8 @@ def validate_boot_sets(session_template: dict,
         return BOOT_SET_ERROR, msg
 
     hardware_specifier_fields = ('node_roles_groups', 'node_list', 'node_groups')
+    warning_flag = False
+    warn_msg = ""
     for bs_name, bs in session_template['boot_sets'].items():
         # Verify that the hardware is specified
         specified = [bs.get(field, None)
@@ -100,8 +102,6 @@ def validate_boot_sets(session_template: dict,
                     LOGGER.error(msg)
                     return BOOT_SET_ERROR, msg
 
-            warning_flag = False
-            warn_msg = ""
             for boot_artifact in ["initrd", "boot_parameters"]:
                 try:
                     artifact = getattr(image_metadata.boot_artifacts, boot_artifact)
@@ -118,7 +118,8 @@ def validate_boot_sets(session_template: dict,
                     LOGGER.warn(msg)
                     warning_flag = True
                     warn_msg = warn_msg + msg
-            if warning_flag:
-                    return BOOT_SET_WARNING, warn_msg
+
+    if warning_flag:
+        return BOOT_SET_WARNING, warn_msg
 
     return BOOT_SET_SUCCESS, "Valid"


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/bos/pull/370 for CSM 1.5