### PR TITLE
CASMCMS-9255: Improve kernel path parsing; fix bug logging image tagging errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.30.11] - 2025-01-15
+### Fixed
+- CASMCMS-9255: Improved parsing of kernel paths to extract IMS IDs
+- Correct bug that could result in some BOS components not having their error fields
+  updated if the IMS image tag failed.
+
 ## [2.30.10] - 2025-01-10
 ### Fixed
 - Change version limit on `requests_retry_session` to avoid install errors.

--- a/src/bos/common/utils.py
+++ b/src/bos/common/utils.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -87,26 +87,6 @@ def exc_type_msg(exc: Exception) -> str:
     (e.g. TypeError: 'int' object is not subscriptable)
     """
     return ''.join(traceback.format_exception_only(type(exc), exc))
-
-def get_image_id(component: str) -> str:
-    """
-    Extract the IMS image ID from the path to the kernel
-    We expect it to look something like this:
-    s3://boot-images/fbcc5b02-b6a4-46a8-9402-2b7138adc327/kernel
-    """
-    # Get kernel's path
-    boot_artifacts = component.get('desired_state', {}).get('boot_artifacts', {})
-    kernel = boot_artifacts.get('kernel')
-    image_id = get_image_id_from_kernel(kernel)
-    return image_id
-
-
-def get_image_id_from_kernel(kernel_path: str) -> str:
-    # Extract image ID from kernel path
-    pattern = re.compile('.*//.*/(.*)/kernel')
-    match = pattern.match(kernel_path)
-    image_id = match.group(1)
-    return image_id
 
 def using_sbps(component: str) -> bool:
     """


### PR DESCRIPTION
This PR addresses two problems and makes some small improvements.

Fixes:

1. In CASMCMS-9255, it was observed that the BOS code assumes that the kernel path will always end with `kernel`, which is not necessarily true. This PR replaces the current functions used for this to instead just parse the path as an `S3Url`, and then uses the existing `get_ims_id_from_s3_url` function to extract the IMS ID.

2. The current code assigns `components_list` to the `image_id_to_nodes` dict, using the `image_id` key. However, if two different sets of artifacts both reference the same IMS image, then each successive assignment will overwrite the previous one. This only ends up mattering in the case that the image tagging fails. In that case, it uses the component list to know which components need their error statuses updated. This PR modifies it so that it instead compiles a union of all components for each image ID, so none are lost.

Improvements:

1. If an IMS image was soft-deleted, the current code may or may not get the IMS ID correctly (depending on whether it ended in `kernel`). If it did, then the IMS tagging would fail. This PR changes it so that for deleted images, it instead notices this and reports it explicitly, without trying the doomed-to-fail tagging.

2. An error is logged when an image is found where the IMS ID cannot be identified or if it is a deleted image.