### PR TITLE
CASMCMS-9177: Have BOS migration job wait for databases to be ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.30.8] - 2025-01-06
+### Changed
+- Have BOS migration job wait for databases to be ready before proceeding
+
 ### Fixed
 - Fixed bug causing no components to be listed when no tenant specified.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.30.8] - 2025-01-06
 ### Changed
 - Have BOS migration job wait for databases to be ready before proceeding
 

--- a/src/bos/server/migrations/__main__.py
+++ b/src/bos/server/migrations/__main__.py
@@ -53,8 +53,9 @@ so that it stays around for much longer after completing.
 """
 
 import logging
+import sys
 
-from .db import COMP_DB, SESS_DB, TEMP_DB
+from .db import COMP_DB, SESS_DB, TEMP_DB, all_db_ready
 from .sanitize import sanitize_component, sanitize_session, sanitize_session_template
 
 
@@ -62,6 +63,10 @@ LOGGER = logging.getLogger('bos.server.migration')
 
 
 def main():
+    if not all_db_ready():
+        LOGGER.error("Not all BOS databases are ready")
+        sys.exit(1)
+
     LOGGER.info("Sanitizing session templates")
     for key, data in TEMP_DB.get_all_as_dict().items():
         sanitize_session_template(key, data)

--- a/src/bos/server/migrations/db.py
+++ b/src/bos/server/migrations/db.py
@@ -23,6 +23,7 @@
 #
 
 import logging
+import time
 
 import bos.server.redis_db_utils as dbutils
 
@@ -32,6 +33,35 @@ TEMP_DB=dbutils.get_wrapper(db='session_templates')
 SESS_DB=dbutils.get_wrapper(db='sessions')
 STAT_DB=dbutils.get_wrapper(db='session_status')
 COMP_DB=dbutils.get_wrapper(db='components')
+
+MAX_DB_WAIT_SECONDS=120.0
+
+def all_db_ready() -> bool:
+    """
+    Wait for up to MAX_DB_WAIT_SECONDS for all databases to be ready
+    """
+    start_time = time.time()
+    first = True
+    while time.time() - start_time <= MAX_DB_WAIT_SECONDS:
+        if first:
+            first = False
+        else:
+            LOGGER.info("Sleeping for 7 seconds before retrying databases")
+            time.sleep(7)
+        if not TEMP_DB.ready:
+            continue
+        LOGGER.info("Template database is ready")
+        if not SESS_DB.ready:
+            continue
+        LOGGER.info("Session database is ready")
+        if not STAT_DB.ready:
+            continue
+        LOGGER.info("Session status database is ready")
+        if not COMP_DB.ready:
+            continue
+        LOGGER.info("Component database is ready")
+        return True
+    return False
 
 
 def delete_from_db(db: dbutils.DBWrapper, key: str, err_msg: str|None=None) -> None:

--- a/src/bos/server/redis_db_utils.py
+++ b/src/bos/server/redis_db_utils.py
@@ -80,6 +80,20 @@ class DBWrapper():
         """Returns the string name of the database, from the DATABASES array"""
         return DATABASES[self.db_id]
 
+    @property
+    def ready(self) -> bool:
+        """
+        Attempt a database query.
+        Return False if an exception is raised (and log a warning)
+        Return True otherwise.
+        """
+        try:
+            self.client.get('')
+        except Exception as err:
+            LOGGER.warning("Failed to query database %s : %s", self.db_string, exc_type_msg(err))
+            return False
+        return True
+
     # The following methods act like REST calls for single items
     def get(self, key):
         """Get the data for the given key."""


### PR DESCRIPTION
During CSM upgrades, the first run of the BOS migration job often fails, because the BOS databases are not yet ready. The job ultimately succeeds on retry, but it leaves some failed migration pods with ugly logs in its wake. This doesn't cause any problems except for possibly concerning an administrator who notices them.

This PR modifies the BOS migration job so that it waits for the databases to be ready before proceeding. It will retry for up to two minutes before failing. Based on what I have seen, this should allow it to succeed on its first attempt in most cases, preventing the problem described above.

I tested this on mug:

```
INFO:bos.server.migration:Beginning post-upgrade BOS data migration
WARNING:bos.server.redis_db_utils:Failed to query database session_templates : redis.exceptions.ConnectionError: Error 111 connecting to cray-bos-db:6379. Connection refused.

INFO:bos.server.migration:Sleeping for 7 seconds before retrying databases
WARNING:bos.server.redis_db_utils:Failed to query database session_templates : redis.exceptions.ConnectionError: Error 111 connecting to cray-bos-db:6379. Connection refused.

INFO:bos.server.migration:Sleeping for 7 seconds before retrying databases
WARNING:bos.server.redis_db_utils:Failed to query database session_templates : redis.exceptions.ConnectionError: Error 111 connecting to cray-bos-db:6379. Connection refused.

INFO:bos.server.migration:Sleeping for 7 seconds before retrying databases
WARNING:bos.server.redis_db_utils:Failed to query database session_templates : redis.exceptions.ConnectionError: Error 111 connecting to cray-bos-db:6379. Connection refused.

INFO:bos.server.migration:Sleeping for 7 seconds before retrying databases
WARNING:bos.server.redis_db_utils:Failed to query database session_templates : redis.exceptions.ConnectionError: Error 111 connecting to cray-bos-db:6379. Connection refused.

INFO:bos.server.migration:Sleeping for 7 seconds before retrying databases
INFO:bos.server.migration:Template database is ready
INFO:bos.server.migration:Session database is ready
INFO:bos.server.migration:Session status database is ready
INFO:bos.server.migration:Component database is ready
INFO:bos.server.migration:Sanitizing session templates
INFO:bos.server.migration:Done sanitizing session templates
INFO:bos.server.migration:Sanitizing sessions
INFO:bos.server.migration:Done sanitizing sessions
INFO:bos.server.migration:Sanitizing components
INFO:bos.server.migration:Done sanitizing components
INFO:bos.server.migration:Completed post-upgrade BOS data migration
```

This PR is for CSM 1.6.1. I'll also make another PR to the develop branch.