### PR TITLE
CASMCMS-9284: Correct some type annotation errors identified by mypy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CASMCMS-9284: Correct some type annotation errors identified by `mypy`
+
 ## [2.33.0] - 2025-02-12
 
 ### Added

--- a/src/bos/common/clients/endpoints/base_generic_endpoint.py
+++ b/src/bos/common/clients/endpoints/base_generic_endpoint.py
@@ -48,7 +48,10 @@ class BaseGenericEndpoint(ABC, Generic[RequestReturnT]):
     """
     BASE_ENDPOINT: str = ''
     ENDPOINT: str = ''
-    error_handler: BaseRequestErrorHandler = RequestErrorHandler
+
+    @property
+    def error_handler(self) -> BaseRequestErrorHandler:
+        return RequestErrorHandler
 
     def __init__(self, session: requests.Session):
         super().__init__()

--- a/src/bos/common/clients/endpoints/request_error_handler.py
+++ b/src/bos/common/clients/endpoints/request_error_handler.py
@@ -32,7 +32,7 @@ from urllib3.exceptions import MaxRetryError
 
 from bos.common.utils import compact_response_text, exc_type_msg
 
-from .defs import RequestData, RequestsMethod
+from .defs import RequestData
 from .exceptions import ApiResponseError
 
 LOGGER = logging.getLogger(__name__)
@@ -58,12 +58,12 @@ class RequestErrorHandler(BaseRequestErrorHandler):
     @classmethod
     def handle_api_response_error(cls, err: ApiResponseError,
                                   request_data: RequestData) -> NoReturn:
-        msg = (f"Non-2XX response ({err.response.status_code}) to "
+        msg = (f"Non-2XX response ({err.response_data.status_code}) to "
                f"{request_data.method_name} {request_data.url}; "
-               f"{err.response.reason} "
-               f"{compact_response_text(err.response.text)}")
+               f"{err.response_data.reason} "
+               f"{compact_response_text(err.response_data.text)}")
         LOGGER.error(msg)
-        raise ApiResponseError(msg, response=err.response) from err
+        raise err
 
     @classmethod
     def handle_connection_error(cls, err: RequestsConnectionError,

--- a/src/bos/common/clients/ims/images.py
+++ b/src/bos/common/clients/ims/images.py
@@ -23,8 +23,7 @@
 #
 from typing import NoReturn
 
-from bos.common.clients.endpoints import ApiResponseError, RequestData, RequestErrorHandler, \
-                                         RequestsMethod
+from bos.common.clients.endpoints import ApiResponseError, RequestData, RequestErrorHandler
 
 from .base import BaseImsEndpoint
 from .defs import IMS_TAG_OPERATIONS, LOGGER
@@ -48,7 +47,10 @@ class ImsImageRequestErrorHandler(RequestErrorHandler):
 
 class ImagesEndpoint(BaseImsEndpoint):
     ENDPOINT = 'images'
-    error_handler = ImsImageRequestErrorHandler
+
+    @property
+    def error_handler(self) -> ImsImageRequestErrorHandler:
+        return ImsImageRequestErrorHandler
 
     def get_image(self, image_id: str) -> dict:
         return self.get_item(image_id)

--- a/src/bos/common/clients/pcs/base.py
+++ b/src/bos/common/clients/pcs/base.py
@@ -29,8 +29,10 @@ from requests.exceptions import HTTPError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from urllib3.exceptions import MaxRetryError
 
-from bos.common.clients.endpoints import ApiResponseError, BaseEndpoint, RequestErrorHandler, \
-                                         RequestData
+from bos.common.clients.endpoints import (ApiResponseError,
+                                          BaseEndpoint,
+                                          RequestErrorHandler,
+                                          RequestData)
 from bos.common.utils import PROTOCOL
 
 from .exceptions import PowerControlException
@@ -55,8 +57,8 @@ class PcsRequestErrorHandler(RequestErrorHandler):
         try:
             super().handle_exception(err, request_data)
         except (ApiResponseError, RequestsConnectionError, HTTPError,
-                JSONDecodeError, MaxRetryError) as err:
-            raise PowerControlException(err) from err
+                JSONDecodeError, MaxRetryError) as exc:
+            raise PowerControlException(exc) from exc
 
 
 class BasePcsEndpoint(BaseEndpoint, ABC):
@@ -64,4 +66,7 @@ class BasePcsEndpoint(BaseEndpoint, ABC):
     This base class provides generic access to the PCS API.
     """
     BASE_ENDPOINT = ENDPOINT
