### PR TITLE
CASMCMS-9165: Fix per-bootset CFS setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix per-bootset CFS setting
 
 ## [2.10.27] - 2024-10-14
 ### Fixed

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -344,7 +344,7 @@ class Session:
         """
         if not self.template.get('enable_cfs', True):
             return ''
-        bs_config = boot_set.get('configuration', '')
+        bs_config = boot_set.get('cfs', {}).get('configuration', '')
         if bs_config:
             return bs_config
         # Otherwise, we take the configuration value from the session template itself


### PR DESCRIPTION
CSM 1.5 backport of https://github.com/Cray-HPE/bos/pull/386

Not changing the version number so that Jason and I can use the same version for our backports.