### PR TITLE
CASMCMS-9291: Add missing info to API spec; create more type annotation helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9286: Reworked some of the API client implementation to resolve intractable mypy complaints
 - Improve session/sessiontemplate controller error responses by including tenant
 - CASMSEC-433: cray-bos-db container now uses the `nobody` user instead of `root`
+- CASMCMS-9291
+  - Updated API spec to define the format of the `error_summary` field
+  - Created additional type-hinting definitions in bos.common.types
 
 ## [2.34.2] - 2025-02-19
 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -629,6 +629,19 @@ components:
           description: |
             The current duration of the ongoing Session or final duration of the completed Session.
       additionalProperties: false
+    V2SessionExtendedStatusErrorComponents:
+      type: object
+      description: Summary of Components impacted by an error.
+      properties:
+        count:
+          type: integer
+          description: The number of Components impacted by the error.
+        list:
+          type: string
+          description: |
+            A comma-separated list of the impacted Components.
+            If more than 10 Components are impacted, the first 10 are shown, following by a trailing '...'
+      additionalProperties: false
     V2SessionExtendedStatus:
       type: object
       description: |
@@ -657,7 +670,9 @@ components:
         error_summary:
           type: object
           description: |
-            A summary of the errors currently listed by all Components
+            A mapping from error messages to a summary of the impacted Components.
+          additionalProperties:
+            $ref: '#/components/schemas/V2SessionExtendedStatusErrorComponents'
         timing:
           $ref: '#/components/schemas/V2SessionExtendedStatusTiming'
       additionalProperties: false

--- a/src/bos/common/clients/bos/options.py
+++ b/src/bos/common/clients/bos/options.py
@@ -29,9 +29,10 @@ from requests.exceptions import HTTPError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from urllib3.exceptions import MaxRetryError
 
-from bos.common.options import OptionsCache
-from bos.common.utils import exc_type_msg, retry_session_get
 from bos.common.clients.bos.base import BASE_BOS_ENDPOINT
+from bos.common.options import OptionsCache
+from bos.common.types.options import OptionsDict
+from bos.common.utils import exc_type_msg, retry_session_get
 
 LOGGER = logging.getLogger(__name__)
 __name = __name__.lower().rsplit('.', maxsplit=1)[-1]
@@ -46,7 +47,7 @@ class Options(OptionsCache):
     result in network calls.
     """
 
-    def _get_options(self, session: requests.Session | None = None) -> dict:
+    def _get_options(self, session: requests.Session | None = None) -> OptionsDict:
         """Retrieves the current options from the BOS api"""
         LOGGER.debug("GET %s", ENDPOINT)
         try:

--- a/src/bos/common/options.py
+++ b/src/bos/common/options.py
@@ -23,9 +23,10 @@
 #
 from abc import ABC, abstractmethod
 
-# To help with type hints
-type OptionValue = int | bool | str
-type OptionsDict = dict[str, OptionValue]
+from bos.common.types.options import OptionsDict, OptionName, OptionValue
+
+# The data structures defined in here need to be kept in sync with the
+# definitions in bos.common.types.options
 
 # This is the source of truth for default option values. All other BOS
 # code should either import this dict directly, or (preferably) access
@@ -61,7 +62,7 @@ class BaseOptions(ABC):
     """
 
     @abstractmethod
-    def get_option(self, key: str) -> OptionValue:
+    def get_option(self, key: OptionName) -> OptionValue:
         """
         Return the value for the specified option
         """
