### PR TITLE
CASMCMS-9285: Type annotation improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CASMCMS-9285: Convert `bos.common.types` into a submodule; begin creating type definitions for BOS structures;
+  select minor type annotation improvements
+
 ## [2.33.0] - 2025-02-12
 
 ### Added

--- a/src/bos/common/clients/endpoints/base_endpoint.py
+++ b/src/bos/common/clients/endpoints/base_endpoint.py
@@ -25,7 +25,7 @@ from abc import ABC
 
 import requests
 
-from bos.common.types import JsonData
+from bos.common.types.general import JsonData
 
 from .base_generic_endpoint import BaseGenericEndpoint
 from .response_data import ResponseData

--- a/src/bos/common/clients/hsm/base.py
+++ b/src/bos/common/clients/hsm/base.py
@@ -29,7 +29,7 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from urllib3.exceptions import MaxRetryError
 
 from bos.common.clients.endpoints import ApiResponseError, BaseEndpoint, RequestsMethod
-from bos.common.types import JsonData
+from bos.common.types.general import JsonData
 from bos.common.utils import PROTOCOL
 
 from .exceptions import HWStateManagerException

--- a/src/bos/common/options.py
+++ b/src/bos/common/options.py
@@ -23,7 +23,7 @@
 #
 from abc import ABC, abstractmethod
 
-from bos.common.types import JsonData, JsonDict
+from bos.common.types.general import JsonData, JsonDict
 
 # This is the source of truth for default option values. All other BOS
 # code should either import this dict directly, or (preferably) access

--- a/src/bos/common/tenant_utils.py
+++ b/src/bos/common/tenant_utils.py
@@ -32,7 +32,7 @@ import connexion
 import requests
 from requests.exceptions import HTTPError
 
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.common.utils import exc_type_msg, retry_session_get, PROTOCOL
 
 LOGGER = logging.getLogger(__name__)

--- a/src/bos/common/types/__init__.py
+++ b/src/bos/common/types/__init__.py
@@ -21,33 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import json
-from typing import NamedTuple, Self
 
-import requests
-
-from bos.common.types.general import JsonData, JsonDict
-
-
-class ResponseData(NamedTuple):
-    """
-    Encapsulates data from a response to an API request. This allows the
-    response itself to be cleaned up when its context manager exits.
-    """
-    headers: JsonDict
-    ok: bool
-    reason: str
-    status_code: int
-    text: bytes | None
-
-    @property
-    def body(self) -> JsonData:
-        return json.loads(self.text) if self.text else None
-
-    @classmethod
-    def from_response(cls, resp: requests.Response) -> Self:
-        return cls(headers=resp.headers,
-                   ok=resp.ok,
-                   reason=resp.reason,
-                   status_code=resp.status_code,
-                   text=resp.text)
+"""
+BOS type annotations
+"""

