### PR TITLE
CASMCMS-8425: Include arch in boot set validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When validating boot sets, if a boot artifact is missing from a manifest, include the manifest S3 URL
   in the associated message.
 - Add check that at least one hardware-specifier field is non-empty to `validate_sanitize_boot_sets`
+- When validating boot sets (at session template patch/creation/validation or session creation),
+  attempt to validate that the specified architecture matches that of the corresponding IMS image.
+  Mismatches are fatal errors.
 
 ### Changed
 - Marked PATCH session status endpoint to be ignored by the CLI.

--- a/src/bos/operators/utils/boot_image_metadata/__init__.py
+++ b/src/bos/operators/utils/boot_image_metadata/__init__.py
@@ -66,6 +66,12 @@ class BootImageMetaData:
         """
         return None
 
+    @property
+    def arch(self):
+        """
+        Get the arch
+        """
+        return None
 
 class BootImageMetaDataBadRead(Exception):
     """

--- a/src/bos/operators/utils/boot_image_metadata/s3_boot_image_metadata.py
+++ b/src/bos/operators/utils/boot_image_metadata/s3_boot_image_metadata.py
@@ -27,6 +27,7 @@ from botocore.exceptions import ClientError
 
 from bos.common.utils import exc_type_msg
 from bos.operators.utils.boot_image_metadata import BootImageMetaData, BootImageMetaDataBadRead
+from bos.operators.utils.clients.ims import get_image, get_ims_id_from_s3_url, ImageNotFound
 from bos.operators.utils.clients.s3 import S3BootArtifacts, S3MissingConfiguration, S3Url, \
                                            ArtifactNotFound
 
@@ -204,3 +205,41 @@ class S3BootImageMetaData(BootImageMetaData):
         Returns the S3 URL to the boot manifest
         """
         return self.boot_artifacts.s3url
+
+    @property
+    def arch(self):
+        """
+        Extract the IMS image ID from the S3 manifest path.
+        Query IMS to get the architecture of the image.
+        Return the 'arch' field from the IMS image
+        If image is not in IMS, or 'arch' field not set, log warnings and return None.
+        (since technically BOS does not require the images to be in IMS)
+        """
+        s3_url = self.manifest_s3_url
+        ims_id = get_ims_id_from_s3_url(s3_url)
+        if not ims_id:
+            LOGGER.warning(
+                "Boot artifact S3 URL '%s' does not follow the expected IMS image convention",
+                s3_url)
+            return None
+        try:
+            ims_image_data = get_image(ims_id)
+        except ImageNotFound:
+            LOGGER.warning(
+                "Can't determine architecture of '%s' because image '%s' does not exist in IMS",
+                s3_url.url, ims_id)
+            return None
+        except Exception as err:
+            LOGGER.error("Error getting IMS image data for '%s' (S3 path '%s'): %s", ims_id,
+                         s3_url.url, exc_type_msg(err))
+            return None
+        try:
+            return ims_image_data["arch"]
+        except KeyError:
+            LOGGER.warning("Can't determine architecture of '%s' because 'arch' field not set in "
+                           "IMS image '%s': %s", s3_url.url, ims_id, ims_image_data)
+        except Exception as err:
+            LOGGER.error("IMS image '%s' (s3 path '%s'): %s", ims_id, s3_url.url, ims_image_data)
+            LOGGER.error("Error getting 'arch' field for IMS image '%s': %s", ims_id,
+                         exc_type_msg(err))
+        return None

--- a/src/bos/operators/utils/boot_image_metadata/s3_boot_image_metadata.py
+++ b/src/bos/operators/utils/boot_image_metadata/s3_boot_image_metadata.py
@@ -27,7 +27,8 @@ from botocore.exceptions import ClientError
 
 from bos.common.utils import exc_type_msg
 from bos.operators.utils.boot_image_metadata import BootImageMetaData, BootImageMetaDataBadRead
-from bos.operators.utils.clients.ims import get_image, get_ims_id_from_s3_url, ImageNotFound
+from bos.operators.utils.clients.ims import get_image, get_ims_id_from_s3_url, ImageNotFound, \
+                                            DEFAULT_IMS_IMAGE_ARCH
 from bos.operators.utils.clients.s3 import S3BootArtifacts, S3MissingConfiguration, S3Url, \
                                            ArtifactNotFound
 
@@ -236,8 +237,10 @@ class S3BootImageMetaData(BootImageMetaData):
         try:
             return ims_image_data["arch"]
         except KeyError:
-            LOGGER.warning("Can't determine architecture of '%s' because 'arch' field not set in "
-                           "IMS image '%s': %s", s3_url.url, ims_id, ims_image_data)
+            LOGGER.warning("Defaulting to '%s' because 'arch' field not set in IMS image '%s' "
+                           "(s3 path '%s'): %s", DEFAULT_IMS_IMAGE_ARCH, ims_id, s3_url.url,
+                           ims_image_data)
+            return DEFAULT_IMS_IMAGE_ARCH
         except Exception as err:
             LOGGER.error("IMS image '%s' (s3 path '%s'): %s", ims_id, s3_url.url, ims_image_data)
             LOGGER.error("Error getting 'arch' field for IMS image '%s': %s", ims_id,

--- a/src/bos/operators/utils/clients/ims.py
+++ b/src/bos/operators/utils/clients/ims.py
@@ -25,6 +25,7 @@
 import logging
 import re
 from requests.exceptions import HTTPError
+from requests.sessions import Session as RequestsSession
 
 from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
 from bos.operators.utils.clients.s3 import S3Url
@@ -58,7 +59,7 @@ class ImageNotFound(Exception):
         super().__init__(f"IMS image id '{image_id}' does not exist in IMS")
 
 
-def get_image(image_id, session=None) -> dict:
+def get_image(image_id: str, session: RequestsSession|None=None) -> dict:
     """
     Queries IMS to retrieve the specified image and return it.
     If the image does not exist, raise ImageNotFound.

