### PR TITLE
CASMCMS-9149: Update autoscaling apiVersion to support updated Kubernetes in CSM 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Have BOS migration job wait for databases to be ready before proceeding
 - Modified operators to use paging when requesting BOS components, using a page size equal to the `max_components_batch_size` option.
 - Put all requests code into context managers -- this includes the HTTP adapters, the sessions, and the request responses.
+- Update autoscaling `apiVersion` to support updated Kubernetes in CSM 1.7
 
 ## [2.31.1] - 2024-12-18
 ### Fixed

--- a/kubernetes/cray-bos/templates/api-autoscaler.yaml
+++ b/kubernetes/cray-bos/templates/api-autoscaler.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2022, 2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */}}
 {{- $baseChartValues := index .Values "cray-service" -}}
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: "{{ include "cray-service.name" . }}"


### PR DESCRIPTION
This is necessary because of the updated Kubernetes version for CSM 1.7.