--- a/src/bos/common/types/components.py
+++ b/src/bos/common/types/components.py
@@ -1,0 +1,70 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Type annotation definitions for BOS components
+"""
+
+from typing import Required, TypedDict
+
+# Mapping from string labels to sets of node names
+type NodeSetMapping = dict[str, set[str]]
+
+type BootArtifacts = dict[str, str]
+type ComponentStatus = dict[str, str]
+
+class ComponentLastAction(TypedDict, total=False):
+    action: str
+    failed: bool
+    last_updated: str
+
+type ComponentEventStats = dict[str, int]
+
+class BaseComponentState(TypedDict, total=False):
+    boot_artifacts: BootArtifacts
+    last_updated: str
+
+class ComponentActualState(BaseComponentState, total=False):
+    bss_token: str
+
+class ComponentDesiredState(BaseComponentState, total=False):
+    bss_token: str
+    configuration: str
+
+class ComponentStagedState(BaseComponentState, total=False):
+    configuration: str
+    session: str
+
+class ComponentRecord(TypedDict, total=False):
+    actual_state: ComponentActualState
+    desired_state: ComponentDesiredState
+    enabled: bool
+    error: str
+    event_stats: ComponentEventStats
+    id: Required[str]
+    last_action: ComponentLastAction
+    retry_policy: int
+    session: str
+    staged_state: ComponentStagedState
+    status: ComponentStatus

--- a/src/bos/common/types/general.py
+++ b/src/bos/common/types/general.py
@@ -21,33 +21,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import json
-from typing import NamedTuple, Self
 
-import requests
+"""
+General type annotation definitions
+"""
 
-from bos.common.types.general import JsonData, JsonDict
-
-
-class ResponseData(NamedTuple):
-    """
-    Encapsulates data from a response to an API request. This allows the
-    response itself to be cleaned up when its context manager exits.
-    """
-    headers: JsonDict
-    ok: bool
-    reason: str
-    status_code: int
-    text: bytes | None
-
-    @property
-    def body(self) -> JsonData:
-        return json.loads(self.text) if self.text else None
-
-    @classmethod
-    def from_response(cls, resp: requests.Response) -> Self:
-        return cls(headers=resp.headers,
-                   ok=resp.ok,
-                   reason=resp.reason,
-                   status_code=resp.status_code,
-                   text=resp.text)
+type JsonData = bool | str | None | int | float | list[JsonData] | dict[str, JsonData]
+type JsonDict = dict[str, JsonData]
+type JsonList = list[JsonData]

--- a/src/bos/common/types/sessions.py
+++ b/src/bos/common/types/sessions.py
@@ -22,6 +22,31 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-type JsonData = bool | str | None | int | float | list[JsonData] | dict[str, JsonData]
-type JsonDict = dict[str, JsonData]
-type JsonList = list[JsonData]
+"""
+Type annotation definitions for BOS sessions
+"""
+
+from typing import Literal, Optional, Required, TypedDict
+
+SessionStatusLabel = Literal['complete', 'pending', 'running']
+
+class SessionStatus(TypedDict, total=False):
+    # Optional means these can be a string or be None
+    end_time: Optional[str]
+    error: Optional[str]
+    start_time: str
+    status: SessionStatusLabel
+
+SessionOperation = Literal['boot', 'reboot', 'shutdown']
+
+class Session(TypedDict, total=False):
+    components: str
+    include_disabled: bool
+    limit: str
+    name: Required[str]
+    operation: Required[SessionOperation]
+    stage: bool
+    status: Required[SessionStatus]
+    template_name: Required[str]
+    # Optional means this can be a string or be None
+    tenant: Optional[str]

--- a/src/bos/common/types/templates.py
+++ b/src/bos/common/types/templates.py
@@ -1,0 +1,72 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Type annotation definitions for BOS session templates
+"""
+
+from typing import get_args, Literal, Optional, Required, TypedDict
+
+class Link(TypedDict, total=False):
+    href: str
+    rel: str
+
+class SessionTemplateCfsParameters(TypedDict, total=False):
+    configuration: str
+
+BootSetArch = Literal['X86', 'ARM', 'Other', 'Unknown']
+
+BOOT_SET_DEFAULT_ARCH: BootSetArch = 'X86'
+
+# Valid boot sets are required to have at least one of these fields
+BootSetHardwareSpecifierFields = Literal['node_list', 'node_roles_groups', 'node_groups']
+
+# This fancy footwork lets us construct a tuple of the string values from the previous definition,
+# allowing us to avoid duplicating it.
+BOOT_SET_HARDWARE_SPECIFIER_FIELDS: tuple[BootSetHardwareSpecifierFields] = \
+    get_args(BootSetHardwareSpecifierFields)
+
+class BootSet(TypedDict, total=False):
+    arch: BootSetArch
+    cfs: SessionTemplateCfsParameters
+    etag: str
+    kernel_parameters: str
+    name: str
+    node_list: list[str]
+    node_groups: list[str]
+    node_roles_groups: list[str]
+    path: Required[str]
+    rootfs_provider: str
+    rootfs_provider_passthrough: str
+    type: Required[str]
+
+class SessionTemplate(TypedDict, total=False):
+    boot_sets: Required[dict[str, BootSet]]
+    cfs: SessionTemplateCfsParameters
+    description: str
+    enable_cfs: bool
+    links: list[Link]
+    name: Required[str]
+    # Optional means this can be a string or be None
+    tenant: Optional[str]

