### PR TITLE
CASMCMS-9274: Prevent SNYK-PYTHON-WERKZEUG-6808933 from failing builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- CASMCMS-9274: Prevent [`SNYK-PYTHON-WERKZEUG-6808933`](https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933) from causing builds to fail.
+
 ### Dependencies
 - Bumped Python dependency versions.
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -103,7 +103,7 @@ pipeline {
                 DOCKER_VERSION = sh(returnStdout: true, script: "head -1 .docker_version").trim()
             }
             steps {
-                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE)
+                publishCsmDockerImageIgnoreSnykPythonWerkzeug6808933(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE)
                 publishCsmHelmCharts(component: env.NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", isStable: env.IS_STABLE)
             }
         }


### PR DESCRIPTION
The BOS builds currently succeed, but github considers them to have failed because the image has the following vulnerability:
https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933

Ordinarily, we would modify BOS so that it was no longer subject to this vulnerability. However, in this case, there is no easy way to accomplish this. Updating the werkzeug module requires several other modules to be updated, and those conflict with other parts of BOS. In order to resolve this CVE, we would have to make some fundamental changes to the way the BOS service is generated.

In addition, while this CVE is considered high severity, the path for vulnerability requires that the debugger be enabled, and that is never the case for us in production.

Finally, given that fewer and fewer resources are being devoted to CSM development, and given the above facts, it is hard to justify spending our dwindling development resources on this effort.

The BOS builds have been hitting this issue for months now. It doesn't absolutely break us, because we are still able to merge PRs, and the artifacts still get published. However, it can cause confusion to people unfamiliar with this situation, when they see that github considers our PRs as not being ready to merge because of a build failure. And a bigger problem is that this persistent failure is likely to mask other security issues, because we will be in the habit of automatically ignoring the fact that BOS builds report a failed security scan.

I [added code to `cms-meta-tools`](https://github.com/Cray-HPE/cms-meta-tools/commit/b056e33826f2a901de588d4f4bf69800089ec0d7) to allow us to run the Snyk scans and specifically ignore just this one failure. This PR modifies BOS to use that new capability. This will allow us to immediately be aware of other CVEs if/when they arise, and will reduce the aforementioned PR confusion.
