### PR TITLE
CASMCMS-9242: Add BOS options: bss_read_timeout, hsm_read_timeout, pcs_read_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- BOS options: bss_read_timeout, hsm_read_timeout, pcs_read_timeout.
+  Allow the amount of time BOS waits for a response from these services before
+  timing out to be configurable
+
 ### Fixed
 - Fixed bug causing no components to be listed when no tenant specified.
 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1603,10 +1603,15 @@ components:
         Options for the Boot Orchestration Service.
       type: object
       properties:
+        bss_read_timeout:
+          type: integer
+          description: The amount of time (in seconds) to wait for a response before timing out a request to BSS
+          example: 20
+          minimum: 10
+          maximum: 86400
         cfs_read_timeout:
           type: integer
-          description: |
-            The amount of time (in seconds) to wait for a response before timing out a request to CFS
+          description: The amount of time (in seconds) to wait for a response before timing out a request to CFS
           example: 20
           minimum: 10
           maximum: 86400
@@ -1644,6 +1649,12 @@ components:
           minimum: 0
           # A little over a year
           maximum: 33554432
+        hsm_read_timeout:
+          type: integer
+          description: The amount of time (in seconds) to wait for a response before timing out a request to HSM
+          example: 20
+          minimum: 10
+          maximum: 86400
         logging_level:
           type: string
           description: The logging level for all BOS services
@@ -1665,6 +1676,12 @@ components:
           minimum: 0
           # Over 12 days
           maximum: 1048576
+        pcs_read_timeout:
+          type: integer
+          description: The amount of time (in seconds) to wait for a response before timing out a request to PCS
+          example: 20
+          minimum: 10
+          maximum: 86400
         polling_frequency:
           type: integer
           description: How frequently the BOS operators check Component state for needed actions. (in seconds)

--- a/src/bos/operators/utils/clients/bos/options.py
+++ b/src/bos/operators/utils/clients/bos/options.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -72,8 +72,20 @@ class Options:
             raise KeyError('Option {} not found and no default exists'.format(key))
 
     @property
+    def bss_read_timeout(self):
+        return self.get_option('bss_read_timeout', int, 10)
+
+    @property
     def cfs_read_timeout(self):
         return self.get_option('cfs_read_timeout', int, 10)
+
+    @property
+    def hsm_read_timeout(self):
+        return self.get_option('hsm_read_timeout', int, 10)
+
+    @property
+    def pcs_read_timeout(self):
+        return self.get_option('pcs_read_timeout', int, 10)
 
     @property
     def logging_level(self):

--- a/src/bos/operators/utils/clients/bss.py
+++ b/src/bos/operators/utils/clients/bss.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,6 +26,7 @@ import logging
 import json
 
 from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
+from bos.operators.utils.clients.bos.options import options
 
 LOGGER = logging.getLogger(__name__)
 SERVICE_NAME = 'cray-bss'
@@ -64,7 +65,7 @@ def set_bss(node_set, kernel_params, kernel, initrd, session=None):
         # Accordingly, an Exception is raised.
         raise Exception("set_bss called with empty node_set")
 
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.bss_read_timeout)  # pylint: disable=redundant-keyword-arg
     LOGGER.info("Params: {}".format(kernel_params))
     url = "%s/bootparameters" % (ENDPOINT)
 

--- a/src/bos/operators/utils/clients/hsm.py
+++ b/src/bos/operators/utils/clients/hsm.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,6 +29,7 @@ from requests.exceptions import HTTPError, ConnectionError
 from urllib3.exceptions import MaxRetryError
 
 from bos.common.utils import compact_response_text, exc_type_msg, requests_retry_session, PROTOCOL
+from bos.operators.utils.clients.bos.options import options
 
 SERVICE_NAME = 'cray-smd'
 BASE_ENDPOINT = "%s://%s/hsm/v2/" % (PROTOCOL, SERVICE_NAME)
@@ -53,7 +54,7 @@ def read_all_node_xnames():
     Queries HSM for the full set of xname components that
     have been discovered; return these as a set.
     """
-    session = requests_retry_session()
+    session = requests_retry_session(read_timeout=options.hsm_read_timeout)  # pylint: disable=redundant-keyword-arg
     endpoint = '%s/State/Components/' % (BASE_ENDPOINT)
     LOGGER.debug("GET %s", endpoint)
     try:
@@ -123,7 +124,7 @@ def get_components(node_list, enabled=None) -> dict[str,list[dict]]:
     if not node_list:
         LOGGER.warning("hsm.get_components called with empty node list")
         return {'Components': []}
-    session = requests_retry_session()
+    session = requests_retry_session(read_timeout=options.hsm_read_timeout)  # pylint: disable=redundant-keyword-arg
     try:
         payload = {'ComponentIDs': node_list}
         if enabled is not None:
@@ -222,7 +223,7 @@ class Inventory(object):
     def get(self, path, params=None):
         url = os.path.join(BASE_ENDPOINT, path)
         if self._session is None:
-            self._session = requests_retry_session()
+            self._session = requests_retry_session(read_timeout=options.hsm_read_timeout)  # pylint: disable=redundant-keyword-arg
         try:
             LOGGER.debug("HSM Inventory: GET %s with params=%s", url, params)
             response = self._session.get(url, params=params, verify=VERIFY)

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,16 +37,19 @@ DB = dbutils.get_wrapper(db='options')
 # options simpler
 OPTIONS_KEY = 'options'
 DEFAULTS = {
+    'bss_read_timeout': 10,
     'cfs_read_timeout': 10,
     'cleanup_completed_session_ttl': "7d",
     'clear_stage': False,
     'component_actual_state_ttl': "4h",
     'disable_components_on_completion': True,
     'discovery_frequency': 5*60,
+    'hsm_read_timeout': 10,
     'logging_level': 'INFO',
     'max_boot_wait_time': 1200,
     'max_power_on_wait_time': 120,
     'max_power_off_wait_time': 300,
+    'pcs_read_timeout': 10,
     'polling_frequency': 15,
     'default_retry_policy': 3,
     'max_component_batch_size': 2800,


### PR DESCRIPTION
CSM 1.5 backport of https://github.com/Cray-HPE/bos/pull/418
Note that it does not include `ims_read_timeout`, as BOS had no IMS client in CSM 1.5.