### PR TITLE
CASMCMS-9287: Address some non-fatal pylint code complaints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9287: Addressed some non-fatal `pylint` code complaints
+
 ### Fixed
 - CASMCMS-9285: Convert `bos.common.types` into a submodule; begin creating type definitions for BOS structures;
   select minor type annotation improvements

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -22,6 +22,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
 """
 BOS Operator - A Python operator for the Boot Orchestration Service.
 """
@@ -205,8 +206,9 @@ class BaseOperator(ABC):
             self.__max_batch_size = max_batch_size
         return max_batch_size
 
-    def _chunk_components(
-            self, components: list[ComponentRecord]) -> Generator[list[ComponentRecord], None, None]:
+    def _chunk_components(self,
+                          components: list[ComponentRecord]) -> Generator[list[ComponentRecord],
+                                                                          None, None]:
         """
         Break up the components into groups of no more than max_batch_size nodes,
         and yield each group in turn.

--- a/src/bos/operators/filters/base.py
+++ b/src/bos/operators/filters/base.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,6 @@
 #
 from abc import ABC, abstractmethod
 import logging
-from typing import List
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +39,7 @@ class BaseFilter(ABC):
 
     INITIAL: bool = False  # Set for filters that are meant to be the first in the list
 
-    def filter(self, components: List) -> List:
+    def filter(self, components: list) -> list:
         results = []
         try:
             if components or self.INITIAL:
@@ -50,14 +49,14 @@ class BaseFilter(ABC):
         return results
 
     @abstractmethod
-    def _filter(self, components: List) -> List:
+    def _filter(self, components: list) -> list:
         raise NotImplementedError
 
 
 class IDFilter(BaseFilter, ABC):
     """ A class for filters that take and return lists of component ids """
 
-    def filter(self, components: List[dict]) -> List[dict]:
+    def filter(self, components: list[dict]) -> list[dict]:
         component_ids = [component['id'] for component in components]
         results = BaseFilter.filter(self, components=component_ids)
         LOGGER.debug('%s filter found the following components: %s',
@@ -70,7 +69,7 @@ class IDFilter(BaseFilter, ABC):
 class DetailsFilter(BaseFilter, ABC):
     """ A class for filters that take and return lists of detailed component information """
 
-    def filter(self, components: List[dict]) -> List[dict]:
+    def filter(self, components: list[dict]) -> list[dict]:
         results = BaseFilter.filter(self, components=components)
         LOGGER.debug(
             '%s filter found the following components: %s',
@@ -85,7 +84,7 @@ class LocalFilter(DetailsFilter, ABC):
     Only the _match method needs to be overridden to filter on one component at a time.
     """
 
-    def _filter(self, components: List[dict]) -> List[dict]:
+    def _filter(self, components: list[dict]) -> list[dict]:
         matching_components = []
         for component in components:
             if self._match(component):

--- a/src/bos/operators/filters/filters.py
+++ b/src/bos/operators/filters/filters.py
@@ -26,7 +26,7 @@ import copy
 from datetime import timedelta
 import logging
 import re
-from typing import List, Type
+from typing import Type
 
 from bos.common.clients.bos import BOSClient
 from bos.common.clients.cfs import CFSClient
@@ -42,10 +42,10 @@ class OR(DetailsFilter):
 
     def __init__(self, filters_a, filters_b) -> None:
         super().__init__()
-        self.filters_a: List[Type[BaseFilter]] = filters_a
-        self.filters_b: List[Type[BaseFilter]] = filters_b
+        self.filters_a: list[Type[BaseFilter]] = filters_a
+        self.filters_b: list[Type[BaseFilter]] = filters_b
 
-    def _filter(self, components: List[dict]) -> List[dict]:
+    def _filter(self, components: list[dict]) -> list[dict]:
         results_a = copy.deepcopy(components)
         for f in self.filters_a:
             results_a = f.filter(results_a)
@@ -77,7 +77,7 @@ class BOSQuery(DetailsFilter):
         self.kwargs = kwargs
         self.bos_client = bos_client
 
-    def _filter(self, _) -> List[dict]:
+    def _filter(self, _) -> list[dict]:
         return self.bos_client.components.get_components(**self.kwargs)
 
 
@@ -93,7 +93,7 @@ class HSMState(IDFilter):
         self.ready = ready
         self.hsm_client = hsm_client
 
-    def _filter(self, components: List[str]) -> List[str]:
+    def _filter(self, components: list[str]) -> list[str]:
         components = self.hsm_client.state_components.get_components(
             components, enabled=self.enabled)
         if self.ready is not None:
@@ -135,7 +135,7 @@ class NOT(LocalFilter):
 
         self.negated_filter._match = negated_match
 
-    def _filter(self, components: List[dict]) -> List[dict]:
+    def _filter(self, components: list[dict]) -> list[dict]:
         return self.negated_filter._filter(components)
 
     def _match(self, component: dict):
@@ -223,7 +223,7 @@ class DesiredConfigurationSetInCFS(LocalFilter):
         self.cfs_components_dict = {}
         self.cfs_client = cfs_client
 
-    def _filter(self, components: List[dict]) -> List[dict]:
+    def _filter(self, components: list[dict]) -> list[dict]:
         component_ids = [component['id'] for component in components]
         cfs_components = self.cfs_client.components.get_components_from_id_list(
             id_list=component_ids)

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -22,6 +22,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
 import copy
 import logging
 from typing import Callable, Iterable