-    error_handler = PcsRequestErrorHandler
+
+    @property
+    def error_handler(self) -> PcsRequestErrorHandler:
+        return PcsRequestErrorHandler

--- a/src/bos/common/utils.py
+++ b/src/bos/common/utils.py
@@ -23,12 +23,13 @@
 #
 
 # Standard imports
-from contextlib import nullcontext
+from contextlib import nullcontext, AbstractContextManager
+import copy
 import datetime
 from functools import partial
 import re
 import traceback
-from typing import Iterator, Optional, Unpack
+from typing import Optional, Unpack
 
 # Third party imports
 from dateutil.parser import parse
@@ -39,6 +40,13 @@ from bos.common.types import JsonDict
 
 PROTOCOL = 'http'
 TIME_DURATION_PATTERN = re.compile(r"^(\d+?)(\D+?)$", re.M | re.S)
+
+
+class InvalidDurationTimestamp(Exception):
+    """
+    Raised by duration_to_timedelta if it is asked to parse a timestamp
+    that does not fit its expected pattern
+    """
 
 
 # Common date and timestamps functions so that timezones and formats are handled consistently.
@@ -66,7 +74,10 @@ def duration_to_timedelta(timestamp: str) -> datetime.timedelta:
         'd': 60 * 60 * 24,
         'w': 60 * 60 * 24 * 7
     }
-    timeval, durationval = TIME_DURATION_PATTERN.search(timestamp).groups()
+    match = TIME_DURATION_PATTERN.search(timestamp)
+    if match is None:
+        raise InvalidDurationTimestamp(f"Timestamp string does not match expected format: '{timestamp}'")
+    timeval, durationval = match.groups()
     timeval = float(timeval)
     seconds = timeval * seconds_table[durationval]
     return datetime.timedelta(seconds=seconds)
@@ -92,17 +103,16 @@ class RetrySessionManager(rrs.RetrySessionManager):
     def __init__(self,
                  protocol: str = PROTOCOL,
                  **adapter_kwargs: Unpack[rrs.RequestsRetryAdapterArgs]):
-        for key, value in DEFAULT_RETRY_ADAPTER_ARGS.items():
-            if key not in adapter_kwargs:
-                adapter_kwargs[key] = value
-        super().__init__(protocol=protocol, **adapter_kwargs)
+        _adapter_kwargs = copy.deepcopy(DEFAULT_RETRY_ADAPTER_ARGS)
+        _adapter_kwargs.update(adapter_kwargs)
+        super().__init__(protocol=protocol, **_adapter_kwargs)
 
 
 def retry_session(
     session: Optional[requests.Session] = None,
     protocol: Optional[str] = None,
     adapter_kwargs: Optional[rrs.RequestsRetryAdapterArgs] = None
-) -> Iterator[requests.Session]:
+) -> AbstractContextManager[requests.Session]:
     if session is not None:
         return nullcontext(session)
     kwargs = adapter_kwargs or {}
@@ -118,7 +128,7 @@ def retry_session_get(*get_args,
                       protocol: Optional[str] = None,
                       adapter_kwargs: Optional[
                           rrs.RequestsRetryAdapterArgs] = None,
-                      **get_kwargs) -> Iterator[requests.Response]:
+                      **get_kwargs) -> AbstractContextManager[requests.Response]:
     with retry_session(session=session,
                        protocol=protocol,
                        adapter_kwargs=adapter_kwargs) as _session:


### PR DESCRIPTION
This addresses a small number of the complaints `mypy` has. Only one of them has any functional impact on BOS itself. Previously the `duration_to_timedelta` function assumed that the timestamp being passed in would necessarily match the regular expression, so it did not check the result of its call to the `search` function. `mypy` does not approve. It sees, and it judges. The way that function worked before, if we did end up in a case where the regex didn't match, then I think it would have ended up raising either an `AttributeError` (when the code tried to call the `groups()` attribute of the `None` object). Now I have it explicitly check to see if it was a match or not. If not, then it will raise a brand new exception type just for this purpose.

That said, I don't know if I've ever seen that error path happen, and given the increased strictness we have on API inputs now, it's possible we never will. But that is the only change in this PR that could have an impact on BOS operational logic.

Oh, I take that back -- `mypy` also caught a bug where I was using the wrong attribute name in a request error object. This PR fixes that. That would have been annoying to find on a live system, since it only happens when you're already in an error path.