### PR TITLE
CASMCMS-9242: Add BOS options: bss_read_timeout, ims_read_timeout, hsm_read_timeout, pcs_read_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- BOS options: bss_read_timeout, hsm_read_timeout, ims_read_timeout, pcs_read_timeout.
+  Allow the amount of time BOS waits for a response from these services before
+  timing out to be configurable
+
 ### Changed
 - Have BOS migration job wait for databases to be ready before proceeding
 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -976,10 +976,15 @@ components:
         Options for the Boot Orchestration Service.
       type: object
       properties:
+        bss_read_timeout:
+          type: integer
+          description: The amount of time (in seconds) to wait for a response before timing out a request to BSS
+          example: 20
+          minimum: 10
+          maximum: 86400
         cfs_read_timeout:
           type: integer
-          description: |
-            The amount of time (in seconds) to wait for a response before timing out a request to CFS
+          description: The amount of time (in seconds) to wait for a response before timing out a request to CFS
           example: 20
           minimum: 10
           maximum: 86400
@@ -1023,6 +1028,12 @@ components:
           minimum: 0
           # A little over a year
           maximum: 33554432
+        hsm_read_timeout:
+          type: integer
+          description: The amount of time (in seconds) to wait for a response before timing out a request to HSM
+          example: 20
+          minimum: 10
+          maximum: 86400
         ims_errors_fatal:
           type: boolean
           description: |
@@ -1041,6 +1052,12 @@ components:
             Otherwise, if the option is false, then a warning will be logged, but the validation will not
             be failed because of this. Note that if ims_images_must_exist is true but ims_errors_fatal is false, then
             a failure to determine whether or not an image is in IMS will NOT result in a fatal error.
+        ims_read_timeout:
+          type: integer
+          description: The amount of time (in seconds) to wait for a response before timing out a request to IMS
+          example: 20
+          minimum: 10
+          maximum: 86400
         logging_level:
           type: string
           description: The logging level for all BOS services
@@ -1069,6 +1086,12 @@ components:
           minimum: 0
           # Over 12 days
           maximum: 1048576
+        pcs_read_timeout:
+          type: integer
+          description: The amount of time (in seconds) to wait for a response before timing out a request to PCS
+          example: 20
+          minimum: 10
+          maximum: 86400
         polling_frequency:
           type: integer
           description: How frequently the BOS operators check Component state for needed actions (in seconds)

