### PR TITLE
CASMCMS-9286: Reworked some of the API client implementation to resolve intractable mypy complaints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9286: Reworked some of the API client implementation to resolve intractable mypy complaints
+
 ## [2.34.2] - 2025-02-19
 
 ### Fixed

--- a/src/bos/common/clients/api_client.py
+++ b/src/bos/common/clients/api_client.py
@@ -21,18 +21,15 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-from abc import ABC
-from typing import Type, TypeVar, Unpack
+from abc import ABC, abstractmethod
+from types import TracebackType
+from typing import Unpack
 
 from requests_retry_session import RequestsRetryAdapterArgs
 
-from bos.common.clients.endpoints import BaseGenericEndpoint
 from bos.common.utils import RetrySessionManager
 
-ClientEndpoint = TypeVar('ClientEndpoint', bound=BaseGenericEndpoint)
-
-
-class APIClient(RetrySessionManager, ABC):
+class APIClient[Endpoints](RetrySessionManager, ABC):
     """
     As a subclass of RetrySessionManager, this class can be used as a context manager,
     and will have a requests session available as self.requests_session
@@ -42,23 +39,23 @@ class APIClient(RetrySessionManager, ABC):
 
     def __init__(self, **adapter_kwargs: Unpack[RequestsRetryAdapterArgs]):
         super().__init__(**adapter_kwargs)
-        self._endpoint_values: dict[Type[ClientEndpoint], ClientEndpoint] = {}
+        self._endpoint_data = self._init_endpoints
 
-    def get_endpoint(self,
-                     endpoint_type: Type[ClientEndpoint]) -> ClientEndpoint:
-        """
-        Endpoints are created only as needed, and passed the managed retry session.
-        """
-        if endpoint_type not in self._endpoint_values:
-            self._endpoint_values[endpoint_type] = endpoint_type(
-                self.requests_session)
-        return self._endpoint_values[endpoint_type]
+    @property
+    def _endpoints(self) -> Endpoints:
+        return self._endpoint_data
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> bool | None:
+    @property
+    @abstractmethod
+    def _init_endpoints(self) -> Endpoints: ...
+
+    def __exit__(self, exc_type: type[BaseException] | None,
+                 exc_val: BaseException | None,
+                 exc_tb: TracebackType | None) -> bool | None:
         """
         The only cleanup we need to do when exiting the context manager is to clear out
         our list of API clients. Our call to super().__exit__ will take care of closing
         out the underlying request session.
         """
-        self._endpoint_values.clear()
+        self._endpoint_data = self._init_endpoints
         return super().__exit__(exc_type, exc_val, exc_tb)

--- a/src/bos/common/clients/api_client_with_timeout_option.py
+++ b/src/bos/common/clients/api_client_with_timeout_option.py
@@ -31,7 +31,7 @@ from bos.common.options import BaseOptions
 
 from .api_client import APIClient
 
-class APIClientWithTimeoutOption(APIClient, ABC):
+class APIClientWithTimeoutOption[T](APIClient[T], ABC):
     """
     As a subclass of RetrySessionManager, this class can be used as a context manager,
     and will have a requests session available as self.requests_session

--- a/src/bos/common/clients/bos/client.py
+++ b/src/bos/common/clients/bos/client.py
@@ -21,23 +21,40 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+from dataclasses import dataclass
+
 from bos.common.clients.api_client import APIClient
 
 from .components import ComponentEndpoint
 from .sessions import SessionEndpoint
 from .session_templates import SessionTemplateEndpoint
 
+@dataclass
+class BosEndpoints:
+    components: ComponentEndpoint | None = None
+    sessions: SessionEndpoint | None = None
+    session_templates: SessionTemplateEndpoint | None = None
 
-class BOSClient(APIClient):
+class BOSClient(APIClient[BosEndpoints]):
+
+    @property
+    def _init_endpoints(self) -> BosEndpoints:
+        return BosEndpoints()
 
     @property
     def components(self) -> ComponentEndpoint:
