### PR TITLE
CASMSEC-433: cray-bos-db container is now run with "nobody" user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- CASMSEC-433: cray-bos-db container now uses the `nobody` user instead of `root`
+
+### Changed
 - CASMCMS-9286: Reworked some of the API client implementation to resolve intractable mypy complaints
 
 ## [2.34.2] - 2025-02-19

--- a/kubernetes/cray-bos/templates/db.yaml
+++ b/kubernetes/cray-bos/templates/db.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -55,14 +55,21 @@ spec:
       labels:
         app.kubernetes.io/name: "{{ include "cray-service.name" . }}-db"
     spec:
+      securityContext:
+        fsGroup: 65534
       containers:
       - name: "{{ include "cray-service.name" . }}-db"
         image: "{{ .Values.database.image.repository }}:{{ .Values.database.image.tag }}"
-        command: ["/bin/sh"]
-        args: ["-c", "echo 'save 10 1' >> /etc/redis.conf && sleep 1 && redis-server /etc/redis.conf"]
+        securityContext:
+          runAsUser: 65534
+          runAsGroup: 65534
         volumeMounts:
         - mountPath: /data
           name: "{{ include "cray-service.name" . }}-db"
+        - name: "{{ include "cray-service.name" . }}-redis-config"
+          mountPath: /usr/local/etc/redis/redis.conf
+          subPath: redis.conf  # Mount the custom redis.conf file
+        command: [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
         ports:
         - containerPort: 6379
           name: redis
@@ -93,6 +100,18 @@ spec:
       - name: "{{ include "cray-service.name" . }}-db"
         persistentVolumeClaim:
           claimName: "{{ include "cray-service.name" . }}-db"
+      - name: "{{ include "cray-service.name" . }}-redis-config"
+        configMap:
+            name: "{{ include "cray-service.name" . }}-redis-configmap"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "cray-service.name" . }}-redis-configmap"
+data:
+  redis.conf: |
+    # Custom redis.conf configuration here
+    save 10 1
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
CASMSEC-433: cray-bos-db container is now run with "nobody" user. As per kyverno cluster policy requirements, pod/container should not be run as root.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
[CASMCMS-7866](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-7866)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:
it was tested on mug.

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Following tests were run
Create a session template.
Create a BOS session
Modify the contents of a BOS component’s state
Display session status


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

