### PR TITLE
CASMCMS-9288: Fix session setup operator attempting to use uninitialized API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.34.1] - 2025-02-18
+
+### Fixed
+- CASMCMS-9288: Fix session setup operator attempting to use uninitialized API client
+
 ## [2.34.0] - 2025-02-18
 
 ### Changed

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -38,7 +38,7 @@ from bos.common.utils import exc_type_msg
 from bos.common.values import Action, EMPTY_ACTUAL_STATE, EMPTY_DESIRED_STATE, EMPTY_STAGED_STATE
 from bos.operators.base import BaseOperator, main, chunk_components
 from bos.operators.filters import HSMState
-from bos.operators.session_completion import SessionCompletionOperator
+from bos.operators.session_completion import mark_session_complete
 from bos.operators.utils.boot_image_metadata.factory import BootImageMetaDataFactory
 from bos.operators.utils.rootfs.factory import ProviderFactory
 
@@ -329,12 +329,7 @@ class Session:
         Input:
           err (string): The error that prevented the session from running
         """
-        self.bos_client.sessions.update_session(self.name, self.tenant,
-                                                {'status': {
-                                                    'error': err
-                                                }})
-        sco = SessionCompletionOperator()
-        sco._mark_session_complete(self.name, self.tenant)
+        mark_session_complete(self.name, self.tenant, self.bos_client, err=err)
         self._log(LOGGER.info, 'Session %s has failed.', self.name)
 
     def _log(self, logger, message, *xargs):


### PR DESCRIPTION
Normally, sessions are marked complete only by the session completion operator. However, in rare cases, the session setup operator does this, when the session cannot even start due to errors. In this case, the session setup operator instantiates a session completion operator of its own, and makes a call to one of its methods. The problem is, this instantiation of the completion operator does not have its API clients initialized (this is normally done as part of the `run` method), and leads to an exception.

This only is a problem because of the API client overhaul I did as part of [CASMCMS-9237](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9237), adding the context managers around the API clients, and having them setup and torn down by the run method.

The fix is easy. This PR moves the code in question into its own function, outside of either operator, and has this function take a BOS API client as one of its parameters. That way, each operator can make use of the function, and just pass in their BOS API client when they do so. This is also an improvement over the previous way, even apart from this bug, because it wasn't good practice to be calling into a protected (single-underscore) method of a class from the outside.

I tested this on wasp and confirmed that it fixed the problem observed.