-        return self.get_endpoint(ComponentEndpoint)
+        if self._endpoints.components is None:
+            self._endpoints.components = ComponentEndpoint(self.requests_session)
+        return self._endpoints.components
 
     @property
     def sessions(self) -> SessionEndpoint:
-        return self.get_endpoint(SessionEndpoint)
+        if self._endpoints.sessions is None:
+            self._endpoints.sessions = SessionEndpoint(self.requests_session)
+        return self._endpoints.sessions
 
     @property
     def session_templates(self) -> SessionTemplateEndpoint:
-        return self.get_endpoint(SessionTemplateEndpoint)
+        if self._endpoints.session_templates is None:
+            self._endpoints.session_templates = SessionTemplateEndpoint(self.requests_session)
+        return self._endpoints.session_templates

--- a/src/bos/common/clients/bss/client.py
+++ b/src/bos/common/clients/bss/client.py
@@ -21,12 +21,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+from dataclasses import dataclass
+
 from bos.common.clients.api_client_with_timeout_option import APIClientWithTimeoutOption
 
 from .boot_parameters import BootParametersEndpoint
 
+@dataclass
+class BssEndpoints:
+    boot_parameters: BootParametersEndpoint | None = None
 
-class BSSClient(APIClientWithTimeoutOption):
+class BSSClient(APIClientWithTimeoutOption[BssEndpoints]):
+    @property
+    def _init_endpoints(self) -> BssEndpoints:
+        return BssEndpoints()
 
     @property
     def read_timeout(self) -> int:
@@ -34,4 +42,6 @@ class BSSClient(APIClientWithTimeoutOption):
 
     @property
     def boot_parameters(self) -> BootParametersEndpoint:
-        return self.get_endpoint(BootParametersEndpoint)
+        if self._endpoints.boot_parameters is None:
+            self._endpoints.boot_parameters = BootParametersEndpoint(self.requests_session)
+        return self._endpoints.boot_parameters

--- a/src/bos/common/clients/cfs/client.py
+++ b/src/bos/common/clients/cfs/client.py
@@ -21,12 +21,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+from dataclasses import dataclass
+
 from bos.common.clients.api_client_with_timeout_option import APIClientWithTimeoutOption
 
 from .components import ComponentEndpoint
 
+@dataclass
+class CfsEndpoints:
+    components: ComponentEndpoint | None = None
 
 class CFSClient(APIClientWithTimeoutOption):
+    @property
+    def _init_endpoints(self) -> CfsEndpoints:
+        return CfsEndpoints()
 
     @property
     def read_timeout(self) -> int:
@@ -34,4 +42,6 @@ class CFSClient(APIClientWithTimeoutOption):
 
     @property
     def components(self) -> ComponentEndpoint:
-        return self.get_endpoint(ComponentEndpoint)
+        if self._endpoints.components is None:
+            self._endpoints.components = ComponentEndpoint(self.requests_session)
+        return self._endpoints.components

--- a/src/bos/common/clients/endpoints/base_generic_endpoint.py
+++ b/src/bos/common/clients/endpoints/base_generic_endpoint.py
@@ -23,7 +23,6 @@
 #
 from abc import ABC, abstractmethod
 import logging
-from typing import Generic, TypeVar
 
 import requests
 
@@ -33,10 +32,7 @@ from .request_error_handler import BaseRequestErrorHandler, RequestErrorHandler
 
 LOGGER = logging.getLogger(__name__)
 