--- a/src/bos/common/utils.py
+++ b/src/bos/common/utils.py
@@ -35,7 +35,7 @@ from dateutil.parser import parse
 import requests
 import requests_retry_session as rrs
 
-from bos.common.types import JsonDict
+from bos.common.types.components import ComponentRecord
 
 PROTOCOL = 'http'
 TIME_DURATION_PATTERN = re.compile(r"^(\d+?)(\D+?)$", re.M | re.S)
@@ -143,7 +143,7 @@ def exc_type_msg(exc: Exception) -> str:
     """
     return ''.join(traceback.format_exception_only(type(exc), exc))
 
-def using_sbps(component: str) -> bool:
+def using_sbps(component: ComponentRecord) -> bool:
     """
     If the component is using the Scalable Boot Provisioning Service (SBPS) to
     provide the root filesystem, then return True.
@@ -175,7 +175,7 @@ def using_sbps_check_kernel_parameters(kernel_parameters: str) -> bool:
     return "root=sbps-s3" in kernel_parameters
 
 
-def components_by_id(components: list[JsonDict]) -> JsonDict:
+def components_by_id(components: list[ComponentRecord]) -> dict[str, ComponentRecord]:
     """
     Input:
     * components: a list containing individual components
@@ -189,7 +189,7 @@ def components_by_id(components: list[JsonDict]) -> JsonDict:
     return {component["id"]: component for component in components}
 
 
-def reverse_components_by_id(components_by_id_map: JsonDict) -> list[JsonDict]:
+def reverse_components_by_id(components_by_id_map: dict[str, ComponentRecord]) -> list[ComponentRecord]:
     """
     Input:
     components_by_id_map: a dictionary with the name of each component as the

--- a/src/bos/common/values.py
+++ b/src/bos/common/values.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,6 +21,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+from bos.common.types.components import (BootArtifacts,
+                                         ComponentActualState,
+                                         ComponentDesiredState,
+                                         ComponentStagedState)
+
 # Phases
 class Phase:
     powering_on = "powering_on"
@@ -52,17 +58,24 @@ class Status:
     on_hold = "on_hold"
 
 
-EMPTY_BOOT_ARTIFACTS = {"kernel": "", "kernel_parameters": "", "initrd": ""}
+EMPTY_BOOT_ARTIFACTS: BootArtifacts = {
+    "kernel": "",
+    "kernel_parameters": "",
+    "initrd": ""
+}
 
-EMPTY_ACTUAL_STATE = {"boot_artifacts": EMPTY_BOOT_ARTIFACTS, "bss_token": ""}
+EMPTY_ACTUAL_STATE: ComponentActualState = {
+    "boot_artifacts": EMPTY_BOOT_ARTIFACTS,
+    "bss_token": ""
+}
 
