### PR TITLE
CASMCMS-9237: CHANGELOG update, linting, update utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added basic paging ability for `GET` requests for `components`.
 
-### Changed
-- Modified operators to use paging when requesting BOS components, using a page size equal to the `max_components_batch_size` option.
-- Put all requests code into context managers -- this includes the HTTP adapters, the sessions, and the request responses.
-
 ### Fixed
 - Fixed bug causing no components to be listed when no tenant specified.
 
 ### Changed
 - Have BOS migration job wait for databases to be ready before proceeding
+- Modified operators to use paging when requesting BOS components, using a page size equal to the `max_components_batch_size` option.
+- Put all requests code into context managers -- this includes the HTTP adapters, the sessions, and the request responses.
 
 ## [2.31.1] - 2024-12-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added basic paging ability for `GET` requests for `components`.
 
+### Changed
+- Modified operators to use paging when requesting BOS components, using a page size equal to the `max_components_batch_size` option.
+- Put all requests code into context managers -- this includes the HTTP adapters, the sessions, and the request responses.
+
 ## [2.31.0] - 2024-11-01
 ### Removed
 - Moved BOS reporter to https://github.com/Cray-HPE/bos-reporter

--- a/src/bos/common/clients/endpoints/request_error_handler.py
+++ b/src/bos/common/clients/endpoints/request_error_handler.py
@@ -42,6 +42,7 @@ class BaseRequestErrorHandler(ABC):
     """
     The abstract base class for request error handlers that will be used by an API endpoint.
     """
