### PR TITLE
CASMCMS-9289: Remove extra / from HSM URLs to prevent request failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CASMCMS-9289: Remove extra `/` from HSM URLs to prevent request failures
+- CASMCMS-9290
+  - Remove no-longer-necessary call to `raise_for_status` in BOS power on operator
+  - Catch all exceptions arising from API call
+  - Update power on operator to reflect fact that the BSS API client returns the
+    `bss-referral-token` itself, not an API response object.
 
 ## [2.34.1] - 2025-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.34.2] - 2025-02-19
+
 ### Fixed
 - CASMCMS-9289: Remove extra `/` from HSM URLs to prevent request failures
 - CASMCMS-9290

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CASMCMS-9289: Remove extra `/` from HSM URLs to prevent request failures
+
 ## [2.34.1] - 2025-02-18
 
 ### Fixed

--- a/src/bos/common/clients/hsm/base.py
+++ b/src/bos/common/clients/hsm/base.py
@@ -35,7 +35,7 @@ from bos.common.utils import PROTOCOL
 from .exceptions import HWStateManagerException
 
 SERVICE_NAME = 'cray-smd'
-ENDPOINT = f"{PROTOCOL}://{SERVICE_NAME}/hsm/v2/"
+ENDPOINT = f"{PROTOCOL}://{SERVICE_NAME}/hsm/v2"
 
 
 class BaseHsmEndpoint(BaseEndpoint, ABC):

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -27,9 +27,6 @@
 from collections import defaultdict
 import logging
 
-# Third party imports
-from requests import HTTPError
-
 # BOS module imports
 from bos.common.clients.ims import get_ims_id_from_s3_url
 from bos.common.clients.s3 import S3Url
@@ -157,18 +154,16 @@ class PowerOnOperator(BaseOperator):
         for key, nodes in boot_artifacts.items():
             kernel, kernel_parameters, initrd = key
             try:
-                resp = self.client.bss.boot_parameters.set_bss(
+                token = self.client.bss.boot_parameters.set_bss(
                     node_set=nodes,
                     kernel_params=kernel_parameters,
                     kernel=kernel,
                     initrd=initrd)
-                resp.raise_for_status()
-            except HTTPError as err:
+            except Exception as err:
                 LOGGER.error(
                     "Failed to set BSS for boot artifacts: %s for nodes: %s. Error: %s",
                     key, nodes, exc_type_msg(err))
             else: # No exception raised in try block
-                token = resp.headers['bss-referral-token']
                 self._record_boot_artifacts(token=token, kernel=kernel,
                                             kernel_parameters=kernel_parameters,
                                             initrd=initrd, retries=retries)


### PR DESCRIPTION
After fixing [CASMTRIAGE-7853](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7853) and [CASMCMS-9288](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9288), the barebones boot test succeeds on wasp. But @spillerc-hpe astutely observed that the corresponding BOS session is marked successful despite not doing anything to the node.

I noticed this in the session setup logs:
```
2025-02-19T18:26:23.638755778Z 2025-02-19 18:26:23,638 - ERROR   - bos.common.clients.endpoints.request_error_handler - Non-2XX response (404) to POST http://cray-smd/hsm/v2//State/Components/Query; Not Found {"type":"about:blank","title":"Not Found","detail":"no such xname.","status":404}
```

Note the two consecutive forward slashes in the URL. Those are an error. The request works fine if they are changed to a single slash. This PR corrects this.

This requires no backports -- it exists only in CSM 1.7, as it was introduced by [CASMCMS-9237](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9237).

I tested this on wasp and it corrected the problem, but led me to find [CASMCMS-9290](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9290), which I am currently investigating.