--- a/src/bos/operators/utils/clients/ims.py
+++ b/src/bos/operators/utils/clients/ims.py
@@ -42,6 +42,9 @@ IMS_TAG_OPERATIONS = ['set', 'remove']
 IMS_S3_KEY_RE = r'^([^/]+)/.+'
 IMS_S3_KEY_RE_PROG = re.compile(IMS_S3_KEY_RE)
 
+# If an IMS image does not have the arch field, default to x86_64 for purposes of
+# backward-compatibility
+DEFAULT_IMS_IMAGE_ARCH = 'x86_64'
 
 class TagFailure(Exception):
     pass

--- a/src/bos/operators/utils/clients/ims.py
+++ b/src/bos/operators/utils/clients/ims.py
@@ -23,9 +23,11 @@
 #
 
 import logging
+import re
 from requests.exceptions import HTTPError
 
 from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
+from bos.operators.utils.clients.s3 import S3Url
 
 SERVICE_NAME = 'cray-ims'
 IMS_VERSION = 'v3'
@@ -34,6 +36,11 @@ IMAGES_ENDPOINT = f"{BASE_ENDPOINT}/images"
 
 LOGGER = logging.getLogger('bos.operators.utils.clients.ims')
 IMS_TAG_OPERATIONS = ['set', 'remove']
+
+# Making minimal assumptions about the IMS ID itself, this pattern just makes sure that the
+# S3 key is some string, then a /, then at least one more character.
+IMS_S3_KEY_RE = r'^([^/]+)/.+'
+IMS_S3_KEY_RE_PROG = re.compile(IMS_S3_KEY_RE)
 
 
 class TagFailure(Exception):
@@ -46,6 +53,38 @@ class ImageNotFound(Exception):
     """
     def __init__(self, image_id: str):
         super().__init__(f"IMS image id '{image_id}' does not exist in IMS")
+
+
+def get_image(image_id, session=None) -> dict:
+    """
+    Queries IMS to retrieve the specified image and return it.
+    If the image does not exist, raise ImageNotFound.
+    Other errors (like a failure to query IMS) will result in appropriate exceptions being raised.
+    """
+    if not session:
+        session = requests_retry_session()
+    url=f"{IMAGES_ENDPOINT}/{image_id}"
+    LOGGER.debug("GET %s", url)
+    response = session.get(url)
+    LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
+                 response.reason, compact_response_text(response.text))
+    try:
+        response.raise_for_status()
+    except HTTPError as err:
+        msg = f"Failed asking IMS to get image {image_id}: {exc_type_msg(err)}"
+        if response.status_code == 404:
+            # If it's not found, we just log it as a warning, because we may be
+            # okay with that -- that will be for the caller to decide
+            LOGGER.warning(msg)
+            raise ImageNotFound(image_id) from err
+        LOGGER.error(msg)
+        raise
+    try:
+        return response.json()
+    except Exception as err:
+        LOGGER.error("Failed decoding JSON response from getting IMS image %s: %s", image_id,
+                     exc_type_msg(err))
+        raise
 
 
 def patch_image(image_id, data, session=None):
@@ -95,3 +134,14 @@ def tag_image(image_id: str, operation: str, key: str, value: str = None, sessio
             }
     }
     patch_image(image_id=image_id, data=data, session=session)
+
+
+def get_ims_id_from_s3_url(s3_url: S3Url) -> str|None:
+    """
+    If the s3_url matches the expected format of an IMS image path, then return the IMS image ID.
+    Otherwise return None.
+    """
+    try:
+        return IMS_S3_KEY_RE_PROG.match(s3_url.key).group(1)
+    except (AttributeError, IndexError):
+        return None

--- a/src/bos/server/controllers/v2/boot_set.py
+++ b/src/bos/server/controllers/v2/boot_set.py
@@ -221,10 +221,7 @@ def validate_boot_set_arch(bs: dict, image_metadata: BootImageMetaData|None=None
             raise CannotValidateBootSetArch(
                 f"Can't find boot artifacts: {exc_type_msg(err)}") from err
 
-    try:
-        ims_image_arch = image_metadata.arch
-    except Exception as err:
-        raise CannotValidateBootSetArch(exc_type_msg(err)) from err
+    ims_image_arch = image_metadata.arch
 
     if ims_image_arch is None:
         raise CannotValidateBootSetArch("Can't determine architecture of boot artifacts")


### PR DESCRIPTION
[CASMCMS-8425](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8425)

This modifies the boot set validation functions so that they look up the boot image in IMS and check that the boot set `arch` corresponds to the IMS boot image architecture. If they mismatch, this fails the validation. For other errors (e.g. image not in IMS, IMS not reachable), only a warning is issued. Based on discussions with Jason, I have opened two follow-on tickets to add options to modify that behavior: [CASMCMS-9145](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9145) (add option to make it fatal if IMS is unreachable) and [CASMCMS-9146](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9146) (add option to make it fatal if a boot image is not in IMS).

If the boot set has an `arch` of `Other`, then the validation is skipped. If the boot set has an `arch` of `Unknown`, then it is treated the same as if it was not specified (that is, it defaults to `X86`).

I tested this on mug and verified that it behaves as expected.