### PR TITLE
CASMCMS-9270: Properly handle being asked to validate nonexistent session template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.32.2] - 2025-02-05
 ### Fixed
-- CASMCMS-9270: Properly handle being asked to validate nonexistent session template
+- CASMCMS-9270: Properly handle being asked to validate nonexistent session template; correct
+  nonexistent template error message
 
 ## [2.32.1] - 2025-01-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.32.2] - 2025-02-05
+### Fixed
+- CASMCMS-9270: Properly handle being asked to validate nonexistent session template
+
 ## [2.32.1] - 2025-01-16
 ### Fixed
 - CASMCMS-9255: Improved parsing of kernel paths to extract IMS IDs

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -126,8 +126,8 @@ def get_v2_sessiontemplate(session_template_id):
         LOGGER.warning("Session template not found: %s", session_template_id)
         return connexion.problem(
             status=404,
-            title="Sessiontemplate could not found.",
-            detail=f"Sessiontemplate {session_template_id} could not be found")
+            title="Session template not found.",
+            detail=f"Session template {session_template_id} could not be found")
     template = DB.get(template_key)
     return template, 200
 
@@ -161,8 +161,8 @@ def delete_v2_sessiontemplate(session_template_id):
         LOGGER.warning("Session template not found: %s", session_template_id)
         return connexion.problem(
             status=404,
-            title="Sessiontemplate could not found.",
-            detail=f"Sessiontemplate {session_template_id} could not be found")
+            title="Session template not found.",
+            detail=f"Session template {session_template_id} could not be found")
     return DB.delete(template_key), 204
 
 
@@ -182,8 +182,8 @@ def patch_v2_sessiontemplate(session_template_id):
         LOGGER.warning("Session template not found: %s", session_template_id)
         return connexion.problem(
             status=404,
-            title="Sessiontemplate could not found.",
-            detail=f"Sessiontemplate {session_template_id} could not be found")
+            title="Session template not found.",
+            detail=f"Session template {session_template_id} could not be found")
 
     try:
         template_data = get_request_json()

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,6 +23,7 @@
 #
 import logging
 import connexion
+from connexion.lifecycle import ConnexionResponse
 
 from bos.common.tenant_utils import get_tenant_from_header, get_tenant_aware_key, \
                                     reject_invalid_tenant
@@ -215,10 +216,13 @@ def validate_v2_sessiontemplate(session_template_id: str):
     LOGGER.debug(
         "GET /v2/sessiontemplatesvalid/%s invoked validate_v2_sessiontemplate",
         session_template_id)
-    data, status_code = get_v2_sessiontemplate(session_template_id)
+    response = get_v2_sessiontemplate(session_template_id)
+    if isinstance(response, ConnexionResponse):
+        # This means it was an error, so we just pass it up
+        return response
 
-    if status_code != 200:
-        return data, status_code
+    # Otherwise it should be a tuple of data and 200 status code
+    data, _ = response
 
     # We assume boot because it and reboot are the most demanding from a validation
     # standpoint.


### PR DESCRIPTION
If you attempt to validate a nonexistent session template, it produces an internal server error:

```
 # cray bos v2 sessiontemplatesvalid describe jason-sollom-forever
Usage: cray bos v2 sessiontemplatesvalid describe [OPTIONS]
                                                  SESSION_TEMPLATE_ID
Try 'cray bos v2 sessiontemplatesvalid describe -h' for help.
Error: Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application. 
```

This is because the endpoint does not properly handle the response from the `get_v2_sessiontemplate` method. This bug appears to exist in all released versions of BOS since this endpoint was introduced.

I discovered this as part of the type annotation work I am doing with CASMCMS-9264.

The fix is simple -- the `get_v2_sessiontemplate` method returns a `ConnexionResponse` on error, or a tuple on success. So first check if it's a `ConnexionResponse`, and if it is, just return it directly. Otherwise, treat it as a tuple and grab the session template data from it.

On mug, with the fix applied:

```
# cray bos v2 sessiontemplatesvalid describe jason-sollom-forever
Usage: cray bos v2 sessiontemplatesvalid describe [OPTIONS]
                                                  SESSION_TEMPLATE_ID
Try 'cray bos v2 sessiontemplatesvalid describe -h' for help.

Error: Session template not found.: Session template jason-sollom-forever could not be found
```

Backports:
1.6: https://github.com/Cray-HPE/bos/pull/432
1.5: https://github.com/Cray-HPE/bos/pull/433
1.4: https://github.com/Cray-HPE/bos/pull/434