### PR TITLE
CASMCMS-9225: Do not use itertools.batched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.30] - 2024-12-19
+### Fixed
+- Do not use `itertools.batched`, because it is not available in this Python version.
+
 ## [2.10.29] - 2024-12-18
 ### Changed
 - Improve performance of large `GET` components requests.

--- a/src/bos/server/redis_db_utils.py
+++ b/src/bos/server/redis_db_utils.py
@@ -21,7 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-from itertools import batched
 import functools
 import json
 import logging
@@ -110,9 +109,11 @@ class DBWrapper():
         """
         Iterate through every item in the database. Parse each item as JSON and yield it.
         """
-        for next_keys in batched(self.client.scan_iter(), 500):
-            for datastr in self.client.mget(next_keys):
+        all_keys = list(self.client.scan_iter())
+        while all_keys:
+            for datastr in self.client.mget(all_keys[:500]):
                 yield json.loads(datastr) if datastr else None
+            all_keys = all_keys[500:]
 
     def get_keys(self):
         """Get an array of all keys"""


### PR DESCRIPTION
I made a mistake in the backports for CSM 1.4 and CSM 1.5 yesterday. I didn't modify the code to account for the fact that `itertools.batched` is not available in the Python version BOS uses in those releases.

We already handle this same thing in `src/bos/operators/base.py`, where we use that function in CSM 1.6, but use an alternative for previous CSM releases. This PR makes the same adjustment to the redis DB utility code which uses `batched` in CSM 1.6.

I tested this on `baldar` and verified that it fixes the issue, passes basic BOS tests, and shows no signs of other issues.