### PR TITLE
CASMCMS-9294: Improve Python type annotations, focused on DB modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9294: Improve Python type annotations, focused on DB modules
+
 ## [2.35.1] - 2025-03-20
 
 ### Fixed

--- a/src/bos/common/clients/bos/base.py
+++ b/src/bos/common/clients/bos/base.py
@@ -79,43 +79,51 @@ class BaseBosTenantAwareEndpoint(BaseBosEndpoint, ABC):
     This base class provides generic access to the BOS API for tenant aware endpoints.
     The individual endpoint needs to be overridden for a specific endpoint.
     """
-
     def get_item(self, item_id, tenant):
         """Get information for a single BOS item"""
-        return self.get(uri=item_id, headers=get_new_tenant_header(tenant))
+        kwargs = { "uri": item_id }
+        if tenant:
+            kwargs["headers"] = get_new_tenant_header(tenant)
+        return self.get(**kwargs)
 
-    def get_items(self, **kwargs):
+    def get_items(self, tenant: str | None = None, **params):
         """Get information for all BOS items"""
-        headers = None
-        if "tenant" in kwargs:
-            tenant = kwargs.pop("tenant")
-            headers = get_new_tenant_header(tenant)
-        return self.get(params=kwargs, headers=headers)
+        kwargs = { "params": params }
+        if tenant:
+            kwargs["headers"] = get_new_tenant_header(tenant)
+        return self.get(**kwargs)
 
     def update_item(self, item_id, tenant, data):
         """Update information for a single BOS item"""
-        return self.patch(uri=item_id,
-                          json=data,
-                          headers=get_new_tenant_header(tenant))
+        kwargs = { "uri": item_id, "json": data }
+        if tenant:
+            kwargs["headers"] = get_new_tenant_header(tenant)
+        return self.patch(**kwargs)
 
     def update_items(self, tenant, data):
         """Update information for multiple BOS items"""
-        return self.patch(json=data, headers=get_new_tenant_header(tenant))
+        kwargs = { "json": data }
+        if tenant:
+            kwargs["headers"] = get_new_tenant_header(tenant)
+        return self.patch(**kwargs)
 
     def post_item(self, item_id, tenant, data=None):
         """Post information for a single BOS item"""
-        return self.post(uri=item_id,
-                         json=data,
-                         headers=get_new_tenant_header(tenant))
+        kwargs = { "uri": item_id, "json": data }
+        if tenant:
+            kwargs["headers"] = get_new_tenant_header(tenant)
+        return self.post(**kwargs)
 
     def put_items(self, tenant, data):
         """Put information for multiple BOS items"""
-        return self.put(json=data, headers=get_new_tenant_header(tenant))
+        kwargs = { "json": data }
+        if tenant:
+            kwargs["headers"] = get_new_tenant_header(tenant)
+        return self.put(**kwargs)
 
-    def delete_items(self, **kwargs):
+    def delete_items(self, tenant: str | None = None, **params):
         """Delete information for multiple BOS items"""
-        headers = None
-        if "tenant" in kwargs:
-            tenant = kwargs.pop("tenant")
-            headers = get_new_tenant_header(tenant)
-        return self.delete(params=kwargs, headers=headers)
+        kwargs = { "params": params }
+        if tenant:
+            kwargs["headers"] = get_new_tenant_header(tenant)
+        return self.delete(**kwargs)

--- a/src/bos/server/controllers/v2/boot_set/sanitize.py
+++ b/src/bos/server/controllers/v2/boot_set/sanitize.py
@@ -23,7 +23,7 @@
 #
 
 from bos.common.utils import exc_type_msg
-from bos.common.types.general import JsonDict
+from bos.common.types.templates import BootSet, SessionTemplate, remove_empty_cfs_field
 from bos.server.controllers.v2.options import OptionsData
 from bos.server.utils import canonize_xname
 
@@ -34,7 +34,7 @@ from .ims import validate_ims_boot_image
 from .validate import check_node_list_for_nids, verify_nonempty_hw_specifier_field
 
 
-def validate_sanitize_boot_sets(template_data: JsonDict,
+def validate_sanitize_boot_sets(template_data: SessionTemplate,
                                 options_data: OptionsData | None=None) -> None:
     """
     Calls validate_sanitize_boot_set on every boot set in the template.
