### PR TITLE
CASMCMS-9234: When renaming session templates during migration, use correct database key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- When renaming session templates during migration, use correct database key to store renamed template.
 
 ## [2.31.0] - 2024-11-01
 ### Removed

--- a/src/bos/server/migrations/sanitize.py
+++ b/src/bos/server/migrations/sanitize.py
@@ -138,7 +138,7 @@ def _sanitize_session_template(key: str | bytes, data: dict) -> None:
 
     delete_template(key, data)
 
-    new_key = get_tenant_aware_key(name, tenant)
+    new_key = get_tenant_aware_key(new_name, tenant)
     LOGGER.info("Old DB key = '%s', new DB key = '%s'", key, new_key)
 
     new_data["name"] = new_name


### PR DESCRIPTION
The BOS migration code has a bug when it comes to renaming session templates. Specifically, it stores the renamed template using a database key based on the old template name. This results in the template being inaccessible using its new name. The fix is very tiny and straightforward.