--- a/src/bos/common/options.py
+++ b/src/bos/common/options.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/bos/common/options.py
+++ b/src/bos/common/options.py
@@ -29,6 +29,7 @@ from typing import Any
 # code should either import this dict directly, or (preferably) access
 # its values indirectly using a DefaultOptions object
 DEFAULTS = {
+    'bss_read_timeout': 20,
     'cfs_read_timeout': 20,
     'cleanup_completed_session_ttl': "7d",
     'clear_stage': False,
@@ -36,13 +37,16 @@ DEFAULTS = {
     'default_retry_policy': 3,
     'disable_components_on_completion': True,
     'discovery_frequency': 300,
+    'hsm_read_timeout': 20,
     'ims_errors_fatal': False,
     'ims_images_must_exist': False,
+    'ims_read_timeout': 20,
     'logging_level': 'INFO',
     'max_boot_wait_time': 1200,
     'max_component_batch_size': 2800,
     'max_power_off_wait_time': 300,
     'max_power_on_wait_time': 120,
+    'pcs_read_timeout': 20,
     'polling_frequency': 15,
     'reject_nids': False,
     'session_limit_required': False
@@ -62,6 +66,10 @@ class BaseOptions(ABC):
     # These properties call the method responsible for getting the option value.
     # All these do is convert the response to the appropriate type for the option,
     # and return it.
+
+    @property
+    def bss_read_timeout(self) -> int:
+        return int(self.get_option('bss_read_timeout'))
 
     @property
     def cfs_read_timeout(self) -> int:
@@ -92,12 +100,20 @@ class BaseOptions(ABC):
         return int(self.get_option('discovery_frequency'))
 
     @property
+    def hsm_read_timeout(self) -> int:
+        return int(self.get_option('hsm_read_timeout'))
+
+    @property
     def ims_errors_fatal(self) -> bool:
         return bool(self.get_option('ims_errors_fatal'))
 
     @property
     def ims_images_must_exist(self) -> bool:
         return bool(self.get_option('ims_images_must_exist'))
+
+    @property
+    def ims_read_timeout(self) -> int:
+        return int(self.get_option('ims_read_timeout'))
 
     @property
     def logging_level(self) -> str:
@@ -118,6 +134,10 @@ class BaseOptions(ABC):
     @property
     def max_power_on_wait_time(self) -> int:
         return int(self.get_option('max_power_on_wait_time'))
+
+    @property
+    def pcs_read_timeout(self) -> int:
+        return int(self.get_option('pcs_read_timeout'))
 
     @property
     def polling_frequency(self) -> int:

--- a/src/bos/operators/utils/clients/bss.py
+++ b/src/bos/operators/utils/clients/bss.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/bos/operators/utils/clients/bss.py
+++ b/src/bos/operators/utils/clients/bss.py
@@ -27,6 +27,7 @@ import json
 from requests.exceptions import HTTPError
 
 from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
+from bos.operators.utils.clients.bos.options import options
 
 LOGGER = logging.getLogger(__name__)
 SERVICE_NAME = 'cray-bss'
@@ -65,7 +66,7 @@ def set_bss(node_set, kernel_params, kernel, initrd, session=None):
         # Accordingly, an Exception is raised.
         raise Exception("set_bss called with empty node_set")
 
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.bss_read_timeout)  # pylint: disable=redundant-keyword-arg
     LOGGER.info("Params: %s", kernel_params)
     url = f"{ENDPOINT}/bootparameters"
 

--- a/src/bos/operators/utils/clients/hsm.py
+++ b/src/bos/operators/utils/clients/hsm.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/bos/operators/utils/clients/hsm.py
+++ b/src/bos/operators/utils/clients/hsm.py
@@ -29,6 +29,7 @@ from requests.exceptions import HTTPError, ConnectionError
 from urllib3.exceptions import MaxRetryError
 
 from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
+from bos.operators.utils.clients.bos.options import options
 
 SERVICE_NAME = 'cray-smd'
 BASE_ENDPOINT = f"{PROTOCOL}://{SERVICE_NAME}/hsm/v2/"
@@ -53,7 +54,7 @@ def read_all_node_xnames():
     Queries HSM for the full set of xname components that
     have been discovered; return these as a set.
     """
-    session = requests_retry_session()
+    session = requests_retry_session(read_timeout=options.hsm_read_timeout)  # pylint: disable=redundant-keyword-arg
     endpoint = f'{BASE_ENDPOINT}/State/Components/'
     LOGGER.debug("GET %s", endpoint)
     try:
@@ -123,7 +124,7 @@ def get_components(node_list, enabled=None) -> dict[str,list[dict]]:
     if not node_list:
         LOGGER.warning("hsm.get_components called with empty node list")
         return {'Components': []}
-    session = requests_retry_session()
+    session = requests_retry_session(read_timeout=options.hsm_read_timeout)  # pylint: disable=redundant-keyword-arg
     try:
         payload = {'ComponentIDs': node_list}
         if enabled is not None:
@@ -222,7 +223,7 @@ class Inventory:
     def get(self, path, params=None):
         url = os.path.join(BASE_ENDPOINT, path)
         if self._session is None:
-            self._session = requests_retry_session()
+            self._session = requests_retry_session(read_timeout=options.hsm_read_timeout)  # pylint: disable=redundant-keyword-arg
         try:
             LOGGER.debug("HSM Inventory: GET %s with params=%s", url, params)
             response = self._session.get(url, params=params, verify=VERIFY)

--- a/src/bos/operators/utils/clients/ims.py
+++ b/src/bos/operators/utils/clients/ims.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/bos/operators/utils/clients/ims.py
+++ b/src/bos/operators/utils/clients/ims.py
@@ -28,6 +28,7 @@ from requests.exceptions import HTTPError
 from requests.sessions import Session as RequestsSession
 
 from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
+from bos.operators.utils.clients.bos.options import options
 from bos.operators.utils.clients.s3 import S3Url
 
 SERVICE_NAME = 'cray-ims'
@@ -67,7 +68,7 @@ def get_image(image_id: str, session: RequestsSession|None=None) -> dict:
     Other errors (like a failure to query IMS) will result in appropriate exceptions being raised.
     """
     if not session:
-        session = requests_retry_session()
+        session = requests_retry_session(read_timeout=options.ims_read_timeout)  # pylint: disable=redundant-keyword-arg
     url=f"{IMAGES_ENDPOINT}/{image_id}"
     LOGGER.debug("GET %s", url)
     try:
@@ -101,7 +102,7 @@ def patch_image(image_id: str, data: dict, session: RequestsSession|None=None) -
         LOGGER.warning("patch_image called without data; returning without action.")
         return
     if not session:
-        session = requests_retry_session()
+        session = requests_retry_session(read_timeout=options.ims_read_timeout)  # pylint: disable=redundant-keyword-arg
     url=f"{IMAGES_ENDPOINT}/{image_id}"
     LOGGER.debug("PATCH %s with body=%s", url, data)
     response = session.patch(url, json=data)
@@ -134,7 +135,7 @@ def tag_image(image_id: str, operation: str, key: str, value: str=None,
         LOGGER.debug("Patching image %s %sing key: %s", image_id, operation, key)
 
     if not session:
-        session = requests_retry_session()
+        session = requests_retry_session(read_timeout=options.ims_read_timeout)  # pylint: disable=redundant-keyword-arg
 
     data = {
         "metadata": {

--- a/src/bos/operators/utils/clients/pcs.py
+++ b/src/bos/operators/utils/clients/pcs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/bos/operators/utils/clients/pcs.py
+++ b/src/bos/operators/utils/clients/pcs.py
@@ -32,6 +32,7 @@ from collections import defaultdict
 import requests
 
 from bos.common.utils import compact_response_text, requests_retry_session, PROTOCOL
+from bos.operators.utils.clients.bos.options import options
 
 SERVICE_NAME = 'cray-power-control'
 POWER_CONTROL_VERSION = 'v1'
@@ -89,7 +90,7 @@ def _power_status(xname=None, power_state_filter=None, management_state_filter=N
     Per the spec, a power_status_all is returned. power_status_all is an array of power
     statuses.
     """
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.pcs_read_timeout)  # pylint: disable=redundant-keyword-arg
     params = {}
     if xname:
         params['xname'] = xname
@@ -144,7 +145,7 @@ def status(nodes, session=None, **kwargs):
     if not nodes:
         LOGGER.warning("status called without nodes; returning without action.")
         return status_bucket
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.pcs_read_timeout)  # pylint: disable=redundant-keyword-arg
     power_status_all = _power_status(xname=list(nodes), session=session, **kwargs)
     for power_status_entry in power_status_all['status']:
         # If the returned xname has an error, it itself is the status regardless of
@@ -169,7 +170,7 @@ def node_to_powerstate(nodes, session=None, **kwargs):
     if not nodes:
         LOGGER.warning("node_to_powerstate called without nodes; returning without action.")
         return power_states
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.pcs_read_timeout)  # pylint: disable=redundant-keyword-arg
     status_bucket = status(nodes, session, **kwargs)
     for pstatus, nodeset in status_bucket.items():
         for node in nodeset:
@@ -210,7 +211,7 @@ def _transition_create(xnames, operation, task_deadline_minutes=None, deputy_key
     if not xnames:
         raise PowerControlComponentsEmptyException(
                 f"_transition_create called with no xnames! (operation={operation})")
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.pcs_read_timeout)  # pylint: disable=redundant-keyword-arg
     try:
         assert operation in {'On', 'Off', 'Soft-Off', 'Soft-Restart', 'Hard-Restart', 'Init',
                              'Force-Off'}
@@ -252,7 +253,7 @@ def power_on(nodes, session=None, task_deadline_minutes=1, **kwargs):
     """
     if not nodes:
         raise PowerControlComponentsEmptyException("power_on called with no nodes!")
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.pcs_read_timeout)  # pylint: disable=redundant-keyword-arg
     return _transition_create(xnames=nodes, operation='On',
                               task_deadline_minutes=task_deadline_minutes,
                               session=session, **kwargs)
@@ -263,7 +264,7 @@ def power_off(nodes, session=None, task_deadline_minutes=1, **kwargs):
     """
     if not nodes:
         raise PowerControlComponentsEmptyException("power_off called with no nodes!")
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.pcs_read_timeout)  # pylint: disable=redundant-keyword-arg
     return _transition_create(xnames=nodes, operation='Off',
                               task_deadline_minutes=task_deadline_minutes,
                               session=session, **kwargs)
@@ -274,7 +275,7 @@ def soft_off(nodes, session=None, task_deadline_minutes=1, **kwargs):
     """
     if not nodes:
         raise PowerControlComponentsEmptyException("soft_off called with no nodes!")
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.pcs_read_timeout)  # pylint: disable=redundant-keyword-arg
     return _transition_create(xnames=nodes, operation='Soft-Off',
                               task_deadline_minutes=task_deadline_minutes,
                               session=session, **kwargs)
@@ -285,7 +286,7 @@ def force_off(nodes, session=None, task_deadline_minutes=1, **kwargs):
     """
     if not nodes:
         raise PowerControlComponentsEmptyException("force_off called with no nodes!")
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.pcs_read_timeout)  # pylint: disable=redundant-keyword-arg
     return _transition_create(xnames=nodes, operation='Force-Off',
                               task_deadline_minutes=task_deadline_minutes,
                               session=session, **kwargs)

--- a/src/bos/server/controllers/v2/boot_set/ims.py
+++ b/src/bos/server/controllers/v2/boot_set/ims.py
@@ -58,12 +58,8 @@ def validate_ims_boot_image(bs: dict, options_data: OptionsData) -> None:
 
     ims_id = get_ims_image_id(bs_path)
 
-    # If IMS being inaccessible is not a fatal error, then reduce the number
-    # of retries we make, to prevent a lengthy delay
-    num_retries = 8 if options_data.ims_errors_fatal else 4
-
     try:
-        image_data = get_ims_image_data(ims_id, num_retries)
+        image_data = get_ims_image_data(ims_id, options_data)
     except ImageNotFound as err:
         if options_data.ims_images_must_exist:
             raise BootSetError(str(err)) from err
@@ -110,14 +106,18 @@ def get_ims_image_id(path: str) -> str:
                       "for IMS images")
 
 
-def get_ims_image_data(ims_id: str, num_retries: int|None=None) -> dict:
+def get_ims_image_data(ims_id: str, options_data: OptionsData) -> dict:
     """
     Query IMS to get the image data and return it,
     or raise an exception.
     """
-    kwargs = { "image_id": ims_id }
-    if num_retries is not None:
-        # A pylint bug generates a false positive error for this call
-        # https://github.com/pylint-dev/pylint/issues/2271
-        kwargs['session'] = requests_retry_session(retries=4) # pylint: disable=redundant-keyword-arg
-    return get_image(**kwargs)
+    # If IMS being inaccessible is not a fatal error, then reduce the number
+    # of retries we make, to prevent a lengthy delay
+    num_retries = 8 if options_data.ims_errors_fatal else 4
+
+    # A pylint bug generates a false positive error for this call
+    # https://github.com/pylint-dev/pylint/issues/2271
+    session = requests_retry_session(  # pylint: disable=redundant-keyword-arg)
+                retries=num_retries,
+                read_timeout=options_data.ims_read_timeout)
+    return get_image(image_id=ims_id, session=session)

--- a/src/bos/server/controllers/v2/boot_set/ims.py
+++ b/src/bos/server/controllers/v2/boot_set/ims.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
[Just like we did for CFS](https://github.com/Cray-HPE/bos/pull/382) with `cfs_read_timeout`, add BOS options to make the read timeouts configurable when making requests to BSS, IMS, HSM, and PCS.

I have tested this on mug.

This PR is for CSM 1.6.1. I will be backing "back" ports to `develop` (for CSM 1.7), `release/2.10` (for CSM 1.5), and `support/2.0` (for CSM 1.4).

There will also be corresponding PRs to `craycli` and `docs-csm` for these releases.