-EMPTY_DESIRED_STATE = {
+EMPTY_DESIRED_STATE: ComponentDesiredState = {
     "configuration": "",
     "boot_artifacts": EMPTY_BOOT_ARTIFACTS,
     "bss_token": ""
 }
 
-EMPTY_STAGED_STATE = {
+EMPTY_STAGED_STATE: ComponentStagedState = {
     "configuration": "",
     "boot_artifacts": EMPTY_BOOT_ARTIFACTS
 }

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -33,7 +33,7 @@ import logging
 import threading
 import os
 import time
-from typing import Generator, List, NoReturn, Type
+from typing import Generator, NoReturn, Optional, Type
 
 from bos.common.clients.bos import BOSClient
 from bos.common.clients.bos.options import options
@@ -43,6 +43,7 @@ from bos.common.clients.hsm import HSMClient
 from bos.common.clients.ims import IMSClient
 from bos.common.clients.pcs import PCSClient
 from bos.common.utils import exc_type_msg
+from bos.common.types.components import ComponentRecord
 from bos.common.values import Status
 from bos.operators.filters import BOSQuery, DesiredConfigurationSetInCFS, HSMState
 from bos.operators.filters.base import BaseFilter
@@ -136,7 +137,7 @@ class BaseOperator(ABC):
 
     @property
     @abstractmethod
-    def filters(self) -> List[Type[BaseFilter]]:
+    def filters(self) -> list[Type[BaseFilter]]:
         return []
 
     def BOSQuery(self, **kwargs) -> BOSQuery:
@@ -205,7 +206,7 @@ class BaseOperator(ABC):
         return max_batch_size
 
     def _chunk_components(
-            self, components: List[dict]) -> Generator[List[dict], None, None]:
+            self, components: list[ComponentRecord]) -> Generator[list[ComponentRecord], None, None]:
         """
         Break up the components into groups of no more than max_batch_size nodes,
         and yield each group in turn.
@@ -223,7 +224,7 @@ class BaseOperator(ABC):
         for chunk in self._chunk_components(components):
             self._run_on_chunk(chunk)
 
-    def _run_on_chunk(self, components: List[dict]) -> None:
+    def _run_on_chunk(self, components: list[ComponentRecord]) -> None:
         """
         Acts on a chunk of components
         """
@@ -249,14 +250,14 @@ class BaseOperator(ABC):
                 component["error"] = str(e)
         self._update_database(components)
 
-    def _get_components(self) -> List[dict]:
+    def _get_components(self) -> list[ComponentRecord]:
         """ Gets the list of all components that require actions  """
         components = []
         for f in self.filters:
             components = f.filter(components)
         return components
 
-    def _handle_failed_components(self, components: List[dict]) -> List[dict]:
+    def _handle_failed_components(self, components: list[ComponentRecord]) -> list[ComponentRecord]:
         """ Marks components failed if the retry limits are exceeded """
         if not components:
             # If we have been passed an empty list, there is nothing to do.
@@ -279,13 +280,13 @@ class BaseOperator(ABC):
         return good_components
 
     @abstractmethod
-    def _act(self, components: List[dict]) -> List[dict]:
+    def _act(self, components: list[ComponentRecord]) -> list[ComponentRecord]:
         """ The action taken by the operator on target components """
         raise NotImplementedError()
 
     def _update_database(self,
-                         components: List[dict],
-                         additional_fields: dict = None) -> None:
+                         components: list[ComponentRecord],
+                         additional_fields: Optional[dict] = None) -> None:
         """
         Updates the BOS database for all components acted on by the operator
         Includes updating the last action, attempt count and error
@@ -327,7 +328,7 @@ class BaseOperator(ABC):
         LOGGER.debug('Updated components: %s', data)
         self.client.bos.components.update_components(data)
 
-    def _preset_last_action(self, components: List[dict]) -> None:
+    def _preset_last_action(self, components: list[ComponentRecord]) -> None:
         # This is done to eliminate the window between performing an action and marking the
         # nodes as acted
         # e.g. nodes could be powered-on without the correct power-on last action, causing
@@ -350,7 +351,7 @@ class BaseOperator(ABC):
         LOGGER.debug('Updated components: %s', data)
         self.client.bos.components.update_components(data)
 
-    def _update_database_for_failure(self, components: List[dict]) -> None:
+    def _update_database_for_failure(self, components: list[ComponentRecord]) -> None:
         """
         Updates the BOS database for all components the operator believes have failed
         """
@@ -378,8 +379,8 @@ class BaseOperator(ABC):
         self.client.bos.components.update_components(data)
 
 
-def chunk_components(components: List[dict],
-                     max_batch_size: int) -> Generator[List[dict], None, None]:
+def chunk_components(components: list[ComponentRecord],
+                     max_batch_size: int) -> Generator[list[ComponentRecord], None, None]:
     """
     Break up the components into groups of no more than max_batch_size nodes,
     and yield each group in turn.

--- a/src/bos/operators/discovery.py
+++ b/src/bos/operators/discovery.py
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 import logging
-from typing import Set
 from copy import copy
 
+from bos.common.types.components import ComponentRecord
 from bos.common.values import Action, EMPTY_ACTUAL_STATE, EMPTY_DESIRED_STATE
 from bos.operators.base import BaseOperator, main
 
@@ -65,7 +65,7 @@ class DiscoveryOperator(BaseOperator):
     def filters(self):
         return []
 
-    def _act(self, components):
+    def _act(self, components: list[ComponentRecord]) -> list[ComponentRecord]:
         return components
 
     def _run(self) -> None:
@@ -87,9 +87,9 @@ class DiscoveryOperator(BaseOperator):
             LOGGER.info("%s new component(s) added to BOS!", len(chunk))
 
     @property
-    def bos_components(self) -> Set[str]:
+    def bos_components(self) -> set[str]:
         """
-        The set of components currently known to BOS
+        The set of component IDs currently known to BOS
         """
         components = set()
         for component in self.client.bos.components.get_components():
@@ -97,16 +97,16 @@ class DiscoveryOperator(BaseOperator):
         return components
 
     @property
-    def hsm_xnames(self) -> Set[str]:
+    def hsm_xnames(self) -> set[str]:
         """
-        The set of components currently known to HSM State Manager
+        The set of component IDs currently known to HSM State Manager
         """
         return self.client.hsm.state_components.read_all_node_xnames()
 
     @property
-    def missing_components(self) -> Set[str]:
+    def missing_components(self) -> set[str]:
         """
-        The set of components that need to be added to BOS.
+        The set of component IDs that need to be added to BOS.
         """
         return self.hsm_xnames - self.bos_components
 

--- a/src/bos/operators/status.py
+++ b/src/bos/operators/status.py
@@ -25,6 +25,7 @@
 import logging
 
 from bos.common.clients.bos.options import options
+from bos.common.types.components import ComponentRecord
 from bos.common.values import Phase, Status, Action, EMPTY_ACTUAL_STATE
 from bos.operators.base import BaseOperator, main
 from bos.operators.filters import DesiredBootStateIsOff, BootArtifactStatesMatch, \
@@ -69,7 +70,7 @@ class StatusOperator(BaseOperator):
     def filters(self):
         return []
 
-    def _act(self, components):
+    def _act(self, components: list[ComponentRecord]) -> list[ComponentRecord]:
         return components
 
     def _run(self) -> None:
@@ -83,7 +84,7 @@ class StatusOperator(BaseOperator):
         for chunk in self._chunk_components(components):
             self._run_on_chunk(chunk)
 
-    def _run_on_chunk(self, components) -> None:
+    def _run_on_chunk(self, components: list[ComponentRecord]) -> None:
         """
         Acts on a chunk of components
         """
@@ -125,7 +126,7 @@ class StatusOperator(BaseOperator):
             cfs_states[component['id']] = component
         return cfs_states
 
-    def _check_status(self, component, power_state, cfs_component):
+    def _check_status(self, component: ComponentRecord, power_state, cfs_component):
         """
         Calculate the component's current status based upon its power state and CFS configuration
         state. If its status differs from the status in the database, return this information.
@@ -185,7 +186,7 @@ class StatusOperator(BaseOperator):
             return updated_component
         return None
 
-    def _calculate_status(self, component, power_state, cfs_component):
+    def _calculate_status(self, component: ComponentRecord, power_state, cfs_component):
         """
         Calculate a component's status based on its current state, power state, and
         CFS state.

--- a/src/bos/server/controllers/v2/boot_set/artifacts.py
+++ b/src/bos/server/controllers/v2/boot_set/artifacts.py
@@ -24,7 +24,7 @@
 
 from bos.common.clients.s3 import S3Object, ArtifactNotFound
 from bos.common.utils import exc_type_msg
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.operators.utils.boot_image_metadata.factory import BootImageMetaDataFactory
 
 from .defs import LOGGER

--- a/src/bos/server/controllers/v2/boot_set/ims.py
+++ b/src/bos/server/controllers/v2/boot_set/ims.py
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.common.utils import exc_type_msg
 from bos.common.clients.ims import get_arch_from_image_data, IMSClient, \
                                             get_ims_id_from_s3_url, ImageNotFound

--- a/src/bos/server/controllers/v2/boot_set/sanitize.py
+++ b/src/bos/server/controllers/v2/boot_set/sanitize.py
@@ -25,7 +25,7 @@
 from typing import Optional
 
 from bos.common.utils import exc_type_msg
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.server.controllers.v2.options import OptionsData
 from bos.server.utils import canonize_xname
 

--- a/src/bos/server/controllers/v2/boot_set/validate.py
+++ b/src/bos/server/controllers/v2/boot_set/validate.py
@@ -26,7 +26,7 @@ from functools import partial
 from typing import Optional
 
 from bos.common.utils import exc_type_msg
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.server.controllers.v2.options import OptionsData
 
 from .artifacts import validate_boot_artifacts

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -31,7 +31,7 @@ from connexion.lifecycle import ConnexionResponse
 from bos.common.utils import exc_type_msg, get_current_timestamp
 from bos.common.tenant_utils import get_tenant_from_header, get_tenant_component_set, \
                                     tenant_error_handler, get_tenant_aware_key
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.common.values import Phase, Action, Status, EMPTY_STAGED_STATE, EMPTY_BOOT_ARTIFACTS
 from bos.server import redis_db_utils as dbutils
 from bos.server.controllers.utils import _400_bad_request, _404_resource_not_found

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -30,7 +30,7 @@ import connexion
 from connexion.lifecycle import ConnexionResponse
 
 from bos.common.options import DEFAULTS, OptionsCache
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.common.utils import exc_type_msg
 from bos.server import redis_db_utils as dbutils
 from bos.server.controllers.utils import _400_bad_request

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -34,7 +34,7 @@ from connexion.lifecycle import ConnexionResponse
 
 from bos.common.tenant_utils import get_tenant_from_header, get_tenant_aware_key, \
                                     reject_invalid_tenant
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.common.utils import exc_type_msg, get_current_time, get_current_timestamp, load_timestamp
 from bos.common.values import Phase, Status
 from bos.server import redis_db_utils as dbutils

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -29,7 +29,7 @@ from connexion.lifecycle import ConnexionResponse
 
 from bos.common.tenant_utils import get_tenant_from_header, get_tenant_aware_key, \
                                     reject_invalid_tenant
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.common.utils import exc_type_msg
 from bos.server import redis_db_utils as dbutils
 from bos.server.controllers.utils import _400_bad_request, _404_resource_not_found

--- a/src/bos/server/dbs/boot_artifacts.py
+++ b/src/bos/server/dbs/boot_artifacts.py
@@ -23,7 +23,7 @@
 #
 import logging
 
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.common.utils import get_current_timestamp
 from bos.server import redis_db_utils as dbutils
 

--- a/src/bos/server/migrations/sanitize.py
+++ b/src/bos/server/migrations/sanitize.py
@@ -28,8 +28,8 @@ import logging
 import string
 from typing import Optional
 
-from bos.common.types import JsonDict
 from bos.common.tenant_utils import get_tenant_aware_key
+from bos.common.types.general import JsonDict
 from bos.server.controllers.v2.boot_set import DEFAULT_ARCH, HARDWARE_SPECIFIER_FIELDS
 from bos.server.schema import validator
 

--- a/src/bos/server/migrations/validate.py
+++ b/src/bos/server/migrations/validate.py
@@ -25,7 +25,7 @@
 import logging
 
 from bos.common.tenant_utils import get_tenant_aware_key
-from bos.common.types import JsonData, JsonDict
+from bos.common.types.general import JsonData, JsonDict
 from bos.common.utils import exc_type_msg
 from bos.server.schema import validator
 

--- a/src/bos/server/redis_db_utils.py
+++ b/src/bos/server/redis_db_utils.py
@@ -31,7 +31,7 @@ from typing import Generator, Optional, ParamSpec, TypeVar
 import connexion
 import redis
 
-from bos.common.types import JsonDict
+from bos.common.types.general import JsonDict
 from bos.common.utils import exc_type_msg
 
 LOGGER = logging.getLogger(__name__)

--- a/src/bos/server/utils.py
+++ b/src/bos/server/utils.py
@@ -26,7 +26,7 @@ import re
 
 import connexion
 
-from bos.common.types import JsonData
+from bos.common.types.general import JsonData
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
The biggest content of this PR is creating the `bos.common.types` submodule, and beginning to define types to use for different BOS data structures. This PR only begins using a small number of these -- future PRs will continue that. This PR does touch a lot of files, mostly because it has to update the import paths for any files importing `JsonDict` or `JsonData`.

This PR has no functional impacts -- it's purely type checking enablement.