### PR TITLE
CASMCMS-9165: Fix per-bootset CFS setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.30.5] - 2024-10-15
+### Fixed
+- Fix per-bootset CFS setting
+
 ## [2.30.4] - 2024-10-15
 ### Added
 #### BOS option

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -364,7 +364,7 @@ class Session:
         """
         if not self.template.get('enable_cfs', True):
             return ''
-        bs_config = boot_set.get('configuration', '')
+        bs_config = boot_set.get('cfs', {}).get('configuration', '')
         if bs_config:
             return bs_config
         # Otherwise, we take the configuration value from the session template itself


### PR DESCRIPTION
As far as I can tell, per-bootset CFS options have been broken in every official release from BOS 2.0.0 onward. This commit broke it:
https://github.com/Cray-HPE/bos/commit/c9dd021e789a96d0ef4050de863ba6af08106dcd

That commit fixed one bug (the `boot_set` argument was incorrectly being used as the name of the boot set, when in fact it was the boot set dict). However, it introduced another problem because it removed the `cfs` field access from the query. So after that commit, the code just looked in the boot set for a `configuration` field, which never exists, since that is not a valid field for a boot set. So it then always defaults to using the overall CFS value for the session template.

Fortunately, the fix is easy.

Shout out to `mypy` -- it found this error in a development branch I'm working in to add mypy into our build process.