### PR TITLE
CASMCMS-9237: Create ApiClients class and provide it to BOS operators inside a context manager

### DIFF
--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
> [CASMCMS-9237](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9237) as a whole involves changes to a number of different files in BOS. In order to aid with review, I'm breaking the overall thing up into smaller PRs. Each will be built on top of each other, and will be merging into the [main PR](https://github.com/Cray-HPE/bos/pull/408) branch. Only once each sub-PR has been approved and merged will I merge that branch into develop.
>Full list of sub-PRs:
>1. [Added basic paging ability for GET requests to list components](https://github.com/Cray-HPE/bos/pull/396)
> 2. [Create generic endpoint classes](https://github.com/Cray-HPE/bos/pull/397)
> 3. [Create generic API client class](https://github.com/Cray-HPE/bos/pull/398)
> 4. [Create ApiClients class and provide it to BOS operators inside a context manager](https://github.com/Cray-HPE/bos/pull/399)
> 5. [Move PCS client to new paradigm](https://github.com/Cray-HPE/bos/pull/400)
> 6. [Move BSS client to new paradigm](https://github.com/Cray-HPE/bos/pull/401)
> 7. [Move CFS client to new paradigm](https://github.com/Cray-HPE/bos/pull/402)
> 8. [Move BOS client to new paradigm](https://github.com/Cray-HPE/bos/pull/403)
> 9. [Move IMS client to new paradigm](https://github.com/Cray-HPE/bos/pull/404)
> 10. [Move HSM client to new paradigm](https://github.com/Cray-HPE/bos/pull/405)
> 11. [CHANGELOG update, linting, update utils](https://github.com/Cray-HPE/bos/pull/406)

This PR is the first step to providing the new API client interfaces to the BOS operators. This creates the `ApiClients` class, which is a context manager that is just a collection of API clients. In this PR, no actual API clients are included -- I have left them commented. The upcoming PRs will add them. This PR just shows how this new `ApiClients` class is initialized in a context manager that goes around the operator `_run()` method. All of the work of the operator is done in there, and so we can safely use that for our context, knowing that the API clients will be available to the operators as they do their work.