### PR TITLE
CASMCMS-9162: Add 'cfs_read_timeout' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+#### BOS option
+- cfs_read_timeout: Allow the amount of time BOS waits for a response from CFS before
+  timing out to be configurable
 
 ## [2.30.3] - 2024-10-10
 ### Changed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -976,6 +976,13 @@ components:
         Options for the Boot Orchestration Service.
       type: object
       properties:
+        cfs_read_timeout:
+          type: integer
+          description: |
+            The amount of time (in seconds) to wait for a response before timing out a request to CFS
+          example: 20
+          minimum: 10
+          maximum: 86400
         cleanup_completed_session_ttl:
           type: string
           description: |

--- a/src/bos/common/options.py
+++ b/src/bos/common/options.py
@@ -29,6 +29,7 @@ from typing import Any
 # code should either import this dict directly, or (preferably) access
 # its values indirectly using a DefaultOptions object
 DEFAULTS = {
+    'cfs_read_timeout': 20,
     'cleanup_completed_session_ttl': "7d",
     'clear_stage': False,
     'component_actual_state_ttl': "4h",
@@ -61,6 +62,10 @@ class BaseOptions(ABC):
     # These properties call the method responsible for getting the option value.
     # All these do is convert the response to the appropriate type for the option,
     # and return it.
+
+    @property
+    def cfs_read_timeout(self) -> int:
+        return int(self.get_option('cfs_read_timeout'))
 
     @property
     def cleanup_completed_session_ttl(self) -> str:

--- a/src/bos/operators/utils/clients/cfs.py
+++ b/src/bos/operators/utils/clients/cfs.py
@@ -23,6 +23,7 @@
 #
 from collections import defaultdict
 import logging
+from bos.operators.utils.clients.bos.options import options
 from requests.exceptions import HTTPError
 
 from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
@@ -45,7 +46,7 @@ def get_components(session=None, **params):
     Returns the list of CFS components
     """
     if not session:
-        session = requests_retry_session()
+        session = requests_retry_session(read_timeout=options.cfs_read_timeout)  # pylint: disable=redundant-keyword-arg
     component_list = []
     while params is not None:
         LOGGER.debug("GET %s with params=%s", COMPONENTS_ENDPOINT, params)
@@ -71,7 +72,7 @@ def patch_components(data, session=None):
         LOGGER.warning("patch_components called without data; returning without action.")
         return
     if not session:
-        session = requests_retry_session()
+        session = requests_retry_session(read_timeout=options.cfs_read_timeout)  # pylint: disable=redundant-keyword-arg
     LOGGER.debug("PATCH %s with body=%s", COMPONENTS_ENDPOINT, data)
     response = session.patch(COMPONENTS_ENDPOINT, json=data)
     LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
@@ -88,7 +89,7 @@ def get_components_from_id_list(id_list):
         LOGGER.warning("get_components_from_id_list called without IDs; returning without action.")
         return []
     LOGGER.debug("get_components_from_id_list called with %d IDs", len(id_list))
-    session = requests_retry_session()
+    session = requests_retry_session(read_timeout=options.cfs_read_timeout)  # pylint: disable=redundant-keyword-arg
     component_list = []
     while id_list:
         next_batch = id_list[:GET_BATCH_SIZE]
@@ -106,7 +107,7 @@ def patch_desired_config(node_ids, desired_config, enabled=False, tags=None, cle
         return
     LOGGER.debug("patch_desired_config called on %d IDs with desired_config=%s enabled=%s tags=%s"
                  " clear_state=%s", len(node_ids), desired_config, enabled, tags, clear_state)
-    session = requests_retry_session()
+    session = requests_retry_session(read_timeout=options.cfs_read_timeout)  # pylint: disable=redundant-keyword-arg
     node_patch = {
         'enabled': enabled,
         'desired_config': desired_config,


### PR DESCRIPTION
## Summary and Scope

Add an option 'cfs_read_timeout' to specify the amount of time in seconds to wait for a response from CFS before timing out.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-9162]
* Change will also be needed in `craycli`
* Documentation changes required in [CASMCMS-9162]


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Odin`

### Test description:

I used a debug version where I could crank the minimum read timeout value down to 1 second. I did that and reproduced the errors seen in CAST-37016 which was the impetus driving CASMCMS-9162. When I increased the value back to 10, I did not see the errors. This was on a system where I had hand-crafted fake CFS components to the total of 3574 components to try and simulate a system at scale. Even with these fake components, a timeout of 10 seconds was sufficient to avoid the time-out error. This was not the case at the customer site CSCS where the default timeout value of 10 seconds did not allow them to avoid the error. However, they can just crank the value higher.

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No.
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? Yes.
- Was downgrade tested? If not, why? Yes, and it broke because you cannot downgrade back to a lower version of redis. See [CASMCMS-9163](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9163) for the breakdown.
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Low.
_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