@@ -160,10 +161,8 @@ class DefaultOptions(BaseOptions):
     Returns the default value for each option
     """
 
-    def get_option(self, key: str) -> OptionValue:
-        if key in DEFAULTS:
-            return DEFAULTS[key]
-        raise KeyError(key)
+    def get_option(self, key: OptionName) -> OptionValue:
+        return DEFAULTS[key]
 
 
 class OptionsCache(DefaultOptions, ABC):
@@ -189,7 +188,7 @@ class OptionsCache(DefaultOptions, ABC):
     def _get_options(self) -> OptionsDict:
         """Retrieves the current options from the BOS api/DB"""
 
-    def get_option(self, key: str) -> OptionValue:
+    def get_option(self, key: OptionName) -> OptionValue:
         if key in self.options:
             return self.options[key]
         try:

--- a/src/bos/common/types/components.py
+++ b/src/bos/common/types/components.py
@@ -25,38 +25,97 @@
 """
 Type annotation definitions for BOS components
 """
-
+import copy
 from typing import Required, TypedDict
 
-# Mapping from string labels to sets of node names
-type NodeSetMapping = dict[str, set[str]]
+from .general import BosDataRecord
 
-type BootArtifacts = dict[str, str]
-type ComponentStatus = dict[str, str]
+class ComponentStatus(TypedDict, total=False):
+    """
+    #/components/schemas/V2ComponentStatus
+    """
+    phase: str
+    status: str
+    status_override: str
+
+class BootArtifacts(TypedDict, total=True):
+    """
+    #/components/schemas/V2BootArtifacts
+    """
+    kernel: str
+    kernel_parameters: str
+    initrd: str
+
+class TimestampedBootArtifacts(BosDataRecord, BootArtifacts, total=True):
+    """
+    When storing the boot artifacts in the database, there is an additional timestamp field
+    """
+    timestamp: str
 
 class ComponentLastAction(TypedDict, total=False):
+    """
+    #/components/schemas/V2ComponentLastAction
+    """
     action: str
     failed: bool
     last_updated: str
 
-type ComponentEventStats = dict[str, int]
+class ComponentEventStats(TypedDict, total=False):
+    """
+    #/components/schemas/V2ComponentEventStats
+    """
+    power_on_attempts: int
+    power_off_graceful_attempts: int
+    power_off_forceful_attempts: int
 
 class BaseComponentState(TypedDict, total=False):
+    """
+    Common fields found in actual state, desired state, and staged state
+    """
     boot_artifacts: BootArtifacts
     last_updated: str
 
 class ComponentActualState(BaseComponentState, total=False):
+    """
+    #/components/schemas/V2ComponentActualState
+    """
     bss_token: str
 
 class ComponentDesiredState(BaseComponentState, total=False):
+    """
+    #/components/schemas/V2ComponentDesiredState
+    """
     bss_token: str
     configuration: str
 
 class ComponentStagedState(BaseComponentState, total=False):
+    """
+    #/components/schemas/V2ComponentStagedState
+    """
     configuration: str
     session: str
 
-class ComponentRecord(TypedDict, total=False):
+def _update_component_state[C: (ComponentActualState,
+                                ComponentDesiredState,
+                                ComponentStagedState)](record: C, new_record_copy: C) -> None:
+    """
+    Perform in-place update of current record using data
+    from new record. This is only called by update_component_record
+    """
+    if "boot_artifacts" in new_record_copy:
+        new_data = new_record_copy.pop("boot_artifacts")
+        if "boot_artifacts" in record:
+            record["boot_artifacts"].update(new_data)
+        else:
+            record["boot_artifacts"] = new_data
+
+    # The remaining fields can be merged the old-fashioned way
+    record.update(new_record_copy)
+
+class ComponentRecord(BosDataRecord, total=False):
+    """
+    #/components/schemas/V2Component
+    """
     actual_state: ComponentActualState
     desired_state: ComponentDesiredState
     enabled: bool
@@ -68,3 +127,52 @@ class ComponentRecord(TypedDict, total=False):
     session: str
     staged_state: ComponentStagedState
     status: ComponentStatus
+
+def update_component_record(record: ComponentRecord, new_record: ComponentRecord) -> None:
+    """
+    Perform in-place update of current record using data from new record.
+    """
+    # Make a copy, to avoid changing new_record in place
+    new_record_copy = copy.deepcopy(new_record)
+
+    # Merge the state dicts -- this is not done in a loop because mypy gets confused keeping track
+    # of string literal values in loops
+    if "actual_state" in new_record_copy:
+        if "actual_state" in record:
+            _update_component_state(record["actual_state"], new_record_copy.pop("actual_state"))
+        else:
+            record["actual_state"] = new_record_copy.pop("actual_state")
+
+    if "desired_state" in new_record_copy:
+        if "desired_state" in record:
+            _update_component_state(record["desired_state"], new_record_copy.pop("desired_state"))
+        else:
+            record["desired_state"] = new_record_copy.pop("desired_state")
+
+    if "staged_state" in new_record_copy:
+        if "staged_state" in record:
+            _update_component_state(record["staged_state"], new_record_copy.pop("staged_state"))
+        else:
+            record["staged_state"] = new_record_copy.pop("staged_state")
+
+    # Next, merge the regular sub-dicts -- this is also not done in a loop, for the same reason as above
+    if "last_action" in new_record_copy:
+        if "last_action" in record:
+            record["last_action"].update(new_record_copy.pop("last_action"))
+        else:
+            record["last_action"] = new_record_copy.pop("last_action")
+
+    if "event_stats" in new_record_copy:
+        if "event_stats" in record:
+            record["event_stats"].update(new_record_copy.pop("event_stats"))
+        else:
+            record["event_stats"] = new_record_copy.pop("event_stats")
+
+    if "status" in new_record_copy:
+        if "status" in record:
+            record["status"].update(new_record_copy.pop("status"))
+        else:
+            record["status"] = new_record_copy.pop("status")
+
+    # The remaining fields can be merged the old-fashioned way
+    record.update(new_record_copy)

--- a/src/bos/common/types/options.py
+++ b/src/bos/common/types/options.py
@@ -1,0 +1,82 @@
+#
+# MIT License
+#
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+from typing import Literal, TypedDict
+
+from .general import BosDataRecord
+
+# To help with type hints
+type OptionValue = int | bool | str
+
+# This should match all of the data structures defined in bos.common.options
+type OptionName = Literal[
+    'bss_read_timeout',
+    'cfs_read_timeout',
+    'cleanup_completed_session_ttl',
+    'clear_stage',
+    'component_actual_state_ttl',
+    'default_retry_policy',
+    'disable_components_on_completion',
+    'discovery_frequency',
+    'hsm_read_timeout',
+    'ims_errors_fatal',
+    'ims_images_must_exist',
+    'ims_read_timeout',
+    'logging_level',
+    'max_boot_wait_time',
+    'max_component_batch_size',
+    'max_power_off_wait_time',
+    'max_power_on_wait_time',
+    'pcs_read_timeout',
+    'polling_frequency',
+    'reject_nids',
+    'session_limit_required'
+]
+
+class OptionsDict(BosDataRecord, total=False):
+    """
+    This should match all of the data structures defined in bos.common.options
+
+    #/components/schemas/V2Options
+    """
+    bss_read_timeout: int
+    cfs_read_timeout: int
+    cleanup_completed_session_ttl: str
+    clear_stage: bool
+    component_actual_state_ttl: str
+    default_retry_policy: int
+    disable_components_on_completion: bool
+    discovery_frequency: int
+    hsm_read_timeout: int
+    ims_errors_fatal: bool
+    ims_images_must_exist: bool
+    ims_read_timeout: int
+    logging_level: str
+    max_boot_wait_time: int
+    max_component_batch_size: int
+    max_power_off_wait_time: int
+    max_power_on_wait_time: int
+    pcs_read_timeout: int
+    polling_frequency: int
+    reject_nids: bool
+    session_limit_required: bool

--- a/src/bos/common/types/session_extended_status.py
+++ b/src/bos/common/types/session_extended_status.py
@@ -23,15 +23,46 @@
 #
 
 """
