### PR TITLE
CASMCMS-9290: Remove no-longer-necessary call to raise_for_status in BOS power on operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CASMCMS-9289: Remove extra `/` from HSM URLs to prevent request failures
+- CASMCMS-9290: Remove no-longer-necessary call to `raise_for_status` in BOS power on operator;
+  catch all exceptions arising from API call
 
 ## [2.34.1] - 2025-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CASMCMS-9289: Remove extra `/` from HSM URLs to prevent request failures
-- CASMCMS-9290: Remove no-longer-necessary call to `raise_for_status` in BOS power on operator;
-  catch all exceptions arising from API call
+- CASMCMS-9290
+  - Remove no-longer-necessary call to `raise_for_status` in BOS power on operator
+  - Catch all exceptions arising from API call
+  - Update power on operator to reflect fact that the BSS API client returns the
+    `bss-referral-token` itself, not an API response object.
 
 ## [2.34.1] - 2025-02-18
 

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -27,9 +27,6 @@
 from collections import defaultdict
 import logging
 
-# Third party imports
-from requests import HTTPError
-
 # BOS module imports
 from bos.common.clients.ims import get_ims_id_from_s3_url
 from bos.common.clients.s3 import S3Url
@@ -162,8 +159,7 @@ class PowerOnOperator(BaseOperator):
                     kernel_params=kernel_parameters,
                     kernel=kernel,
                     initrd=initrd)
-                resp.raise_for_status()
-            except HTTPError as err:
+            except Exception as err:
                 LOGGER.error(
                     "Failed to set BSS for boot artifacts: %s for nodes: %s. Error: %s",
                     key, nodes, exc_type_msg(err))

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -154,7 +154,7 @@ class PowerOnOperator(BaseOperator):
         for key, nodes in boot_artifacts.items():
             kernel, kernel_parameters, initrd = key
             try:
-                resp = self.client.bss.boot_parameters.set_bss(
+                token = self.client.bss.boot_parameters.set_bss(
                     node_set=nodes,
                     kernel_params=kernel_parameters,
                     kernel=kernel,
@@ -164,7 +164,6 @@ class PowerOnOperator(BaseOperator):
                     "Failed to set BSS for boot artifacts: %s for nodes: %s. Error: %s",
                     key, nodes, exc_type_msg(err))
             else: # No exception raised in try block
-                token = resp.headers['bss-referral-token']
                 self._record_boot_artifacts(token=token, kernel=kernel,
                                             kernel_parameters=kernel_parameters,
                                             initrd=initrd, retries=retries)


### PR DESCRIPTION
After the API client overhaul, I overlooked removing a now-unnecessary call to `raise_for_status` inside the power on operator. The exception in question will already have been raised from the API client error handler. This PR removes the now-unneeded call, and expands the `except` statement to catch all of the exceptions being raised from inside the API client.

The power on operator still expects the client to return a request response object, but it actually directly returns the desired token. This PR updates the operator to reflect that.

I tested this on wasp (where I found the problems) and verified that it resolved them.

This requires no backports -- it exists only in CSM 1.7, as it was introduced by [CASMCMS-9237](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9237).