### PR TITLE
CASMCMS-9225: Added basic paging ability for GET requests to list components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added basic paging ability for `GET` requests for `components`.
 
 ## [2.31.0] - 2024-11-01
 ### Removed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1691,6 +1691,21 @@ paths:
           in: query
           description: |-
             Retrieve the Components with the given status.
+        - name: start_after_id
+          schema:
+            $ref: '#/components/schemas/V2ComponentId'
+          in: query
+          description: |-
+            Begin listing Components after the specified ID. Used for paging.
+        - name: page_size
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1048576
+          in: query
+          description: |-
+            Maximum number of Components to include in response. Used for paging. 0 means no limit
+            (which is the same as not specifying this parameter).
       description: |-
         Retrieve the full collection of Components in the form of a
         ComponentArray. Full results can also be filtered by query

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -145,8 +145,6 @@ def _filter_component(data: dict,
     # Do all of the checks we can before calculating status, to avoid doing it needlessly
     if id_set is not None and data["id"] not in id_set:
         return None
-    if tenant_components is not None and data["id"] not in tenant_components:
-        return None
     if enabled is not None and data.get('enabled', None) != enabled:
         return None
     if session is not None and data.get('session', None) != session:

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -70,7 +70,7 @@ def get_v2_components(ids="",
         id_list = None
     tenant = get_tenant_from_header()
     LOGGER.debug("GET /v2/components for tenant=%s with %d IDs specified",
-                 tenant, len(id_list))
+                 tenant, len(id_list) if id_list else 0)
     response = get_v2_components_data(id_list=id_list,
                                       enabled=enabled,
                                       session=session,

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -49,7 +49,7 @@ def get_v2_components(ids="",
                       phase=None,
                       status=None,
                       start_after_id=None,
-                      page_size=None):
+                      page_size=0):
     """Used by the GET /components API operation
 
     Allows filtering using a comma separated list of ids.
@@ -78,7 +78,7 @@ def get_v2_components(ids="",
                                       status=status,
                                       tenant=tenant,
                                       start_after_id=start_after_id,
-                                      page_size=page_size or 0,
+                                      page_size=page_size,
                                       delete_timestamp=True)
     LOGGER.debug(
         "GET /v2/components returning data for tenant=%s on %d components",

--- a/src/bos/server/redis_db_utils.py
+++ b/src/bos/server/redis_db_utils.py
@@ -116,8 +116,8 @@ class DBWrapper():
         Get an array of data for all keys after passing them through the specified filter
         (discarding any for which the filter returns None)
         If start_after_id is specified, all ids lexically <= that id will be skipped.
-        If page_size is specified, the list will be returned if it contains that many
-        elements, even if there may be more remaining.
+        If page_size is specified, the number of items in the returned list will be equal to or less than the page_size.
+        More elements may remain and additional queries will be needed to acquire them.
         """
         data = []
         for value in self.iter_values(start_after_key):

--- a/src/bos/server/redis_db_utils.py
+++ b/src/bos/server/redis_db_utils.py
@@ -21,9 +21,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+from itertools import batched
 import functools
 import json
 import logging
+from typing import Callable, Optional
 
 import connexion
 import redis
@@ -105,6 +107,34 @@ class DBWrapper():
             single_data = json.loads(datastr)
             data.append(single_data)
         return data
+
+    def get_all_filtered(self,
+                         filter_func: Callable[[dict], dict | None],
+                         start_after_key: Optional[str] = None,
+                         page_size: int = 0) -> list[dict]:
+        """
+        Get an array of data for all keys after passing them through the specified filter
+        (discarding any for which the filter returns None)
+        If start_after_id is specified, all ids lexically <= that id will be skipped.
+        If page_size is specified, the list will be returned if it contains that many
+        elements, even if there may be more remaining.
+        """
+        data = []
+        for value in self.iter_values(start_after_key):
+            filtered_value = filter_func(value)
+            if filtered_value is not None:
+                data.append(filtered_value)
+                if page_size and len(data) == page_size:
+                    break
+        return data
+
+    def iter_values(self, start_after_key: Optional[str] = None):
+        all_keys = sorted({k.decode() for k in self.client.scan_iter()})
+        if start_after_key is not None:
+            all_keys = [k for k in all_keys if k > start_after_key]
+        for next_keys in batched(all_keys, 500):
+            for datastr in self.client.mget(next_keys):
+                yield json.loads(datastr) if datastr else None
 
     def get_all_as_dict(self):
         """Return a mapping from all keys to their corresponding data

--- a/src/bos/server/redis_db_utils.py
+++ b/src/bos/server/redis_db_utils.py
@@ -129,6 +129,10 @@ class DBWrapper():
         return data
 
     def iter_values(self, start_after_key: Optional[str] = None):
+        """
+        Iterate through every item in the database. Parse each item as JSON and yield it.
+        If start_after_key is specified, skip any keys that are lexically <= the specified key.
+        """
         all_keys = sorted({k.decode() for k in self.client.scan_iter()})
         if start_after_key is not None:
             all_keys = [k for k in all_keys if k > start_after_key]


### PR DESCRIPTION
> [CASMCMS-9225](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9225) as a whole involves changes to a number of different files in BOS. In order to aid with review, I'm breaking the overall thing up into smaller PRs. Each will be built on top of each other, and will be merging into the `casmcms-9225-full` branch. Only once each sub-PR has been approved and merged will I merge that branch into develop.

[CASMCMS-9225](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9225) overall is addressing problems I found when investigating possible resource leaks in BOS (related to Josh Williamson's memory leak investigation with PCS). In the past we've made other changes to BOS to ensure that its requests to services like PCS and CFS do not get excessively large (this was done mostly by adding the `max_component_batch_size` option). However, one thing that was not addressed by this was when the BOS operators poll BOS itself to figure out which components require action. In those cases, the size of the request responses can end up scaling linearly with the number of nodes in the system, and on mug I observed that this could lead to two problems:

1. These requests were more likely to encounter timeouts, because it took the BOS server longer to assemble the very large responses.
2. I observed evidence that any time BOS encountered a timeout, there was a chance of an apparent memory leak, and the size of the leaked memory appeared to be related to the size of the response it was receiving. Thus, timeouts on these very large responses led to large memory leaks, eventually resulting in OOMKills.

This PR makes the following changes:

1. Adds two new options that can be specified when listing BOS components (`max_page_size` and `start_after_id`). These enable paging when listing BOS components. They are both optional, and if they are not specified, BOS works exactly as before. Thus, they are entirely backward-compatible. My current plan is not to add these to the Cray CLI -- their main purpose is for BOS internal use, although of course anyone using the API is free to use them. If there is demand, it would not be difficult to add them into the CLI, however.
2. The code used to list BOS components had minor refactoring, to make it more efficient when iterating through the BOS components database, filtering out components and composing its responses. I did this because I discovered that even with paging, BOS could still be quite slow when responding to some queries, particularly ones where very few components matched the filters. In that case, BOS still had to go through its entire components database before providing a response. The refactoring made here led to a 3-4x speed improvement for such requests.

This PR does NOT yet modify the BOS operators to use these new abilities. That will be in a separate PR, because that code ended up being refactored for other reasons.