### PR TITLE
CASMCMS-9242: Add BOS options: bss_read_timeout, hsm_read_timeout, capmc_read_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- BOS options: bss_read_timeout, hsm_read_timeout, capmc_read_timeout.
+  Allow the amount of time BOS waits for a response from these services before
+  timing out to be configurable
 
 ## [2.0.49] - 2024-12-19
 ### Fixed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1639,10 +1639,21 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
         Options for the Boot Orchestration Service.
       type: object
       properties:
+        bss_read_timeout:
+          type: integer
+          description: The amount of time (in seconds) to wait for a response before timing out a request to BSS
+          example: 20
+          minimum: 10
+          maximum: 86400
+        capmc_read_timeout:
+          type: integer
+          description: The amount of time (in seconds) to wait for a response before timing out a request to CAPMC
+          example: 20
+          minimum: 10
+          maximum: 86400
         cfs_read_timeout:
           type: integer
-          description: |
-            The amount of time (in seconds) to wait for a response before timing out a request to CFS
+          description: The amount of time (in seconds) to wait for a response before timing out a request to CFS
           example: 20
           minimum: 10
           maximum: 86400
@@ -1663,6 +1674,12 @@ it=999 spire_join_token=${SPIRE_JOIN_TOKEN}"
         discovery_frequency:
           type: integer
           description: How frequently the BOS discovery agent syncs new components from HSM. (in seconds)
+        hsm_read_timeout:
+          type: integer
+          description: The amount of time (in seconds) to wait for a response before timing out a request to HSM
+          example: 20
+          minimum: 10
+          maximum: 86400
         logging_level:
           type: string
           description: The logging level for all BOS services

--- a/src/bos/operators/utils/clients/bos/options.py
+++ b/src/bos/operators/utils/clients/bos/options.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -73,8 +73,20 @@ class Options:
             raise KeyError('Option {} not found and no default exists'.format(key))
 
     @property
+    def bss_read_timeout(self):
+        return self.get_option('bss_read_timeout', int, 10)
+
+    @property
+    def capmc_read_timeout(self):
+        return self.get_option('capmc_read_timeout', int, 10)
+
+    @property
     def cfs_read_timeout(self):
         return self.get_option('cfs_read_timeout', int, 10)
+
+    @property
+    def hsm_read_timeout(self):
+        return self.get_option('hsm_read_timeout', int, 10)
 
     @property
     def logging_level(self):

--- a/src/bos/operators/utils/clients/bss.py
+++ b/src/bos/operators/utils/clients/bss.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,6 +27,7 @@ import json
 
 from bos.common.utils import compact_response_text, exc_type_msg
 from bos.operators.utils import requests_retry_session, PROTOCOL
+from bos.operators.utils.clients.bos.options import options
 
 LOGGER = logging.getLogger(__name__)
 SERVICE_NAME = 'cray-bss'
@@ -65,7 +66,7 @@ def set_bss(node_set, kernel_params, kernel, initrd, session=None):
         # Accordingly, an Exception is raised.
         raise Exception("set_bss called with empty node_set")
 
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.bss_read_timeout)  # pylint: disable=redundant-keyword-arg
     LOGGER.info("Params: {}".format(kernel_params))
     url = "%s/bootparameters" % (ENDPOINT)
 

--- a/src/bos/operators/utils/clients/capmc.py
+++ b/src/bos/operators/utils/clients/capmc.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,6 +31,7 @@ from typing import List
 
 from bos.common.utils import compact_response_text
 from bos.operators.utils import requests_retry_session, PROTOCOL
+from bos.operators.utils.clients.bos.options import options
 
 SERVICE_NAME = 'cray-capmc'
 CAPMC_VERSION = 'v1'
@@ -325,7 +326,7 @@ def status(nodes, filtertype = 'show_all', session = None):
 
     endpoint = '%s/get_xname_status' % (ENDPOINT)
     status_bucket = defaultdict(set)
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.capmc_read_timeout)  # pylint: disable=redundant-keyword-arg
     body = {'filter': filtertype,
             'xnames': list(nodes)}
 