-General type annotation definitions
+Type annotation definitions for BOS extended session statuses
 """
 from typing import TypedDict
 
-type JsonData = bool | str | None | int | float | list[JsonData] | dict[str, JsonData]
-type JsonDict = dict[str, JsonData]
-type JsonList = list[JsonData]
+from .general import BosDataRecord
+from .sessions import SessionStatusLabel
 
-class BosDataRecord(TypedDict):
+class SessionExtendedStatusPhases(TypedDict, total=True):
     """
-    Parent class for BOS database records
+    #/components/schemas/V2SessionExtendedStatusPhases
     """
+    percent_complete: float
+    percent_powering_on: float
+    percent_powering_off: float
+    percent_configuring: float
+
+class SessionExtendedStatusErrorComponents(TypedDict, total=True):
+    """
+    #/components/schemas/V2SessionExtendedStatusErrorComponents
+    """
+    count: int
+    list: str
+
+class SessionExtendedStatusTiming(TypedDict, total=True):
+    """
+    #/components/schemas/V2SessionExtendedStatusTiming
+    """
+    end_time: str | None
+    start_time: str
+    duration: str
+
+class SessionExtendedStatus(BosDataRecord, total=False):
+    """
+    #/components/schemas/V2SessionExtendedStatus
+    """
+    status: SessionStatusLabel
+    managed_components_count: int
+    phases: SessionExtendedStatusPhases
+    percent_successful: float
+    percent_failed: float
+    percent_staged: float
+    error_summary: dict[str, SessionExtendedStatusErrorComponents]
+    timing: SessionExtendedStatusTiming

--- a/src/bos/common/types/sessions.py
+++ b/src/bos/common/types/sessions.py
@@ -25,12 +25,17 @@
 """
 Type annotation definitions for BOS sessions
 """
-
+import copy
 from typing import Literal, Required, TypedDict
+
+from .general import BosDataRecord
 
 SessionStatusLabel = Literal['complete', 'pending', 'running']
 
 class SessionStatus(TypedDict, total=False):
+    """
+    #/components/schemas/V2SessionStatus
+    """
     end_time: str | None
     error: str | None
     start_time: str
@@ -38,7 +43,10 @@ class SessionStatus(TypedDict, total=False):
 
 SessionOperation = Literal['boot', 'reboot', 'shutdown']
 
-class Session(TypedDict, total=False):
+class Session(BosDataRecord, total=False):
+    """
+    #/components/schemas/V2Session
+    """
     components: str
     include_disabled: bool
     limit: str
@@ -48,3 +56,21 @@ class Session(TypedDict, total=False):
     status: Required[SessionStatus]
     template_name: Required[str]
     tenant: str | None
+
+def update_session_record(record: Session, new_record: Session) -> None:
+    """
+    Patch 'record' in-place with the data from 'new_record'.
+    """
+    # Make a copy, to avoid changing new_record in place
+    new_record_copy = copy.deepcopy(new_record)
+
+    # First, merge the status sub-dict
+    if "status" in new_record_copy:
+        if "status" in record:
+            record["status"].update(new_record_copy["status"])
+            new_record_copy["status"] = record["status"]
+        else:
+            record["status"] = new_record_copy["status"]
+
+    # The remaining fields can be merged the old-fashioned way
+    record.update(new_record_copy)

--- a/src/bos/common/types/templates.py
+++ b/src/bos/common/types/templates.py
@@ -25,14 +25,22 @@
 """
 Type annotation definitions for BOS session templates
 """
-
+import copy
 from typing import get_args, Literal, Required, TypedDict
 
+from .general import BosDataRecord
+
 class Link(TypedDict, total=False):
+    """
+    #/components/schemas/Link
+    """
     href: str
     rel: str
 
 class SessionTemplateCfsParameters(TypedDict, total=False):
+    """
+    #/components/schemas/V2CfsParameters
+    """
     configuration: str
 
 BootSetArch = Literal['X86', 'ARM', 'Other', 'Unknown']
@@ -48,6 +56,9 @@ BOOT_SET_HARDWARE_SPECIFIER_FIELDS: tuple[BootSetHardwareSpecifierFields] = \
     get_args(BootSetHardwareSpecifierFields)
 
 class BootSet(TypedDict, total=False):
+    """
+    #/components/schemas/V2BootSet
+    """
     arch: BootSetArch
     cfs: SessionTemplateCfsParameters
     etag: str
@@ -61,7 +72,26 @@ class BootSet(TypedDict, total=False):
     rootfs_provider_passthrough: str
     type: Required[str]
 
-class SessionTemplate(TypedDict, total=False):
+def _update_boot_set(record: BootSet, new_record_copy: BootSet) -> None:
+    """
+    This helper function will be used when patching boot sets.
+    It patches 'record' in-place with the data from 'new_record_copy'.
+    This is only ever called by _update_boot_sets
+    """
+    if "cfs" in new_record_copy:
+        new_data = new_record_copy.pop("cfs")
+        if "cfs" in record:
+            record["cfs"].update(new_data)
+        else:
+            record["cfs"] = new_data
+
+    # The remaining fields can be merged the old-fashioned way
+    record.update(new_record_copy)
+
+class SessionTemplate(BosDataRecord, total=False):
+    """
+    #/components/schemas/V2SessionTemplate
+    """
     boot_sets: Required[dict[str, BootSet]]
     cfs: SessionTemplateCfsParameters
     description: str
@@ -69,3 +99,55 @@ class SessionTemplate(TypedDict, total=False):
     links: list[Link]
     name: Required[str]
     tenant: str | None
+
+def _update_boot_sets(record: dict[str, BootSet], new_record_copy: dict[str, BootSet]) -> None:
+    """
+    This helper function will be used when patching the 'boot_sets' map of a session template.
+    It patches 'record' in-place with the data from 'new_record_copy'.
+    This is only ever called by update_template_record
+    """
+    for new_bs_name, new_bs_record in new_record_copy.items():
+        if new_bs_name in record:
+            _update_boot_set(record[new_bs_name], new_bs_record)
+        else:
+            record[new_bs_name] = new_bs_record
+
+def update_template_record(record: SessionTemplate, new_record: SessionTemplate) -> None:
+    """
+    This is used to patch session template data.
+    The session template 'record' is patched in-place with the data from 'new_record'.
+    """
+    # Make a copy, to avoid changing new_record in place
+    new_record_copy = copy.deepcopy(new_record)
+
+    if "cfs" in new_record_copy:
+        new_cfs_data = new_record_copy.pop("cfs")
+        if "cfs" in record:
+            record["cfs"].update(new_cfs_data)
+        else:
+            record["cfs"] = new_cfs_data
+
+    # Next, merge "boot_sets"
+    if "boot_sets" in new_record_copy:
+        new_bs_data = new_record_copy["boot_sets"]
+        if "boot_sets" in record:
+            _update_boot_sets(record["boot_sets"], new_bs_data)
+            new_record_copy["boot_sets"] = record["boot_sets"]
+        else:
+            record["boot_sets"] = new_bs_data
+
+    # The remaining fields can be merged the old-fashioned way
+    record.update(new_record_copy)
+
+def remove_empty_cfs_field(data: SessionTemplate | BootSet) -> None:
+    """
+    If the data contains a 'cfs' field that is set to a null value
+    (either an empty dict, or a dict whose 'configuration' field maps to an empty string),
+    then delete it in-place. Do this to reduce confusion, since the behavior is the same either
+    way, but the absence of the 'cfs' field has a more obvious meaning.
+    """
+    if "cfs" not in data:
+        return
+    if data["cfs"] and data["cfs"].get("configuration"):
+        return
+    del data["cfs"]


### PR DESCRIPTION
This PR contains no functional changes to BOS. It does two things:

1. Updates the API spec to define the format of the `error_summary` field in the BOS extended session status. This format is fixed, so we may as well specify it in the API spec.

2. Creates additional helper classes and functions under bos.common.types. Most of these are not yet used. Many of these are just defining `TypedDict` versions of objects from the API spec. 

This is enablement for the next PR, which is going to address type annotation issues in the redis DB module.