--- a/src/bos/operators/status.py
+++ b/src/bos/operators/status.py
@@ -28,8 +28,11 @@ from bos.common.clients.bos.options import options
 from bos.common.types.components import ComponentRecord
 from bos.common.values import Phase, Status, Action, EMPTY_ACTUAL_STATE
 from bos.operators.base import BaseOperator, main
-from bos.operators.filters import DesiredBootStateIsOff, BootArtifactStatesMatch, \
-    DesiredConfigurationIsNone, LastActionIs, TimeSinceLastAction
+from bos.operators.filters import (BootArtifactStatesMatch,
+                                   DesiredBootStateIsOff,
+                                   DesiredConfigurationIsNone,
+                                   LastActionIs,
+                                   TimeSinceLastAction)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/bos/server/controllers/v2/boot_set/ims.py
+++ b/src/bos/server/controllers/v2/boot_set/ims.py
@@ -22,11 +22,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+from bos.common.clients.ims import (get_arch_from_image_data,
+                                    get_ims_id_from_s3_url,
+                                    ImageNotFound,
+                                    IMSClient)
+from bos.common.clients.s3 import S3Url
 from bos.common.types.general import JsonDict
 from bos.common.utils import exc_type_msg
-from bos.common.clients.ims import get_arch_from_image_data, IMSClient, \
-                                            get_ims_id_from_s3_url, ImageNotFound
-from bos.common.clients.s3 import S3Url
 from bos.server.controllers.v2.options import OptionsData
 
 from .defs import DEFAULT_ARCH

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -29,8 +29,10 @@ import connexion
 from connexion.lifecycle import ConnexionResponse
 
 from bos.common.utils import exc_type_msg, get_current_timestamp
-from bos.common.tenant_utils import get_tenant_from_header, get_tenant_component_set, \
-                                    tenant_error_handler, get_tenant_aware_key
+from bos.common.tenant_utils import (get_tenant_aware_key,
+                                     get_tenant_component_set,
+                                     get_tenant_from_header,
+                                     tenant_error_handler)
 from bos.common.types.general import JsonDict
 from bos.common.values import Phase, Action, Status, EMPTY_STAGED_STATE, EMPTY_BOOT_ARTIFACTS
 from bos.server import redis_db_utils as dbutils

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -26,7 +26,6 @@ import threading
 import time
 from typing import Literal, NoReturn
 
-import connexion
 from connexion.lifecycle import ConnexionResponse
 
 from bos.common.options import DEFAULTS, OptionsCache

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -32,8 +32,9 @@ import uuid
 import connexion
 from connexion.lifecycle import ConnexionResponse
 
-from bos.common.tenant_utils import get_tenant_from_header, get_tenant_aware_key, \
-                                    reject_invalid_tenant
+from bos.common.tenant_utils import (get_tenant_aware_key,
+                                     get_tenant_from_header,
+                                     reject_invalid_tenant)
 from bos.common.types.general import JsonDict
 from bos.common.utils import exc_type_msg, get_current_time, get_current_timestamp, load_timestamp
 from bos.common.values import Phase, Status

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -27,8 +27,9 @@ from typing import Literal, Optional
 
 from connexion.lifecycle import ConnexionResponse
 
-from bos.common.tenant_utils import get_tenant_from_header, get_tenant_aware_key, \
-                                    reject_invalid_tenant
+from bos.common.tenant_utils import (get_tenant_aware_key,
+                                     get_tenant_from_header,
+                                     reject_invalid_tenant)
 from bos.common.types.general import JsonDict
 from bos.common.utils import exc_type_msg
 from bos.server import redis_db_utils as dbutils

--- a/src/bos/server/migrations/sanitize.py
+++ b/src/bos/server/migrations/sanitize.py
@@ -34,9 +34,15 @@ from bos.server.controllers.v2.boot_set import DEFAULT_ARCH, HARDWARE_SPECIFIER_
 from bos.server.schema import validator
 
 from .db import TEMP_DB, delete_component, delete_session, delete_template
-from .validate import ValidationError, check_component, check_session, check_keys, \
-                      get_required_field, get_validate_tenant, is_valid_available_template_name, \
-                      validate_bootset_path, validate_against_schema
+from .validate import (ValidationError,
+                       check_component,
+                       check_session,
+                       check_keys,
+                       get_required_field,
+                       get_validate_tenant,
+                       is_valid_available_template_name,
+                       validate_bootset_path,
+                       validate_against_schema)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/bos/server/redis_db_utils.py
+++ b/src/bos/server/redis_db_utils.py
@@ -132,7 +132,8 @@ class DBWrapper():
         Get an array of data for all keys after passing them through the specified filter
         (discarding any for which the filter returns None)
         If start_after_id is specified, all ids lexically <= that id will be skipped.
-        If page_size is specified, the number of items in the returned list will be equal to or less than the page_size.
+        If page_size is specified, the number of items in the returned list will be equal
+        to or less than the page_size.
         More elements may remain and additional queries will be needed to acquire them.
         """
         data = []


### PR DESCRIPTION
Just addressing some `pylint` complaints I just noticed. Most of this has no real impact. In one case (in the power on operator) I did refactor a function so that some of its code is moved into a separate function. The overall logic is unchanged (except I did change some log messages from errors to warnings, for cases where there was a transient failure but we are retrying -- I reserved the error log level for if we give up retrying)..

I am making this PR against my branch for another PR, only because I am editing a couple of the same files.