@@ -405,7 +406,7 @@ def power(nodes: List, state: str, force: bool = True, session = None,
     if state not in valid_states:
         raise ValueError("State must be one of {} not {}".format(valid_states, state))
 
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.capmc_read_timeout)  # pylint: disable=redundant-keyword-arg
     prefix, output_format = node_type(nodes)
     power_endpoint = '%s/%s_%s' % (ENDPOINT, prefix, state)
 
@@ -452,7 +453,7 @@ def call(endpoint, nodes, node_format = 'xnames', cont = True, reason = "None gi
     payload = {'reason': reason,
                node_format: list(nodes),
                'continue': cont}
-    session = session or requests_retry_session()
+    session = session or requests_retry_session(read_timeout=options.capmc_read_timeout)  # pylint: disable=redundant-keyword-arg
     if kwargs:
         payload.update(kwargs)
     LOGGER.debug("POST %s with body=%s", endpoint, payload)

--- a/src/bos/operators/utils/clients/hsm.py
+++ b/src/bos/operators/utils/clients/hsm.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,6 +30,7 @@ from urllib3.exceptions import MaxRetryError
 
 from bos.common.utils import compact_response_text, exc_type_msg
 from bos.operators.utils import requests_retry_session, PROTOCOL
+from bos.operators.utils.clients.bos.options import options
 
 SERVICE_NAME = 'cray-smd'
 BASE_ENDPOINT = "%s://%s/hsm/v2/" % (PROTOCOL, SERVICE_NAME)
@@ -54,7 +55,7 @@ def read_all_node_xnames():
     Queries HSM for the full set of xname components that
     have been discovered; return these as a set.
     """
-    session = requests_retry_session()
+    session = requests_retry_session(read_timeout=options.hsm_read_timeout)  # pylint: disable=redundant-keyword-arg
     endpoint = '%s/State/Components/' % (BASE_ENDPOINT)
     LOGGER.debug("GET %s", endpoint)
     try:
@@ -124,7 +125,7 @@ def get_components(node_list, enabled=None) -> dict[str,list[dict]]:
     if not node_list:
         LOGGER.warning("hsm.get_components called with empty node list")
         return {'Components': []}
-    session = requests_retry_session()
+    session = requests_retry_session(read_timeout=options.hsm_read_timeout)  # pylint: disable=redundant-keyword-arg
     try:
         payload = {'ComponentIDs': node_list}
         if enabled is not None:
@@ -223,7 +224,7 @@ class Inventory(object):
     def get(self, path, params=None):
         url = os.path.join(BASE_ENDPOINT, path)
         if self._session is None:
-            self._session = requests_retry_session()
+            self._session = requests_retry_session(read_timeout=options.hsm_read_timeout)  # pylint: disable=redundant-keyword-arg
         try:
             LOGGER.debug("HSM Inventory: GET %s with params=%s", url, params)
             response = self._session.get(url, params=params, verify=VERIFY)

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,12 +37,15 @@ DB = dbutils.get_wrapper(db='options')
 # options simpler
 OPTIONS_KEY = 'options'
 DEFAULTS = {
+    'bss_read_timeout': 10,
+    'capmc_read_timeout': 10,
     'cfs_read_timeout': 10,
     'cleanup_completed_session_ttl': "7d",
     'clear_stage': False,
     'component_actual_state_ttl': "4h",
     'disable_components_on_completion': True,
     'discovery_frequency': 5*60,
+    'hsm_read_timeout': 10,
     'logging_level': 'INFO',
     'max_boot_wait_time': 1200,
     'max_power_on_wait_time': 120,


### PR DESCRIPTION
CSM 1.4 backport of https://github.com/Cray-HPE/bos/pull/418
Note:
* There is no `ims_read_timeout`, since BOS had not query IMS in CSM 1.4
* Instead of `pcs_read_timeout`, it has `capmc_read_timeout`, since BOS used CAPMC in CSM 1.4