### PR TITLE
Provide an option to control the PCS transition deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- BOS option to control how long a deadline it gives PCS to complete its transition
+
 ## [2.30.5] - 2024-10-15
 ### Fixed
 - Fix per-bootset CFS setting

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -976,6 +976,13 @@ components:
         Options for the Boot Orchestration Service.
       type: object
       properties:
+        pcs_transition_deadline:
+          type: integer
+          description: |
+            The amount of time (in minutes) to set the deadline for a PCS pcs_transition_deadline
+          example: 1
+          minimum: 1
+          maximum: 1440
         cfs_read_timeout:
           type: integer
           description: |

--- a/src/bos/common/options.py
+++ b/src/bos/common/options.py
@@ -29,6 +29,7 @@ from typing import Any
 # code should either import this dict directly, or (preferably) access
 # its values indirectly using a DefaultOptions object
 DEFAULTS = {
+    'pcs_transition_deadline': 60,
     'cfs_read_timeout': 20,
     'cleanup_completed_session_ttl': "7d",
     'clear_stage': False,
@@ -62,6 +63,10 @@ class BaseOptions(ABC):
     # These properties call the method responsible for getting the option value.
     # All these do is convert the response to the appropriate type for the option,
     # and return it.
+
+    @property
+    def pcs_transition_deadline(self) -> int:
+        return int(self.get_option('pcs_transition_deadline'))
 
     @property
     def cfs_read_timeout(self) -> int:

--- a/src/bos/operators/power_off_forceful.py
+++ b/src/bos/operators/power_off_forceful.py
@@ -59,7 +59,7 @@ class ForcefulPowerOffOperator(BaseOperator):
     def _act(self, components):
         if components:
             component_ids = [component['id'] for component in components]
-            pcs.force_off(nodes=component_ids)
+            pcs.force_off(nodes=component_ids, task_deadline_minutes=options.pcs_transition_deadline)
         return components
 
 

--- a/src/bos/operators/power_off_graceful.py
+++ b/src/bos/operators/power_off_graceful.py
@@ -26,6 +26,7 @@ import logging
 
 from bos.common.values import Action, Status
 from bos.operators.utils.clients import pcs
+from bos.operators.utils.clients.bos.options import options
 from bos.operators.base import BaseOperator, main
 from bos.operators.filters import BOSQuery, HSMState
 
@@ -55,7 +56,7 @@ class GracefulPowerOffOperator(BaseOperator):
     def _act(self, components):
         if components:
             component_ids = [component['id'] for component in components]
-            pcs.soft_off(component_ids)
+            pcs.soft_off(component_ids, task_deadline_minutes=options.pcs_transition_deadline)
         return components
 
 

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -39,6 +39,7 @@ from bos.operators.utils.clients import bss
 from bos.operators.utils.clients import pcs
 from bos.operators.utils.clients.ims import tag_image
 from bos.operators.utils.clients.cfs import set_cfs
+from bos.operators.utils.clients.bos.options import options
 from bos.operators.base import BaseOperator, main
 from bos.operators.filters import BOSQuery, HSMState
 from bos.server.dbs.boot_artifacts import record_boot_artifacts
@@ -88,7 +89,7 @@ class PowerOnOperator(BaseOperator):
             raise Exception(f"Error encountered setting CFS information: {e}") from e
         component_ids = [component['id'] for component in components]
         try:
-            pcs.power_on(component_ids)
+            pcs.power_on(component_ids, task_deadline_minutes=options.pcs_transition_deadline)
         except Exception as e:
             raise Exception(f"Error encountered calling CAPMC to power on: {e}") from e
         return components


### PR DESCRIPTION
## Summary and Scope

Provide an option to control the PCS transition deadline

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `drax`
  * Local development environment
  * Virtual Shasta

### Test description:

I set the deadline to two minutes rather than the default one minute. I successfully rebooted all four compute nodes on drax using this more generous default.

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
None.
_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