@@ -63,7 +63,7 @@ def validate_sanitize_boot_sets(template_data: JsonDict,
         validate_sanitize_boot_set(bs_name, bs, options_data=options_data)
 
 
-def validate_sanitize_boot_set(bs_name: str, bs_data: JsonDict,
+def validate_sanitize_boot_set(bs_name: str, bs_data: BootSet,
                                options_data: OptionsData) -> None:
     """
     Called when creating/updating a BOS session template.
@@ -86,6 +86,9 @@ def validate_sanitize_boot_set(bs_name: str, bs_data: JsonDict,
     # Set the 'arch' field to the default value, if it is not present
     if "arch" not in bs_data:
         bs_data["arch"] = DEFAULT_ARCH
+
+    # Remove the 'cfs' field if it is set to a null value (either an empty dict, or a dict whose 'configuration' field maps to an empty string
+    remove_empty_cfs_field(bs_data)
 
     # Check the boot artifacts
     try:

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -23,16 +23,17 @@
 #
 from functools import partial
 import logging
-from typing import Literal
+from typing import Literal, cast
 
 import connexion
-from connexion.lifecycle import ConnexionResponse
+from connexion.lifecycle import ConnexionResponse as CxResponse
 
 from bos.common.utils import exc_type_msg, get_current_timestamp
 from bos.common.tenant_utils import (get_tenant_aware_key,
                                      get_tenant_component_set,
                                      get_tenant_from_header,
                                      tenant_error_handler)
+from bos.common.types.components import ComponentRecord
 from bos.common.types.general import JsonDict
 from bos.common.values import Phase, Action, Status, EMPTY_STAGED_STATE, EMPTY_BOOT_ARTIFACTS
 from bos.server import redis_db_utils as dbutils
@@ -42,20 +43,21 @@ from bos.server.dbs.boot_artifacts import get_boot_artifacts, BssTokenUnknown
 from bos.server.utils import get_request_json
 
 LOGGER = logging.getLogger(__name__)
-DB = dbutils.get_wrapper(db='components')
-SESSIONS_DB = dbutils.get_wrapper(db='sessions')
+DB = dbutils.ComponentDBWrapper()
+SESSIONS_DB = dbutils.SessionDBWrapper()
 
 
 @tenant_error_handler
 @dbutils.redis_error_handler
-def get_v2_components(ids: str | None=None,
-                      enabled: bool | None=None,
-                      session: str | None=None,
-                      staged_session: str | None=None,
-                      phase: str | None=None,
-                      status: str | None=None,
-                      start_after_id: str | None=None,
-                      page_size: int=0) -> tuple[list[JsonDict], Literal[200]] | ConnexionResponse:
+def get_v2_components(
+        ids: str | None=None,
+        enabled: bool | None=None,
+        session: str | None=None,
+        staged_session: str | None=None,
+        phase: str | None=None,
+        status: str | None=None,
+        start_after_id: str | None=None,
+        page_size: int=0) -> tuple[list[ComponentRecord], Literal[200]] | CxResponse:
     """Used by the GET /components API operation
 
     Allows filtering using a comma separated list of ids.
@@ -100,13 +102,12 @@ def get_v2_components_data(id_list: list[str] | None=None,
                            tenant: str | None=None,
                            start_after_id: str | None=None,
                            page_size: int=0,
-                           delete_timestamp: bool=False) -> list[JsonDict]:
+                           delete_timestamp: bool=False) -> list[ComponentRecord]:
     """Used by the GET /components API operation
 
     Allows filtering using a comma separated list of ids.
     """
-    tenant_components = None if tenant is None else get_tenant_component_set(
-        tenant)
+    tenant_components = get_tenant_component_set(tenant) if tenant else None
 
     if id_list is not None:
         id_set = set(id_list)
@@ -138,14 +139,14 @@ def get_v2_components_data(id_list: list[str] | None=None,
                                page_size=page_size)
 
 
-def _filter_component(data: JsonDict,
+def _filter_component(data: ComponentRecord,
                       id_set: set[str] | None=None,
                       enabled: bool | None=None,
                       session: str | None=None,
                       staged_session: str | None=None,
                       phase: str | None=None,
                       status: str | None=None,
-                      delete_timestamp: bool=False) -> JsonDict | None:
+                      delete_timestamp: bool=False) -> ComponentRecord | None:
     # Do all of the checks we can before calculating status, to avoid doing it needlessly
     if id_set is not None and data["id"] not in id_set:
         return None
@@ -169,7 +170,7 @@ def _filter_component(data: JsonDict,
     return updated_data
 
 
-def _set_status(data: JsonDict, delete_timestamp: bool = False) -> JsonDict:
+def _set_status(data: ComponentRecord, delete_timestamp: bool = False) -> ComponentRecord:
     """
     This sets the status field of the overall status.
     """
@@ -181,7 +182,7 @@ def _set_status(data: JsonDict, delete_timestamp: bool = False) -> JsonDict:
     return data
 
 
-def _calculate_status(data: JsonDict) -> str:
+def _calculate_status(data: ComponentRecord) -> str:
     """
     Calculates and returns the status of a component
     """
@@ -222,11 +223,11 @@ def _calculate_status(data: JsonDict) -> str:
 
 
 @dbutils.redis_error_handler
-def put_v2_components() -> tuple[list[JsonDict], Literal[200]] | ConnexionResponse:
+def put_v2_components() -> tuple[list[ComponentRecord], Literal[200]] | CxResponse:
     """Used by the PUT /components API operation"""
     LOGGER.debug("PUT /v2/components invoked put_v2_components")
     try:
-        data = get_request_json()
+        data = cast(list[ComponentRecord], get_request_json())
     except Exception as err:
         LOGGER.error("Error parsing PUT request data: %s", exc_type_msg(err))
         return _400_bad_request(f"Error parsing the data provided: {err}")
@@ -247,7 +248,7 @@ def put_v2_components() -> tuple[list[JsonDict], Literal[200]] | ConnexionRespon
 
 @tenant_error_handler
 @dbutils.redis_error_handler
-def patch_v2_components() -> tuple[list[JsonDict], Literal[200]] | ConnexionResponse:
+def patch_v2_components() -> tuple[list[ComponentRecord], Literal[200]] | CxResponse:
     """Used by the PATCH /components API operation"""
     LOGGER.debug("PATCH /v2/components invoked patch_v2_components")
     try:
@@ -265,7 +266,8 @@ def patch_v2_components() -> tuple[list[JsonDict], Literal[200]] | ConnexionResp
     return _400_bad_request(f"Unexpected data type {type(data).__name__}")
 
 
-def patch_v2_components_list(data: list[JsonDict]) -> tuple[list[JsonDict], Literal[200]] | ConnexionResponse:
+def patch_v2_components_list(
+        data: list[ComponentRecord]) -> tuple[list[ComponentRecord], Literal[200]] | CxResponse:
     try:
         LOGGER.debug("patch_v2_components_list: %d components specified",
                      len(data))
@@ -290,7 +292,8 @@ def patch_v2_components_list(data: list[JsonDict]) -> tuple[list[JsonDict], Lite
     return response, 200
 
 
-def patch_v2_components_dict(data: JsonDict) -> tuple[list[JsonDict], Literal[200]] | ConnexionResponse:
+def patch_v2_components_dict(data: JsonDict) -> tuple[list[ComponentRecord],
+                                                      Literal[200]] | CxResponse:
     filters = data.get("filters", {})
     ids = filters.get("ids", None)
     session = filters.get("session", None)
@@ -334,7 +337,7 @@ def patch_v2_components_dict(data: JsonDict) -> tuple[list[JsonDict], Literal[20
 
 @tenant_error_handler
 @dbutils.redis_error_handler
-def get_v2_component(component_id: str) -> tuple[JsonDict, Literal[200]] | ConnexionResponse:
+def get_v2_component(component_id: str) -> tuple[ComponentRecord, Literal[200]] | CxResponse:
     """Used by the GET /components/{component_id} API operation"""
     LOGGER.debug("GET /v2/components/%s invoked get_v2_component",
                  component_id)
@@ -348,12 +351,12 @@ def get_v2_component(component_id: str) -> tuple[JsonDict, Literal[200]] | Conne
 
 
 @dbutils.redis_error_handler
-def put_v2_component(component_id: str) -> tuple[JsonDict, Literal[200]] | ConnexionResponse:
+def put_v2_component(component_id: str) -> tuple[ComponentRecord, Literal[200]] | CxResponse:
     """Used by the PUT /components/{component_id} API operation"""
     LOGGER.debug("PUT /v2/components/%s invoked put_v2_component",
                  component_id)
     try:
-        data = get_request_json()
+        data = cast(ComponentRecord, get_request_json())
     except Exception as err:
         LOGGER.error("Error parsing PUT '%s' request data: %s", component_id,
                      exc_type_msg(err))
@@ -366,12 +369,12 @@ def put_v2_component(component_id: str) -> tuple[JsonDict, Literal[200]] | Conne
 
 @tenant_error_handler
 @dbutils.redis_error_handler
-def patch_v2_component(component_id: str) -> tuple[JsonDict, Literal[200]] | ConnexionResponse:
+def patch_v2_component(component_id: str) -> tuple[ComponentRecord, Literal[200]] | CxResponse:
     """Used by the PATCH /components/{component_id} API operation"""
     LOGGER.debug("PATCH /v2/components/%s invoked patch_v2_component",
                  component_id)
     try:
-        data = get_request_json()
+        data = cast(ComponentRecord, get_request_json())
     except Exception as err:
         LOGGER.error("Error parsing PATCH '%s' request data: %s", component_id,
                      exc_type_msg(err))
@@ -414,7 +417,7 @@ def validate_actual_state_change_is_allowed(component_id: str) -> bool:
 
 @tenant_error_handler
 @dbutils.redis_error_handler
-def delete_v2_component(component_id: str) -> tuple[None, Literal[204]] | ConnexionResponse:
+def delete_v2_component(component_id: str) -> tuple[None, Literal[204]] | CxResponse:
     """Used by the DELETE /components/{component_id} API operation"""
     LOGGER.debug("DELETE /v2/components/%s invoked delete_v2_component",
                  component_id)
@@ -426,7 +429,7 @@ def delete_v2_component(component_id: str) -> tuple[None, Literal[204]] | Connex
 
 @tenant_error_handler
 @dbutils.redis_error_handler
-def post_v2_apply_staged() -> tuple[JsonDict, Literal[200]] | ConnexionResponse:
+def post_v2_apply_staged() -> tuple[JsonDict, Literal[200]] | CxResponse:
     """Used by the POST /applystaged API operation"""
     LOGGER.debug("POST /v2/applystaged invoked post_v2_apply_staged")
     try:
@@ -506,7 +509,7 @@ def _apply_staged(component_id: str, clear_staged: bool=False) -> Literal[False]
     return response
 
 
-def _set_state_from_staged(data: JsonDict) -> Literal[True]:
+def _set_state_from_staged(data: ComponentRecord) -> Literal[True]:
     staged_state = data.get("staged_state", {})
     staged_session_id_sans_tenant = staged_state.get("session", "")
     tenant = get_tenant_from_header()
@@ -544,7 +547,7 @@ def _set_state_from_staged(data: JsonDict) -> Literal[True]:
     return True
 
 
-def _copy_staged_to_desired(data: JsonDict) -> None:
+def _copy_staged_to_desired(data: ComponentRecord) -> None:
     staged_state = data.get("staged_state", {})
     data["desired_state"] = {
         "boot_artifacts": staged_state.get("boot_artifacts", {}),
@@ -552,7 +555,7 @@ def _copy_staged_to_desired(data: JsonDict) -> None:
     }
 
 
-def _set_auto_fields(data: JsonDict) -> JsonDict:
+def _set_auto_fields(data: ComponentRecord) -> ComponentRecord:
     data = _populate_boot_artifacts(data)
     data = _set_last_updated(data)
     data = _set_on_hold_when_enabled(data)
@@ -561,7 +564,7 @@ def _set_auto_fields(data: JsonDict) -> JsonDict:
     return data
 
 
-def _populate_boot_artifacts(data: JsonDict) -> JsonDict:
+def _populate_boot_artifacts(data: ComponentRecord) -> ComponentRecord:
     """
     If there is a BSS Token present in the actual_state,
     then look up the boot artifacts and add them to the
@@ -590,7 +593,7 @@ def _populate_boot_artifacts(data: JsonDict) -> JsonDict:
     return data
 
 
-def del_timestamp(data: JsonDict) -> None:
+def del_timestamp(data: ComponentRecord) -> None:
     """
     # The actual state boot artifacts dictionary contains a timestamp
     # that is used for internal references only; we should strip it
@@ -603,7 +606,7 @@ def del_timestamp(data: JsonDict) -> None:
         pass
 
 
-def _set_last_updated(data: JsonDict) -> JsonDict:
+def _set_last_updated(data: ComponentRecord) -> ComponentRecord:
     timestamp = get_current_timestamp()
     for section in [
             'actual_state', 'desired_state', 'staged_state', 'last_action'
@@ -614,7 +617,7 @@ def _set_last_updated(data: JsonDict) -> JsonDict:
     return data
 
 
-def _set_on_hold_when_enabled(data: JsonDict) -> JsonDict:
+def _set_on_hold_when_enabled(data: ComponentRecord) -> ComponentRecord:
     """
     The status operator doesn't monitor disabled components, so this causes a delay until it can
     revaluate the component so that other operators don't act on old phase information.
@@ -627,7 +630,7 @@ def _set_on_hold_when_enabled(data: JsonDict) -> JsonDict:
     return data
 
 
-def _clear_session_when_manually_updated(data: JsonDict) -> JsonDict:
+def _clear_session_when_manually_updated(data: ComponentRecord) -> ComponentRecord:
     """
     If the desired state for a component is updated outside of the setup operator, that component
     should no longer be considered part of it's original session.
@@ -637,7 +640,7 @@ def _clear_session_when_manually_updated(data: JsonDict) -> JsonDict:
     return data
 
 
-def _clear_event_stats_when_desired_state_changes(data: JsonDict) -> JsonDict:
+def _clear_event_stats_when_desired_state_changes(data: ComponentRecord) -> ComponentRecord:
     desired_state = data.get("desired_state", {})
     if "boot_artifacts" in desired_state or "configuration" in desired_state:
         data["event_stats"] = {
@@ -648,7 +651,7 @@ def _clear_event_stats_when_desired_state_changes(data: JsonDict) -> JsonDict:
     return data
 
 
-def _update_handler(data: JsonDict) -> JsonDict:
+def _update_handler(data: ComponentRecord) -> ComponentRecord:
     # Allows processing of data during common patch operation
     return data
 

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -26,16 +26,17 @@ from datetime import datetime, timedelta
 from functools import partial
 import logging
 import re
-from typing import Literal
+from typing import Literal, cast
 import uuid
 
 import connexion
-from connexion.lifecycle import ConnexionResponse
+from connexion.lifecycle import ConnexionResponse as CxResponse
 
-from bos.common.tenant_utils import (get_tenant_aware_key,
-                                     get_tenant_from_header,
+from bos.common.tenant_utils import (get_tenant_from_header,
                                      reject_invalid_tenant)
 from bos.common.types.general import JsonDict
+from bos.common.types.session_extended_status import SessionExtendedStatus
+from bos.common.types.sessions import Session as SessionRecord
 from bos.common.utils import exc_type_msg, get_current_time, get_current_timestamp, load_timestamp
 from bos.common.values import Phase, Status
 from bos.server import redis_db_utils as dbutils
@@ -49,16 +50,16 @@ from bos.server.models.v2_session_create import V2SessionCreate as SessionCreate
 from bos.server.utils import get_request_json, ParsingException
 
 LOGGER = logging.getLogger(__name__)
-DB = dbutils.get_wrapper(db='sessions')
-COMPONENTS_DB = dbutils.get_wrapper(db='components')
-STATUS_DB = dbutils.get_wrapper(db='session_status')
+DB = dbutils.SessionDBWrapper()
+COMPONENTS_DB = dbutils.ComponentDBWrapper()
+STATUS_DB = dbutils.SessionStatusDBWrapper()
 MAX_COMPONENTS_IN_ERROR_DETAILS = 10
 LIMIT_NID_RE = re.compile(r'^[&!]*nid')
 
 
 @reject_invalid_tenant
 @dbutils.redis_error_handler
-def post_v2_session() -> tuple[JsonDict, Literal[201]] | ConnexionResponse:  # noqa: E501
+def post_v2_session() -> tuple[SessionRecord, Literal[201]] | CxResponse:  # noqa: E501
     """POST /v2/session
     Creates a new session. # noqa: E501
     :param session: A JSON object for creating sessions
@@ -70,7 +71,7 @@ def post_v2_session() -> tuple[JsonDict, Literal[201]] | ConnexionResponse:  # n
     # -- Validation --
     try:
         session_create = SessionCreate.from_dict(
-            get_request_json())  # noqa: E501
+            cast(SessionRecord, get_request_json()))  # noqa: E501
     except Exception as err:
         LOGGER.error("Error parsing POST request data: %s", exc_type_msg(err))
         return _400_bad_request(f"Error parsing the data provided: {err}")
@@ -102,7 +103,7 @@ def post_v2_session() -> tuple[JsonDict, Literal[201]] | ConnexionResponse:  # n
                  session_create.operation)
     # Check that the template_name exists.
     session_template_response = get_v2_sessiontemplate(template_name)
-    if isinstance(session_template_response, ConnexionResponse):
+    if isinstance(session_template_response, CxResponse):
         msg = f"Session Template Name invalid: {template_name}"
         LOGGER.error(msg)
         return _400_bad_request(msg)
@@ -121,12 +122,11 @@ def post_v2_session() -> tuple[JsonDict, Literal[201]] | ConnexionResponse:  # n
     # -- Setup Record --
     tenant = get_tenant_from_header()
     session = _create_session(session_create, tenant)
-    session_key = get_tenant_aware_key(session.name, tenant)
-    if session_key in DB:
+    if DB.has_tenanted_entry(session.name, tenant):
         LOGGER.warning("v2 session named %s already exists (tenant = '%s')", session.name, tenant)
         return _409_session_already_exists(session.name, tenant)
     session_data = session.to_dict()
-    response = DB.put(session_key, session_data)
+    response = DB.tenant_aware_put(session.name, tenant, session_data)
     return response, 201
 
 
@@ -151,7 +151,7 @@ def _create_session(session_create: SessionCreate, tenant: str | None) -> Sessio
 
 
 @dbutils.redis_error_handler
-def patch_v2_session(session_id: str) -> tuple[JsonDict, Literal[200]] | ConnexionResponse:
+def patch_v2_session(session_id: str) -> tuple[SessionRecord, Literal[200]] | CxResponse:
     """PATCH /v2/session
     Patch the session identified by session_id
     Args:
@@ -161,25 +161,23 @@ def patch_v2_session(session_id: str) -> tuple[JsonDict, Literal[200]] | Connexi
     """
     LOGGER.debug("PATCH /v2/sessions/%s invoked patch_v2_session", session_id)
     try:
-        patch_data_json = get_request_json()
+        patch_data_json = cast(SessionRecord, get_request_json())
     except Exception as err:
         LOGGER.error("Error parsing PATCH '%s' request data: %s", session_id,
                      exc_type_msg(err))
         return _400_bad_request(f"Error parsing the data provided: {err}")
 
     tenant = get_tenant_from_header()
-    session_key = get_tenant_aware_key(session_id, tenant)
-    if session_key not in DB:
+    if not DB.has_tenanted_entry(session_id, tenant):
         LOGGER.warning("Could not find v2 session %s (tenant = '%s')", session_id, tenant)
         return _404_session_not_found(resource_id=session_id, tenant=tenant)  # pylint: disable=redundant-keyword-arg
 
-    component = DB.patch(session_key, patch_data_json)
-    return component, 200
+    return DB.tenant_aware_patch(session_id, tenant, patch_data_json), 200
 
 
 @dbutils.redis_error_handler
 def get_v2_session(
-        session_id: str) -> tuple[JsonDict, Literal[200]] | ConnexionResponse:  # noqa: E501
+        session_id: str) -> tuple[SessionRecord, Literal[200]] | CxResponse:  # noqa: E501
     """GET /v2/session
     Get the session by session ID
     Args:
@@ -189,17 +187,16 @@ def get_v2_session(
     """
     LOGGER.debug("GET /v2/sessions/%s invoked get_v2_session", session_id)
     tenant = get_tenant_from_header()
-    session_key = get_tenant_aware_key(session_id, tenant)
-    if session_key not in DB:
+    session = DB.tenant_aware_get(session_id, tenant)
+    if session is None:
         LOGGER.warning("Could not find v2 session %s (tenant = '%s')", session_id, tenant)
         return _404_session_not_found(resource_id=session_id, tenant=tenant)  # pylint: disable=redundant-keyword-arg
-    session = DB.get(session_key)
     return session, 200
 
 
 @dbutils.redis_error_handler
 def get_v2_sessions(min_age: str | None=None, max_age: str | None=None,
-                    status: str | None=None) -> tuple[list[JsonDict],
+                    status: str | None=None) -> tuple[list[SessionRecord],
                                                          Literal[200]]:  # noqa: E501
     """GET /v2/session
 
@@ -218,7 +215,7 @@ def get_v2_sessions(min_age: str | None=None, max_age: str | None=None,
 
 @dbutils.redis_error_handler
 def delete_v2_session(
-        session_id: str) -> tuple[None, Literal[204]] | ConnexionResponse:  # noqa: E501
+        session_id: str) -> tuple[None, Literal[204]] | CxResponse:  # noqa: E501
     """DELETE /v2/session
 
     Delete the session by session id
@@ -226,19 +223,18 @@ def delete_v2_session(
     LOGGER.debug("DELETE /v2/sessions/%s invoked delete_v2_session",
                  session_id)
     tenant = get_tenant_from_header()
-    session_key = get_tenant_aware_key(session_id, tenant)
-    if session_key not in DB:
+    session = DB.tenant_aware_get_and_delete(session_id, tenant)
+    if session is None:
         LOGGER.warning("Could not find v2 session %s (tenant = '%s')", session_id, tenant)
         return _404_session_not_found(resource_id=session_id, tenant=tenant)  # pylint: disable=redundant-keyword-arg
-    if session_key in STATUS_DB:
-        STATUS_DB.delete(session_key)
-    return DB.delete(session_key), 204
+    STATUS_DB.tenant_aware_delete(session_id, tenant)
+    return None, 204
 
 
 @dbutils.redis_error_handler
 def delete_v2_sessions(
         min_age: str | None=None, max_age: str | None=None,
-        status: str | None=None) -> tuple[None, Literal[204]] | ConnexionResponse:  # noqa: E501
+        status: str | None=None) -> tuple[None, Literal[204]] | CxResponse:  # noqa: E501
     LOGGER.debug(
         "DELETE /v2/sessions invoked delete_v2_sessions with min_age=%s max_age=%s status=%s",
         min_age, max_age, status)
@@ -253,17 +249,15 @@ def delete_v2_sessions(
         return _400_bad_request(f"Error parsing age field: {err}")
 
     for session in sessions:
-        session_key = get_tenant_aware_key(session['name'], tenant)
-        if session_key in STATUS_DB:
-            STATUS_DB.delete(session_key)
-        DB.delete(session_key)
+        STATUS_DB.tenant_aware_delete(session['name'], tenant)
+        DB.tenant_aware_delete(session['name'], tenant)
 
     return None, 204
 
 
 @dbutils.redis_error_handler
 def get_v2_session_status(
-        session_id: str) -> tuple[JsonDict, Literal[200]] | ConnexionResponse:  # noqa: E501
+        session_id: str) -> tuple[SessionExtendedStatus, Literal[200]] | CxResponse:  # noqa: E501
     """GET /v2/session/status
     Get the session status by session ID
     Args:
@@ -274,23 +268,22 @@ def get_v2_session_status(
     LOGGER.debug("GET /v2/sessions/status/%s invoked get_v2_session_status",
                  session_id)
     tenant = get_tenant_from_header()
-    session_key = get_tenant_aware_key(session_id, tenant)
-    if session_key not in DB:
+    session = DB.tenant_aware_get(session_id, tenant)
+    if session is None:
         LOGGER.warning("Could not find v2 session %s (tenant = '%s')", session_id, tenant)
         return _404_session_not_found(resource_id=session_id, tenant=tenant)  # pylint: disable=redundant-keyword-arg
-    session = DB.get(session_key)
-    if session.get(
-            "status",
-        {}).get("status") == "complete" and session_key in STATUS_DB:
-        # If the session is complete and the status is saved,
-        # return the status from completion time
-        return STATUS_DB.get(session_key), 200
-    return _get_v2_session_status(session_key, session), 200
+    if session.get("status",{}).get("status") == "complete":
+        session_status = STATUS_DB.tenant_aware_get(session_id, tenant)
+        if session_status is not None:
+            # If the session is complete and the status is saved,
+            # return the status from completion time
+            return session_status, 200
+    return _get_v2_session_status(session_id, tenant, session), 200
 
 
 @dbutils.redis_error_handler
 def save_v2_session_status(
-        session_id: str) -> tuple[JsonDict, Literal[200]] | ConnexionResponse:  # noqa: E501
+        session_id: str) -> tuple[SessionExtendedStatus, Literal[200]] | CxResponse:  # noqa: E501
     """POST /v2/session/status
     Get the session status by session ID
     Args:
@@ -301,16 +294,18 @@ def save_v2_session_status(
     LOGGER.debug("POST /v2/sessions/status/%s invoked save_v2_session_status",
                  session_id)
     tenant = get_tenant_from_header()
-    session_key = get_tenant_aware_key(session_id, tenant)
-    if session_key not in DB:
+    session = DB.tenant_aware_get(session_id, tenant)
+    if session is None:
         LOGGER.warning("Could not find v2 session %s (tenant = '%s')", session_id, tenant)
         return _404_session_not_found(resource_id=session_id, tenant=tenant)  # pylint: disable=redundant-keyword-arg
-    return STATUS_DB.put(session_key, _get_v2_session_status(session_key)), 200
+    extended_status = _get_v2_session_status(session_id, tenant, session)
+    return STATUS_DB.tenant_aware_put(session_id, tenant, extended_status), 200
 
 
 def _get_filtered_sessions(tenant: str | None, min_age: str | None, max_age: str | None,
-                           status: str | None) -> list[JsonDict]:
-    response = DB.get_all()
+                           status: str | None) -> list[SessionRecord]:
+    if not any([tenant, min_age, max_age, status]):
+        return DB.get_all()
     min_start = None
     max_start = None
     if min_age:
@@ -325,37 +320,28 @@ def _get_filtered_sessions(tenant: str | None, min_age: str | None, max_age: str
         except Exception as e:
             LOGGER.warning('Unable to parse max_age: %s', max_age)
             raise ParsingException(e) from e
-    if any([min_start, max_start, status, tenant]):
-        response = [
-            r for r in response
-            if _matches_filter(r, tenant, min_start, max_start, status)
-        ]
-    return response
+    return DB.get_all_filtered(filter_func=partial(_matches_filter, tenant=tenant, min_start=min_start, max_start=max_start, status=status))
 
 
-def _matches_filter(data: dict, tenant: str | None, min_start: datetime | None,
-                    max_start: datetime | None, status: str | None) -> bool:
+def _matches_filter(data: SessionRecord, tenant: str | None, min_start: datetime | None,
+                    max_start: datetime | None, status: str | None) -> SessionRecord | None:
     if tenant and tenant != data.get("tenant"):
-        return False
+        return None
     session_status = data.get('status', {})
     if status and status != session_status.get('status'):
-        return False
+        return None
     start_time = session_status['start_time']
     session_start = None
     if start_time:
         session_start = load_timestamp(start_time)
     if min_start and (not session_start or session_start < min_start):
-        return False
+        return None
     if max_start and (not session_start or session_start > max_start):
-        return False
-    return True
+        return None
+    return data
 
 
-def _get_v2_session_status(session_key: str|bytes, session: JsonDict | None=None) -> JsonDict:
-    if not session:
-        session = DB.get(session_key)
-    session_id = session.get("name", {})
-    tenant_id = session.get("tenant")
+def _get_v2_session_status(session_id: str, tenant_id: str | None, session: SessionRecord) -> SessionExtendedStatus:
     components = get_v2_components_data(session=session_id, tenant=tenant_id)
     staged_components = get_v2_components_data(staged_session=session_id,
                                                tenant=tenant_id)
@@ -451,14 +437,14 @@ def _age_to_timestamp(age: str) -> datetime:
 _404_session_not_found = partial(_404_tenanted_resource_not_found, resource_type="Session")
 
 
-def _409_session_already_exists(session_id: str, tenant: str | None) -> ConnexionResponse:
+def _409_session_already_exists(session_id: str, tenant: str | None) -> CxResponse:
     """
     ProblemAlreadyExists
     """
-    if tenant is None:
-        detail=f"Session '{session_id}' already exists"
-    else:
+    if tenant:
         detail=f"Session '{session_id}' already exists for tenant '{tenant}'"
+    else:
+        detail=f"Session '{session_id}' already exists"
     return connexion.problem(
         status=409,
         title="The resource to be created already exists",

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -23,14 +23,13 @@
 #
 from functools import partial
 import logging
-from typing import Literal
+from typing import Literal, cast
 
-from connexion.lifecycle import ConnexionResponse
+from connexion.lifecycle import ConnexionResponse as CxResponse
 
-from bos.common.tenant_utils import (get_tenant_aware_key,
-                                     get_tenant_from_header,
+from bos.common.tenant_utils import (get_tenant_from_header,
                                      reject_invalid_tenant)
-from bos.common.types.general import JsonDict
+from bos.common.types.templates import SessionTemplate, remove_empty_cfs_field
 from bos.common.utils import exc_type_msg
 from bos.server import redis_db_utils as dbutils
 from bos.server.controllers.utils import _400_bad_request, _404_tenanted_resource_not_found
@@ -39,7 +38,7 @@ from bos.server.utils import get_request_json
 from .boot_set import validate_boot_sets, validate_sanitize_boot_sets
 
 LOGGER = logging.getLogger(__name__)
-DB = dbutils.get_wrapper(db='session_templates')
+DB = dbutils.SessionTemplateDBWrapper()
 
 EXAMPLE_BOOT_SET = {
     "type": "s3",
@@ -69,7 +68,7 @@ EXAMPLE_SESSION_TEMPLATE = {
 
 @reject_invalid_tenant
 @dbutils.redis_error_handler
-def put_v2_sessiontemplate(session_template_id: str) -> tuple[JsonDict, Literal[200]] | ConnexionResponse:  # noqa: E501
+def put_v2_sessiontemplate(session_template_id: str) -> tuple[SessionTemplate, Literal[200]] | CxResponse:  # noqa: E501
     """PUT /v2/sessiontemplates
 
     Creates a new session template. # noqa: E501
@@ -77,7 +76,7 @@ def put_v2_sessiontemplate(session_template_id: str) -> tuple[JsonDict, Literal[
     LOGGER.debug("PUT /v2/sessiontemplates/%s invoked put_v2_sessiontemplate",
                  session_template_id)
     try:
-        template_data = get_request_json()
+        template_data = cast(SessionTemplate, get_request_json())
     except Exception as err:
         LOGGER.error("Error parsing PUT '%s' request data: %s",
                      session_template_id, exc_type_msg(err))
@@ -91,28 +90,33 @@ def put_v2_sessiontemplate(session_template_id: str) -> tuple[JsonDict, Literal[
         LOGGER.debug("Full template: %s", template_data)
         return _400_bad_request(f"The session template could not be created: {err}")
 
-    tenant = get_tenant_from_header()
+    tenant = get_tenant_from_header() or None
     template_data['tenant'] = tenant
-    template_key = get_tenant_aware_key(session_template_id, tenant)
-    return DB.put(template_key, template_data), 200
+    return DB.tenant_aware_put(session_template_id, tenant, template_data), 200
 
 
 @dbutils.redis_error_handler
-def get_v2_sessiontemplates() -> tuple[list[JsonDict], Literal[200]]:  # noqa: E501
+def get_v2_sessiontemplates() -> tuple[list[SessionTemplate], Literal[200]]:  # noqa: E501
     """
     GET /v2/sessiontemplates
 
     List all sessiontemplates
     """
     LOGGER.debug("GET /v2/sessiontemplates invoked get_v2_sessiontemplates")
-    response = _get_filtered_templates(tenant=get_tenant_from_header())
+    tenant=get_tenant_from_header()
+    if tenant:
+        def _matches_filter(data: SessionTemplate) -> SessionTemplate | None:
+            return data if tenant == data.get("tenant") else None
+        response = DB.get_all_filtered(filter_func=_matches_filter)
+    else:
+        response = DB.get_all()
     LOGGER.debug("get_v2_sessiontemplates returning %d templates",
                  len(response))
     return response, 200
 
 
 @dbutils.redis_error_handler
-def get_v2_sessiontemplate(session_template_id: str) -> tuple[JsonDict, Literal[200]] | ConnexionResponse:
+def get_v2_sessiontemplate(session_template_id: str) -> tuple[SessionTemplate, Literal[200]] | CxResponse:
     """
     GET /v2/sessiontemplates
 
@@ -121,19 +125,18 @@ def get_v2_sessiontemplate(session_template_id: str) -> tuple[JsonDict, Literal[
     LOGGER.debug("GET /v2/sessiontemplates/%s invoked get_v2_sessiontemplate",
                  session_template_id)
     tenant = get_tenant_from_header()
-    template_key = get_tenant_aware_key(session_template_id, tenant)
-    if template_key not in DB:
+    template = DB.tenant_aware_get(session_template_id, tenant)
+    if template is None:
         if tenant:
             LOGGER.warning("Session template not found for tenant '%s': %s", tenant, session_template_id)
         else:
             LOGGER.warning("Session template not found: %s", session_template_id)
-        return _404_template_not_found(resource_id=session_template_id, tenant=tenant)  # pylint: disable=redundant-keyword-arg
-    template = DB.get(template_key)
+        return _404_template_not_found(resource_id=session_template_id, tenant=tenant)
     return template, 200
 
 
 @dbutils.redis_error_handler
-def get_v2_sessiontemplatetemplate() -> tuple[JsonDict, Literal[200]]:
+def get_v2_sessiontemplatetemplate() -> tuple[SessionTemplate, Literal[200]]:
     """
     GET /v2/sessiontemplatetemplate
 
@@ -146,7 +149,7 @@ def get_v2_sessiontemplatetemplate() -> tuple[JsonDict, Literal[200]]:
 
 
 @dbutils.redis_error_handler
-def delete_v2_sessiontemplate(session_template_id: str) -> tuple[None, Literal[204]] | ConnexionResponse:
+def delete_v2_sessiontemplate(session_template_id: str) -> tuple[None, Literal[204]] | CxResponse:
     """
     DELETE /v2/sessiontemplates
 
@@ -156,18 +159,18 @@ def delete_v2_sessiontemplate(session_template_id: str) -> tuple[None, Literal[2
         "DELETE /v2/sessiontemplates/%s invoked delete_v2_sessiontemplate",
         session_template_id)
     tenant = get_tenant_from_header()
-    template_key = get_tenant_aware_key(session_template_id, tenant)
-    if template_key not in DB:
+    template = DB.tenant_aware_get_and_delete(session_template_id, tenant)
+    if template is None:
         if tenant:
             LOGGER.warning("Session template not found for tenant '%s': %s", tenant, session_template_id)
         else:
             LOGGER.warning("Session template not found: %s", session_template_id)
-        return _404_template_not_found(resource_id=session_template_id, tenant=tenant)  # pylint: disable=redundant-keyword-arg
-    return DB.delete(template_key), 204
+        return _404_template_not_found(resource_id=session_template_id, tenant=tenant)
+    return None, 204
 
 
 @dbutils.redis_error_handler
-def patch_v2_sessiontemplate(session_template_id: str) -> tuple[JsonDict, Literal[200]] | ConnexionResponse:
+def patch_v2_sessiontemplate(session_template_id: str) -> tuple[SessionTemplate, Literal[200]] | CxResponse:
     """
     PATCH /v2/sessiontemplates
 
@@ -177,16 +180,15 @@ def patch_v2_sessiontemplate(session_template_id: str) -> tuple[JsonDict, Litera
         "PATCH /v2/sessiontemplates/%s invoked patch_v2_sessiontemplate",
         session_template_id)
     tenant = get_tenant_from_header()
-    template_key = get_tenant_aware_key(session_template_id, tenant)
-    if template_key not in DB:
+    if not DB.has_tenanted_entry(session_template_id, tenant):
         if tenant:
             LOGGER.warning("Session template not found for tenant '%s': %s", tenant, session_template_id)
         else:
             LOGGER.warning("Session template not found: %s", session_template_id)
-        return _404_template_not_found(resource_id=session_template_id, tenant=tenant)  # pylint: disable=redundant-keyword-arg
+        return _404_template_not_found(resource_id=session_template_id, tenant=tenant)
 
     try:
-        template_data = get_request_json()
+        template_data = cast(SessionTemplate, get_request_json())
     except Exception as err:
         LOGGER.error("Error parsing PATCH '%s' request data: %s",
                      session_template_id, exc_type_msg(err))
@@ -199,11 +201,11 @@ def patch_v2_sessiontemplate(session_template_id: str) -> tuple[JsonDict, Litera
                      session_template_id, exc_type_msg(err))
         return _400_bad_request(f"The session template could not be patched: {err}")
 
-    return DB.patch(template_key, template_data), 200
+    return DB.tenant_aware_patch(session_template_id, tenant, template_data), 200
 
 
 @dbutils.redis_error_handler
-def validate_v2_sessiontemplate(session_template_id: str) -> tuple[str, Literal[200]] | ConnexionResponse:
+def validate_v2_sessiontemplate(session_template_id: str) -> tuple[str, Literal[200]] | CxResponse:
     """
     Validate a V2 session template. Look for missing elements or errors that would prevent
     a session from being launched using this template.
@@ -212,7 +214,7 @@ def validate_v2_sessiontemplate(session_template_id: str) -> tuple[str, Literal[
         "GET /v2/sessiontemplatesvalid/%s invoked validate_v2_sessiontemplate",
         session_template_id)
     response = get_v2_sessiontemplate(session_template_id)
-    if isinstance(response, ConnexionResponse):
+    if isinstance(response, CxResponse):
         # This means it was an error, so we just pass it up
         return response
 
@@ -229,25 +231,14 @@ def validate_v2_sessiontemplate(session_template_id: str) -> tuple[str, Literal[
     return msg, 200
 
 
-def _get_filtered_templates(tenant: str | None) -> list[JsonDict]:
-    response = DB.get_all()
-    if any([tenant]):
-        response = [r for r in response if _matches_filter(r, tenant)]
-    return response
-
-
-def _matches_filter(data: JsonDict, tenant: str) -> bool:
-    if tenant and tenant != data.get("tenant"):
-        return False
-    return True
-
-
-def validate_sanitize_session_template(session_template_id: str, template_data: JsonDict) -> None:
+def validate_sanitize_session_template(session_template_id: str, template_data: SessionTemplate) -> None:
     """
     Used when creating or patching session templates
     """
     validate_sanitize_boot_sets(template_data)
     template_data['name'] = session_template_id
+
+    remove_empty_cfs_field(template_data)
 
     # Validate this against the API schema
     # An exception will be raised if it does not follow it
@@ -258,6 +249,5 @@ def validate_sanitize_session_template(session_template_id: str, template_data: 
     # validate_sanitize_boot_sets()
     for bs in template_data["boot_sets"].values():
         del bs["name"]
-
 
 _404_template_not_found = partial(_404_tenanted_resource_not_found, resource_type="Session template")

--- a/src/bos/server/dbs/boot_artifacts.py
+++ b/src/bos/server/dbs/boot_artifacts.py
@@ -23,12 +23,12 @@
 #
 import logging
 
-from bos.common.types.general import JsonDict
+from bos.common.types.components import TimestampedBootArtifacts
 from bos.common.utils import get_current_timestamp
-from bos.server import redis_db_utils as dbutils
+from bos.server.redis_db_utils import BootArtifactsDBWrapper
 
 LOGGER = logging.getLogger(__name__)
-TOKENS_DB = dbutils.get_wrapper(db='bss_tokens_boot_artifacts')
+TOKENS_DB = BootArtifactsDBWrapper()
 
 
 class BssTokenException(Exception):
@@ -60,7 +60,7 @@ def record_boot_artifacts(token: str, kernel: str, kernel_parameters: str,
         })
 
 
-def get_boot_artifacts(token: str) -> JsonDict:
+def get_boot_artifacts(token: str) -> TimestampedBootArtifacts:
     """
     Get the boot artifacts associated with a BSS token.
 
@@ -72,4 +72,7 @@ def get_boot_artifacts(token: str) -> JsonDict:
     """
     if token not in TOKENS_DB:
         raise BssTokenUnknown
-    return TOKENS_DB.get(token)
+    boot_artifacts = TOKENS_DB.get(token)
+    if boot_artifacts is None:
+        raise BssTokenUnknown
+    return boot_artifacts

--- a/src/bos/server/migrations/db.py
+++ b/src/bos/server/migrations/db.py
@@ -29,10 +29,10 @@ import bos.server.redis_db_utils as dbutils
 
 LOGGER = logging.getLogger(__name__)
 
-TEMP_DB = dbutils.get_wrapper(db='session_templates')
-SESS_DB = dbutils.get_wrapper(db='sessions')
-STAT_DB = dbutils.get_wrapper(db='session_status')
-COMP_DB = dbutils.get_wrapper(db='components')
+TEMP_DB = dbutils.SessionTemplateDBWrapper()
+SESS_DB = dbutils.SessionDBWrapper()
+STAT_DB = dbutils.SessionStatusDBWrapper()
+COMP_DB = dbutils.ComponentDBWrapper()
 
 MAX_DB_WAIT_SECONDS=120.0
 

--- a/src/bos/server/migrations/sanitize.py
+++ b/src/bos/server/migrations/sanitize.py
@@ -318,9 +318,14 @@ def get_unused_legal_template_name(name: str, tenant: str | None) -> str:
         if not name or not any(c in TEMPLATE_NAME_CHARACTERS for c in name):
             raise
 
-    LOGGER.warning(
-        "Session template name '%s' (tenant: %s) does not follow schema. "
-        "Will attempt to rename to a legal name", name, tenant)
+    if tenant:
+        LOGGER.warning(
+            "Session template name '%s' (tenant: %s) does not follow schema. "
+            "Will attempt to rename to a legal name", name, tenant)
+    else:
+        LOGGER.warning(
+            "Session template name '%s' does not follow schema. "
+            "Will attempt to rename to a legal name", name)
 
     # Strip out illegal characters, but replace spaces with underscores and prepend 'auto_renamed_'
     new_name_base = 'auto_renamed_' + ''.join(
@@ -344,9 +349,12 @@ def get_unused_legal_template_name(name: str, tenant: str | None) -> str:
             if is_valid_available_template_name(new_name, tenant):
                 return new_name
 
-    LOGGER.error(
-        "Unable to find unused valid new name for session template '%s' (tenant: %s)",
-        name, tenant)
+    if tenant:
+        LOGGER.error(
+            "Unable to find unused valid new name for session template '%s' (tenant: %s)",
+            name, tenant)
+    else:
+        LOGGER.error("Unable to find unused valid new name for session template '%s'", name)
     raise ValidationError("Name does not follow schema")
 
 

--- a/src/bos/server/redis_db_utils/__init__.py
+++ b/src/bos/server/redis_db_utils/__init__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,40 +21,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import logging
-from typing import Literal
 
-from bos.common.utils import exc_type_msg
-from bos.server.models.healthz import Healthz
-from bos.server import redis_db_utils
-
-DB = redis_db_utils.OptionsDBWrapper()
-
-LOGGER = logging.getLogger(__name__)
-
-
-def _get_db_status() -> str:
-    available = False
-    try:
-        if DB.info():
-            available = True
-    except Exception as e:
-        LOGGER.error(exc_type_msg(e))
-
-    if available:
-        return 'ok'
-    return 'not_available'
-
-
-def get_v2_healthz() -> tuple[Healthz, Literal[200]]:
-    """GET /v2/healthz
-
-    Query BOS etcd for health status
-
-    :rtype: Healthz
-    """
-    LOGGER.debug("GET /v2/healthz invoked get_v2_healthz")
-    return Healthz(
-        db_status=_get_db_status(),
-        api_status='ok',
-    ), 200
+from .boot_artifacts_dbwrapper import BootArtifactsDBWrapper
+from .component_dbwrapper import ComponentDBWrapper
+from .dbwrapper import DBWrapper
+from .options_dbwrapper import OptionsDBWrapper
+from .redis_error_handler import redis_error_handler
+from .session_dbwrapper import SessionDBWrapper
+from .session_status_dbwrapper import SessionStatusDBWrapper
+from .session_template_dbwrapper import SessionTemplateDBWrapper

--- a/src/bos/server/redis_db_utils/boot_artifacts_dbwrapper.py
+++ b/src/bos/server/redis_db_utils/boot_artifacts_dbwrapper.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,40 +21,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import logging
-from typing import Literal
+"""
+BootArtifactsDBWrapper class
+"""
 
-from bos.common.utils import exc_type_msg
-from bos.server.models.healthz import Healthz
-from bos.server import redis_db_utils
+from bos.common.types.components import TimestampedBootArtifacts
 
-DB = redis_db_utils.OptionsDBWrapper()
+from .dbwrapper import DBWrapper
+from .defs import Databases
 
-LOGGER = logging.getLogger(__name__)
-
-
-def _get_db_status() -> str:
-    available = False
-    try:
-        if DB.info():
-            available = True
-    except Exception as e:
-        LOGGER.error(exc_type_msg(e))
-
-    if available:
-        return 'ok'
-    return 'not_available'
-
-
-def get_v2_healthz() -> tuple[Healthz, Literal[200]]:
-    """GET /v2/healthz
-
-    Query BOS etcd for health status
-
-    :rtype: Healthz
+class BootArtifactsDBWrapper(DBWrapper[TimestampedBootArtifacts]):
     """
-    LOGGER.debug("GET /v2/healthz invoked get_v2_healthz")
-    return Healthz(
-        db_status=_get_db_status(),
-        api_status='ok',
-    ), 200
+    Boot artifacts database wrapper
+    """
+
+    @property
+    def db_id(self) -> Databases:
+        return Databases.BSS_TOKENS_BOOT_ARTIFACTS

--- a/src/bos/server/redis_db_utils/component_dbwrapper.py
+++ b/src/bos/server/redis_db_utils/component_dbwrapper.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,40 +21,28 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import logging
-from typing import Literal
+"""
+ComponentDBWrapper class
+"""
 
-from bos.common.utils import exc_type_msg
-from bos.server.models.healthz import Healthz
-from bos.server import redis_db_utils
+from bos.common.types.components import ComponentRecord, update_component_record
 
-DB = redis_db_utils.OptionsDBWrapper()
+from .dbwrapper import DBWrapper
+from .defs import Databases
 
-LOGGER = logging.getLogger(__name__)
-
-
-def _get_db_status() -> str:
-    available = False
-    try:
-        if DB.info():
-            available = True
-    except Exception as e:
-        LOGGER.error(exc_type_msg(e))
-
-    if available:
-        return 'ok'
-    return 'not_available'
-
-
-def get_v2_healthz() -> tuple[Healthz, Literal[200]]:
-    """GET /v2/healthz
-
-    Query BOS etcd for health status
-
-    :rtype: Healthz
+class ComponentDBWrapper(DBWrapper[ComponentRecord]):
     """
-    LOGGER.debug("GET /v2/healthz invoked get_v2_healthz")
-    return Healthz(
-        db_status=_get_db_status(),
-        api_status='ok',
-    ), 200
+    Components database wrapper
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.patch = self._patch
+
+    @property
+    def db_id(self) -> Databases:
+        return Databases.COMPONENTS
+
+    @classmethod
+    def _patch_data(cls, data: ComponentRecord, new_data: ComponentRecord) -> None:
+        update_component_record(data, new_data)

--- a/src/bos/server/redis_db_utils/defs.py
+++ b/src/bos/server/redis_db_utils/defs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,40 +21,22 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import logging
-from typing import Literal
+"""
+Definitions for redis_db_utils modules
+"""
 
-from bos.common.utils import exc_type_msg
-from bos.server.models.healthz import Healthz
-from bos.server import redis_db_utils
+from enum import IntEnum
 
-DB = redis_db_utils.OptionsDBWrapper()
-
-LOGGER = logging.getLogger(__name__)
-
-
-def _get_db_status() -> str:
-    available = False
-    try:
-        if DB.info():
-            available = True
-    except Exception as e:
-        LOGGER.error(exc_type_msg(e))
-
-    if available:
-        return 'ok'
-    return 'not_available'
-
-
-def get_v2_healthz() -> tuple[Healthz, Literal[200]]:
-    """GET /v2/healthz
-
-    Query BOS etcd for health status
-
-    :rtype: Healthz
+class Databases(IntEnum):
     """
-    LOGGER.debug("GET /v2/healthz invoked get_v2_healthz")
-    return Healthz(
-        db_status=_get_db_status(),
-        api_status='ok',
-    ), 200
+    Integer value is the database ID
+    """
+    OPTIONS = 0
+    COMPONENTS = 1
+    SESSION_TEMPLATES = 2
+    SESSIONS = 3
+    BSS_TOKENS_BOOT_ARTIFACTS = 4
+    SESSION_STATUS = 5
+
+DB_HOST = 'cray-bos-db'
+DB_PORT = 6379

--- a/src/bos/server/redis_db_utils/session_dbwrapper.py
+++ b/src/bos/server/redis_db_utils/session_dbwrapper.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,40 +21,28 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import logging
-from typing import Literal
+"""
+SessionDBWrapper class
+"""
 
-from bos.common.utils import exc_type_msg
-from bos.server.models.healthz import Healthz
-from bos.server import redis_db_utils
+from bos.common.types.sessions import Session, update_session_record
 
-DB = redis_db_utils.OptionsDBWrapper()
+from .defs import Databases
+from .tenant_aware_dbwrapper import TenantAwareDBWrapper
 
-LOGGER = logging.getLogger(__name__)
-
-
-def _get_db_status() -> str:
-    available = False
-    try:
-        if DB.info():
-            available = True
-    except Exception as e:
-        LOGGER.error(exc_type_msg(e))
-
-    if available:
-        return 'ok'
-    return 'not_available'
-
-
-def get_v2_healthz() -> tuple[Healthz, Literal[200]]:
-    """GET /v2/healthz
-
-    Query BOS etcd for health status
-
-    :rtype: Healthz
+class SessionDBWrapper(TenantAwareDBWrapper[Session]):
     """
-    LOGGER.debug("GET /v2/healthz invoked get_v2_healthz")
-    return Healthz(
-        db_status=_get_db_status(),
-        api_status='ok',
-    ), 200
+    Session database wrapper
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.tenant_aware_patch = self._tenant_aware_patch
+
+    @property
+    def db_id(self) -> Databases:
+        return Databases.SESSIONS
+
+    @classmethod
+    def _patch_data(cls, data: Session, new_data: Session) -> None:
+        update_session_record(data, new_data)

--- a/src/bos/server/redis_db_utils/session_status_dbwrapper.py
+++ b/src/bos/server/redis_db_utils/session_status_dbwrapper.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,40 +21,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import logging
-from typing import Literal
+"""
+SessionStatusDBWrapper class
+"""
 
-from bos.common.utils import exc_type_msg
-from bos.server.models.healthz import Healthz
-from bos.server import redis_db_utils
+from bos.common.types.session_extended_status import SessionExtendedStatus
 
-DB = redis_db_utils.OptionsDBWrapper()
+from .defs import Databases
+from .tenant_aware_dbwrapper import TenantAwareDBWrapper
 
-LOGGER = logging.getLogger(__name__)
-
-
-def _get_db_status() -> str:
-    available = False
-    try:
-        if DB.info():
-            available = True
-    except Exception as e:
-        LOGGER.error(exc_type_msg(e))
-
-    if available:
-        return 'ok'
-    return 'not_available'
-
-
-def get_v2_healthz() -> tuple[Healthz, Literal[200]]:
-    """GET /v2/healthz
-
-    Query BOS etcd for health status
-
-    :rtype: Healthz
+class SessionStatusDBWrapper(TenantAwareDBWrapper[SessionExtendedStatus]):
     """
-    LOGGER.debug("GET /v2/healthz invoked get_v2_healthz")
-    return Healthz(
-        db_status=_get_db_status(),
-        api_status='ok',
-    ), 200
+    Wrapper for session status database
+    """
+
+    @property
+    def db_id(self) -> Databases:
+        return Databases.SESSION_STATUS

--- a/src/bos/server/redis_db_utils/session_template_dbwrapper.py
+++ b/src/bos/server/redis_db_utils/session_template_dbwrapper.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022, 2024-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,40 +21,28 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import logging
-from typing import Literal
+"""
+SessionTemplateDBWrapper class
+"""
 
-from bos.common.utils import exc_type_msg
-from bos.server.models.healthz import Healthz
-from bos.server import redis_db_utils
+from bos.common.types.templates import SessionTemplate, update_template_record
 
-DB = redis_db_utils.OptionsDBWrapper()
+from .defs import Databases
+from .tenant_aware_dbwrapper import TenantAwareDBWrapper
 
-LOGGER = logging.getLogger(__name__)
-
-
-def _get_db_status() -> str:
-    available = False
-    try:
-        if DB.info():
-            available = True
-    except Exception as e:
-        LOGGER.error(exc_type_msg(e))
-
-    if available:
-        return 'ok'
-    return 'not_available'
-
-
-def get_v2_healthz() -> tuple[Healthz, Literal[200]]:
-    """GET /v2/healthz
-
-    Query BOS etcd for health status
-
-    :rtype: Healthz
+class SessionTemplateDBWrapper(TenantAwareDBWrapper[SessionTemplate]):
     """
-    LOGGER.debug("GET /v2/healthz invoked get_v2_healthz")
-    return Healthz(
-        db_status=_get_db_status(),
-        api_status='ok',
-    ), 200
+    Wrapper for session templates database
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.tenant_aware_patch = self._tenant_aware_patch
+
+    @property
+    def db_id(self) -> Databases:
+        return Databases.SESSION_TEMPLATES
+
+    @classmethod
+    def _patch_data(cls, data: SessionTemplate, new_data: SessionTemplate) -> None:
+        update_template_record(data, new_data)

--- a/src/bos/server/redis_db_utils/tenant_aware_dbwrapper.py
+++ b/src/bos/server/redis_db_utils/tenant_aware_dbwrapper.py
@@ -1,0 +1,70 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+DBWrapper class
+"""
+
+from abc import ABC
+from collections.abc import Callable
+
+from bos.common.tenant_utils import get_tenant_aware_key
+from bos.common.types.general import BosDataRecord
+
+from .dbwrapper import DBWrapper
+
+class TenantAwareDBWrapper[DataType: BosDataRecord](DBWrapper[DataType], ABC):
+    """A wrapper around a Redis database connection, for a database
+    with tenant-aware keys
+    """
+    def has_tenanted_entry(self, name: str, tenant: str | None) -> bool:
+        """
+        Checks if data exists for given name/tenant
+        """
+        return get_tenant_aware_key(name, tenant) in self
+
+    def tenant_aware_get(self, name: str, tenant: str | None) -> DataType | None:
+        """Get the data for the given name/tenant."""
+        return self.get(get_tenant_aware_key(name, tenant))
+
+    def tenant_aware_get_and_delete(self, name: str, tenant: str | None) -> DataType | None:
+        """Get the data for the given name/tenant and delete it from the DB."""
+        return self.get_and_delete(get_tenant_aware_key(name, tenant))
+
+    def tenant_aware_put(self, name: str, tenant: str | None, new_data: DataType) -> DataType | None:
+        """Put data in to the database, replacing any old data."""
+        return self.put(get_tenant_aware_key(name, tenant), new_data)
+
+    def _tenant_aware_patch(self, name: str, tenant: str | None, new_data: DataType,
+              data_handler: Callable[[DataType],DataType] | None=None) -> DataType | None:
+        """Patch data in the database.
+           data_handler provides a way to operate on the full patched data
+
+           Not all BOS databases support patching. Subclasses which do support patch
+           operations should provide a tenant_aware_patch method.
+           """
+        return self._patch(get_tenant_aware_key(name, tenant), new_data, data_handler)
+
+    def tenant_aware_delete(self, name: str, tenant: str | None) -> None:
+        """Deletes data from the database."""
+        return self.delete(get_tenant_aware_key(name, tenant))


### PR DESCRIPTION
Break the `redis_db_utils` file into a module.
Split the DB wrapper class into a base class, with subclasses for each BOS database (along with an intermediate 'tenant-aware' DB for those BOS databases whose keys include the tenant).
Update the BOS code which uses the databases to reflect these changes.