-RequestReturnT = TypeVar('RequestReturnT')
-
-
-class BaseGenericEndpoint(ABC, Generic[RequestReturnT]):
+class BaseGenericEndpoint[RequestReturnT](ABC):
     """
     This base class provides generic access to an API endpoint.
     RequestReturnT represents the type of data this API will return.
@@ -50,7 +46,7 @@ class BaseGenericEndpoint(ABC, Generic[RequestReturnT]):
     ENDPOINT: str = ''
 
     @property
-    def error_handler(self) -> BaseRequestErrorHandler:
+    def error_handler(self) -> type[BaseRequestErrorHandler]:
         return RequestErrorHandler
 
     def __init__(self, session: requests.Session):

--- a/src/bos/common/clients/hsm/client.py
+++ b/src/bos/common/clients/hsm/client.py
@@ -21,14 +21,24 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+from dataclasses import dataclass
+
 from bos.common.clients.api_client_with_timeout_option import APIClientWithTimeoutOption
 
 from .groups import GroupsEndpoint
 from .partitions import PartitionsEndpoint
 from .state_components import StateComponentsEndpoint
 
+@dataclass
+class HsmEndpoints:
+    groups: GroupsEndpoint | None = None
+    partitions: PartitionsEndpoint | None = None
+    state_components: StateComponentsEndpoint | None = None
 
-class HSMClient(APIClientWithTimeoutOption):
+class HSMClient(APIClientWithTimeoutOption[HsmEndpoints]):
+    @property
+    def _init_endpoints(self) -> HsmEndpoints:
+        return HsmEndpoints()
 
     @property
     def read_timeout(self) -> int:
@@ -36,12 +46,18 @@ class HSMClient(APIClientWithTimeoutOption):
 
     @property
     def groups(self) -> GroupsEndpoint:
-        return self.get_endpoint(GroupsEndpoint)
+        if self._endpoints.groups is None:
+            self._endpoints.groups = GroupsEndpoint(self.requests_session)
+        return self._endpoints.groups
 
     @property
     def partitions(self) -> PartitionsEndpoint:
-        return self.get_endpoint(PartitionsEndpoint)
+        if self._endpoints.partitions is None:
+            self._endpoints.partitions = PartitionsEndpoint(self.requests_session)
+        return self._endpoints.partitions
 
     @property
     def state_components(self) -> StateComponentsEndpoint:
-        return self.get_endpoint(StateComponentsEndpoint)
+        if self._endpoints.state_components is None:
+            self._endpoints.state_components = StateComponentsEndpoint(self.requests_session)
+        return self._endpoints.state_components

--- a/src/bos/common/clients/ims/client.py
+++ b/src/bos/common/clients/ims/client.py
@@ -21,14 +21,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+from dataclasses import dataclass
+
 from requests_retry_session import RequestsRetryAdapterArgs
 
 from bos.common.clients.api_client_with_timeout_option import APIClientWithTimeoutOption
 
 from .images import ImagesEndpoint
 
+@dataclass
+class ImsEndpoints:
+    images: ImagesEndpoint | None = None
 
-class IMSClient(APIClientWithTimeoutOption):
+class IMSClient(APIClientWithTimeoutOption[ImsEndpoints]):
+
+    @property
+    def _init_endpoints(self) -> ImsEndpoints:
+        return ImsEndpoints()
 
     @property
     def read_timeout(self) -> int:
@@ -44,4 +53,6 @@ class IMSClient(APIClientWithTimeoutOption):
 
     @property
     def images(self) -> ImagesEndpoint:
-        return self.get_endpoint(ImagesEndpoint)
+        if self._endpoints.images is None:
+            self._endpoints.images = ImagesEndpoint(self.requests_session)
+        return self._endpoints.images

--- a/src/bos/common/clients/ims/images.py
+++ b/src/bos/common/clients/ims/images.py
@@ -49,7 +49,7 @@ class ImagesEndpoint(BaseImsEndpoint):
     ENDPOINT = 'images'
 
     @property
-    def error_handler(self) -> ImsImageRequestErrorHandler:
+    def error_handler(self) -> type[ImsImageRequestErrorHandler]:
         return ImsImageRequestErrorHandler
 
     def get_image(self, image_id: str) -> dict:

--- a/src/bos/common/clients/pcs/base.py
+++ b/src/bos/common/clients/pcs/base.py
@@ -68,5 +68,5 @@ class BasePcsEndpoint(BaseEndpoint, ABC):
     BASE_ENDPOINT = ENDPOINT
 
     @property
-    def error_handler(self) -> PcsRequestErrorHandler:
+    def error_handler(self) -> type[PcsRequestErrorHandler]:
         return PcsRequestErrorHandler

--- a/src/bos/common/clients/pcs/client.py
+++ b/src/bos/common/clients/pcs/client.py
@@ -21,13 +21,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+from dataclasses import dataclass
+
 from bos.common.clients.api_client_with_timeout_option import APIClientWithTimeoutOption
 
 from .power_status import PowerStatusEndpoint
 from .transitions import TransitionsEndpoint
 
+@dataclass
+class PcsEndpoints:
+    power_status: PowerStatusEndpoint | None = None
+    transitions: TransitionsEndpoint | None = None
 
-class PCSClient(APIClientWithTimeoutOption):
+class PCSClient(APIClientWithTimeoutOption[PcsEndpoints]):
+
+    @property
+    def _init_endpoints(self) -> PcsEndpoints:
+        return PcsEndpoints()
 
     @property
     def read_timeout(self) -> int:
@@ -35,8 +45,12 @@ class PCSClient(APIClientWithTimeoutOption):
 
     @property
     def power_status(self) -> PowerStatusEndpoint:
-        return self.get_endpoint(PowerStatusEndpoint)
+        if self._endpoints.power_status is None:
+            self._endpoints.power_status = PowerStatusEndpoint(self.requests_session)
+        return self._endpoints.power_status
 
     @property
     def transitions(self) -> TransitionsEndpoint:
-        return self.get_endpoint(TransitionsEndpoint)
+        if self._endpoints.transitions is None:
+            self._endpoints.transitions = TransitionsEndpoint(self.requests_session)
+        return self._endpoints.transitions

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -35,7 +35,7 @@ import threading
 import os
 import time
 from types import TracebackType
-from typing import Generator, NoReturn, Self, Type
+from typing import Generator, NoReturn, Self
 
 from bos.common.clients.bos import BOSClient
 from bos.common.clients.bos.options import options
@@ -93,7 +93,7 @@ class ApiClients:
         self._stack.enter_context(self.pcs)
         return self
 
-    def __exit__(self, exc_type: Type[BaseException] | None,
+    def __exit__(self, exc_type: type[BaseException] | None,
                  exc_val: BaseException | None,
                  exc_tb: TracebackType | None) -> bool | None:
         """
