### PR TITLE
CASMCMS-9145: Create BOS option arch_check_requires_ims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `arch_check_requires_ims` BOS option. This determines whether or not a failure to
+  get IMS data is considered fatal when validating image architecture in a boot set. By default
+  this is false. Note that this has no effect for boot sets whose images are not in IMS, nor
+  for boot sets whose architecture is `Other`.
+
 ### Changed
 - Refactored some BOS Options code to use abstract base classes, to avoid code duplication.
 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1063,6 +1063,15 @@ components:
         session_limit_required:
           type: boolean
           description: If true, Sessions cannot be created without specifying the limit parameter.
+        arch_check_requires_ims:
+          type: boolean
+          description: |
+            This option modifies how BOS behaves when validating the architecture of a boot image in a boot set.
+            Specifically, this option comes into play when BOS needs data from IMS in order to do this validation, but
+            IMS is unreachable.
+            In the above situation, if this option is true, then the validation will fail.
+            Otherwise, if the option is false, then a warning will be logged, but the validation will not
+            be failed because of this.
       additionalProperties: true
       minProperties: 1
       maxProperties: 1024

--- a/src/bos/common/options.py
+++ b/src/bos/common/options.py
@@ -29,6 +29,7 @@ from typing import Any
 # code should either import this dict directly, or (preferably) access
 # its values indirectly using a DefaultOptions object
 DEFAULTS = {
+    'arch_check_requires_ims': False,
     'cleanup_completed_session_ttl': "7d",
     'clear_stage': False,
     'component_actual_state_ttl': "4h",
@@ -59,6 +60,10 @@ class BaseOptions(ABC):
     # These properties call the method responsible for getting the option value.
     # All these do is convert the response to the appropriate type for the option,
     # and return it.
+
+    @property
+    def arch_check_requires_ims(self) -> bool:
+        return bool(self.get_option('arch_check_requires_ims'))
 
     @property
     def cleanup_completed_session_ttl(self) -> str:

--- a/src/bos/operators/utils/clients/ims.py
+++ b/src/bos/operators/utils/clients/ims.py
@@ -154,3 +154,25 @@ def get_ims_id_from_s3_url(s3_url: S3Url) -> str|None:
         return IMS_S3_KEY_RE_PROG.match(s3_url.key).group(1)
     except (AttributeError, IndexError):
         return None
+
+
+def get_arch_from_image_data(image_data: dict) -> str:
+    """
+    Returns the value of the 'arch' field in the image data
+    If it is not present, logs a warning and returns the default value
+    """
+    try:
+        arch = image_data['arch']
+    except KeyError:
+        LOGGER.warning("Defaulting to '%s' because 'arch' not set in IMS image data: %s",
+                       DEFAULT_IMS_IMAGE_ARCH, image_data)
+        return DEFAULT_IMS_IMAGE_ARCH
+    except Exception as err:
+        LOGGER.error("Unexpected error parsing IMS image data (%s): %s", exc_type_msg(err),
+                     image_data)
+        raise
+    if arch:
+        return arch
+    LOGGER.warning("Defaulting to '%s' because 'arch' set to null value in IMS image data: %s",
+                   DEFAULT_IMS_IMAGE_ARCH, image_data)
+    return DEFAULT_IMS_IMAGE_ARCH


### PR DESCRIPTION
This adds a new BOS v2 option -- `arch_check_requires_ims`. It governs what happens when BOS needs to get image arch data from IMS, and there is an error getting it (other than the image not being in IMS). Currently, in that situation, an error is logged, but the architecture validation is skipped. If this new option is false (as it will be by default), then the current behavior will continue.

If this new option is true, then IMS errors will be considered fatal. If a boot set is being validated and one of these errors comes up, then the boot set validation will fail.

I tested this on mug, verifying that I got the correct behavior for both settings of the option, with IMS both up and down.