+
     @classmethod
     @abstractmethod
     def handle_exception(cls, err: Exception,
@@ -53,6 +54,7 @@ class RequestErrorHandler(BaseRequestErrorHandler):
     """
     The default request error handler used by API endpoints.
     """
+
     @classmethod
     def handle_api_response_error(cls, err: ApiResponseError,
                                   request_data: RequestData) -> NoReturn:

--- a/src/bos/common/tenant_utils.py
+++ b/src/bos/common/tenant_utils.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/bos/common/utils.py
+++ b/src/bos/common/utils.py
@@ -28,7 +28,7 @@ import datetime
 from functools import partial
 import re
 import traceback
-from typing import Iterator, List, Optional, Unpack
+from typing import Iterator, Optional, Unpack
 
 # Third party imports
 from dateutil.parser import parse
@@ -77,7 +77,6 @@ DEFAULT_RETRY_ADAPTER_ARGS = rrs.RequestsRetryAdapterArgs(
     connect_timeout=3,
     read_timeout=10)
 
-
 retry_session_manager = partial(rrs.retry_session_manager,
                                 protocol=PROTOCOL,
                                 **DEFAULT_RETRY_ADAPTER_ARGS)
@@ -120,12 +119,6 @@ def retry_session_get(*get_args,
                        protocol=protocol,
                        adapter_kwargs=adapter_kwargs) as _session:
         return _session.get(*get_args, **get_kwargs)
-
-
-requests_retry_session = partial(rrs.requests_retry_session,
-                                 session=None,
-                                 protocol=PROTOCOL,
-                                 **DEFAULT_RETRY_ADAPTER_ARGS)
 
 
 def compact_response_text(response_text: str) -> str:
@@ -201,7 +194,7 @@ def using_sbps_check_kernel_parameters(kernel_parameters: str) -> bool:
     return "root=sbps-s3" in kernel_parameters
 
 
-def components_by_id(components: List[dict]) -> dict:
+def components_by_id(components: list[dict]) -> dict:
     """
     Input:
     * components: a list containing individual components
@@ -215,7 +208,7 @@ def components_by_id(components: List[dict]) -> dict:
     return {component["id"]: component for component in components}
 
 
-def reverse_components_by_id(components_by_id_map: dict) -> List[dict]:
+def reverse_components_by_id(components_by_id_map: dict) -> list[dict]:
     """
     Input:
     components_by_id_map: a dictionary with the name of each component as the

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -62,6 +62,7 @@ class MissingSessionData(BaseOperatorException):
     desired state.
     """
 
+
 class ApiClients:
     """
     Context manager to provide API clients to BOS operators.
@@ -95,7 +96,6 @@ class ApiClients:
         context for all of the API clients.
         """
         return self._stack.__exit__(exc_type, exc_val, exc_tb)
-
 
 
 class BaseOperator(ABC):

--- a/src/bos/operators/power_off_forceful.py
+++ b/src/bos/operators/power_off_forceful.py
@@ -50,10 +50,10 @@ class ForcefulPowerOffOperator(BaseOperator):
     def filters(self):
         return [
             self.BOSQuery(enabled=True,
-                     status=','.join([
-                         Status.power_off_forcefully_called,
-                         Status.power_off_gracefully_called
-                     ])),
+                          status=','.join([
+                              Status.power_off_forcefully_called,
+                              Status.power_off_gracefully_called
+                          ])),
             TimeSinceLastAction(seconds=options.max_power_off_wait_time),
             self.HSMState(),
         ]

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -80,7 +80,9 @@ class PowerOnOperator(BaseOperator):
             raise Exception(
                 f"Error encountered setting BSS information: {e}") from e
         try:
-            self.client.cfs.components.set_cfs(components, enabled=False, clear_state=True)
+            self.client.cfs.components.set_cfs(components,
+                                               enabled=False,
+                                               clear_state=True)
         except Exception as e:
             raise Exception(
                 f"Error encountered setting CFS information: {e}") from e
@@ -148,10 +150,11 @@ class PowerOnOperator(BaseOperator):
         for key, nodes in boot_artifacts.items():
             kernel, kernel_parameters, initrd = key
             try:
-                resp = self.client.bss.boot_parameters.set_bss(node_set=nodes,
-                                   kernel_params=kernel_parameters,
-                                   kernel=kernel,
-                                   initrd=initrd)
+                resp = self.client.bss.boot_parameters.set_bss(
+                    node_set=nodes,
+                    kernel_params=kernel_parameters,
+                    kernel=kernel,
+                    initrd=initrd)
                 resp.raise_for_status()
             except HTTPError as err:
                 LOGGER.error(
@@ -237,7 +240,8 @@ class PowerOnOperator(BaseOperator):
         my_components_by_id = components_by_id(components)
         for image in image_ids:
             try:
-                self.client.ims.images.tag_image(image, "set", "sbps-project", "true")
+                self.client.ims.images.tag_image(image, "set", "sbps-project",
+                                                 "true")
             except Exception as e:
                 components_to_update = []
                 for node in image_id_to_nodes[image]:

--- a/src/bos/operators/session_cleanup.py
+++ b/src/bos/operators/session_cleanup.py
@@ -28,7 +28,6 @@ import re
 from bos.common.clients.bos.options import options
 from bos.operators.base import BaseOperator, main
 
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -40,7 +40,6 @@ from bos.operators.session_completion import SessionCompletionOperator
 from bos.operators.utils.boot_image_metadata.factory import BootImageMetaDataFactory
 from bos.operators.utils.rootfs.factory import ProviderFactory
 
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -75,7 +74,8 @@ class SessionSetupOperator(BaseOperator):
         LOGGER.info('Found %d sessions that require action', len(sessions))
         inventory_cache = Inventory(self.client.hsm)
         for data in sessions:
-            session = Session(data, inventory_cache, self.client.bos, self.HSMState)
+            session = Session(data, inventory_cache, self.client.bos,
+                              self.HSMState)
             session.setup(self.max_batch_size)
 
     def _get_pending_sessions(self):
@@ -84,7 +84,8 @@ class SessionSetupOperator(BaseOperator):
 
 class Session:
 
-    def __init__(self, data, inventory_cache, bos_client: BOSClient, hsm_state: Callable[...,HSMState]):
+    def __init__(self, data, inventory_cache, bos_client: BOSClient,
+                 hsm_state: Callable[..., HSMState]):
         self.session_data = data
         self.inventory = inventory_cache
         self.bos_client = bos_client

--- a/src/bos/operators/status.py
+++ b/src/bos/operators/status.py
@@ -30,7 +30,6 @@ from bos.operators.base import BaseOperator, main
 from bos.operators.filters import DesiredBootStateIsOff, BootArtifactStatesMatch, \
     DesiredConfigurationIsNone, LastActionIs, TimeSinceLastAction
 
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -101,14 +101,15 @@ def get_v2_components_data(id_list=None,
 
     Allows filtering using a comma separated list of ids.
     """
-    tenant_components = None if tenant is None else get_tenant_component_set(tenant)
+    tenant_components = None if tenant is None else get_tenant_component_set(
+        tenant)
 
     if id_list is not None:
         id_set = set(id_list)
         if tenant_components is not None:
             id_set.intersection_update(tenant_components)
     else:
-         id_set = tenant_components
+        id_set = tenant_components
 
     # If id_set is not None but is empty, that means no components in the system
     # will match our filter, so we can return an empty list immediately.


### PR DESCRIPTION
> [CASMCMS-9237](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9237) as a whole involves changes to a number of different files in BOS. In order to aid with review, I'm breaking the overall thing up into smaller PRs. Each will be built on top of each other, and will be merging into the [main PR](https://github.com/Cray-HPE/bos/pull/408) branch. Only once each sub-PR has been approved and merged will I merge that branch into develop.
>Full list of sub-PRs:
>1. [Added basic paging ability for GET requests to list components](https://github.com/Cray-HPE/bos/pull/396)
> 2. [Create generic endpoint classes](https://github.com/Cray-HPE/bos/pull/397)
> 3. [Create generic API client class](https://github.com/Cray-HPE/bos/pull/398)
> 4. [Create ApiClients class and provide it to BOS operators inside a context manager](https://github.com/Cray-HPE/bos/pull/399)
> 5. [Move PCS client to new paradigm](https://github.com/Cray-HPE/bos/pull/400)
> 6. [Move BSS client to new paradigm](https://github.com/Cray-HPE/bos/pull/401)
> 7. [Move CFS client to new paradigm](https://github.com/Cray-HPE/bos/pull/402)
> 8. [Move BOS client to new paradigm](https://github.com/Cray-HPE/bos/pull/403)
> 9. [Move IMS client to new paradigm](https://github.com/Cray-HPE/bos/pull/404)
> 10. [Move HSM client to new paradigm](https://github.com/Cray-HPE/bos/pull/405)
> 11. [CHANGELOG update, linting, update utils](https://github.com/Cray-HPE/bos/pull/406)

This final PR does some housekeeping. It updates the CHANGELOG, runs the changed code through a linter, and modifies the tenant utilities to use a context manager when making a request to TAPMS.

The combined code from all of these PRs is currently running on mug.