@@ -141,7 +141,7 @@ class BaseOperator(ABC):
 
     @property
     @abstractmethod
-    def filters(self) -> list[Type[BaseFilter]]:
+    def filters(self) -> list[type[BaseFilter]]:
         return []
 
     def BOSQuery(self, **kwargs) -> BOSQuery:
@@ -441,7 +441,7 @@ def _init_logging() -> None:
     logging.basicConfig(level=log_level, format=log_format)
 
 
-def main(operator: Type[BaseOperator]):
+def main(operator: type[BaseOperator]):
     """
     The main method for any operator type.
     Automatically handles logging and heartbeats as well as starting the operator.

--- a/src/bos/operators/filters/filters.py
+++ b/src/bos/operators/filters/filters.py
@@ -26,7 +26,6 @@ import copy
 from datetime import timedelta
 import logging
 import re
-from typing import Type
 
 from bos.common.clients.bos import BOSClient
 from bos.common.clients.cfs import CFSClient
@@ -42,8 +41,8 @@ class OR(DetailsFilter):
 
     def __init__(self, filters_a, filters_b) -> None:
         super().__init__()
-        self.filters_a: list[Type[BaseFilter]] = filters_a
-        self.filters_b: list[Type[BaseFilter]] = filters_b
+        self.filters_a: list[type[BaseFilter]] = filters_a
+        self.filters_b: list[type[BaseFilter]] = filters_b
 
     def _filter(self, components: list[dict]) -> list[dict]:
         results_a = copy.deepcopy(components)
@@ -126,7 +125,7 @@ class HSMState(IDFilter):
 class NOT(LocalFilter):
     """ Returns the opposite of the given filter.  Use on local filters only."""
 
-    def __init__(self, filter: Type[LocalFilter]) -> None:
+    def __init__(self, filter: type[LocalFilter]) -> None:
         self.negated_filter = filter
         self.filter_match = filter._match
 


### PR DESCRIPTION
The underlying logic remains the same, but this changes the implementation to make it easier to placate `mypy`