### PR TITLE
CASMCMS-9295: Improve Python type annotations in boot_image_metadata 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - CASMCMS-9294: Improve Python type annotations, focused on DB modules
+- CASMCMS-9295: Improve Python type annotations in `boot_image_metadata` modules
 
 ## [2.35.1] - 2025-03-20
 

--- a/src/bos/operators/utils/boot_image_metadata/__init__.py
+++ b/src/bos/operators/utils/boot_image_metadata/__init__.py
@@ -23,16 +23,26 @@
 #
 
 from abc import abstractmethod, ABC
+from typing import TypedDict
 
+from bos.common.types.templates import BootSet
+
+class BootImageArtifactSummary(TypedDict, total=False):
+    kernel: str
+    initrd: str
+    rootfs: str
+    rootfs_etag: str
+    boot_parameters: str
+    boot_parameters_etag: str
 
 class BootImageMetaData(ABC):
     """
     Base class for BootImage Metadata
     """
 
-    def __init__(self, boot_set: dict):
+    def __init__(self, boot_set: BootSet) -> None:
         self._boot_set = boot_set
-        self.artifact_summary = {}
+        self.artifact_summary: BootImageArtifactSummary = {}
 
     @property
     @abstractmethod
@@ -71,7 +81,13 @@ class BootImageMetaData(ABC):
         """
 
 
-class BootImageMetaDataBadRead(Exception):
+class BootImageError(Exception):
+    """
+    General error getting boot image
+    """
+
+
+class BootImageMetaDataBadRead(BootImageError):
     """
     The metadata for the boot image could not be read/retrieved.
     """

--- a/src/bos/operators/utils/boot_image_metadata/factory.py
+++ b/src/bos/operators/utils/boot_image_metadata/factory.py
@@ -23,6 +23,8 @@
 #
 import logging
 
+from bos.common.types.templates import BootSet
+from bos.operators.utils.boot_image_metadata import BootImageMetaData
 from bos.operators.utils.boot_image_metadata.s3_boot_image_metadata import S3BootImageMetaData
 
 LOGGER = logging.getLogger(__name__)
@@ -40,10 +42,10 @@ class BootImageMetaDataFactory:
     the type of the BootImageMetaData specified
     """
 
-    def __init__(self, boot_set: dict):
+    def __init__(self, boot_set: BootSet):
         self.boot_set = boot_set
 
-    def __call__(self):
+    def __call__(self) -> BootImageMetaData:
         path_type = self.boot_set.get('type', None)
         if not path_type:
             raise BootImageMetaDataUnknown(

--- a/src/bos/operators/utils/boot_image_metadata/s3_boot_image_metadata.py
+++ b/src/bos/operators/utils/boot_image_metadata/s3_boot_image_metadata.py
@@ -30,19 +30,25 @@ from bos.common.clients.s3 import (ArtifactNotFound,
                                    S3MissingConfiguration,
                                    S3Url)
 from bos.common.utils import exc_type_msg
-from bos.operators.utils.boot_image_metadata import BootImageMetaData, BootImageMetaDataBadRead
+from bos.common.types.templates import BootSet
+from bos.operators.utils.boot_image_metadata import (BootImageError,
+                                                     BootImageMetaData,
+                                                     BootImageMetaDataBadRead)
 
 LOGGER = logging.getLogger(__name__)
 
 
 class S3BootImageMetaData(BootImageMetaData):
 
-    def __init__(self, boot_set: dict):
+    def __init__(self, boot_set: BootSet):
         """
         Create an S3 BootImage by downloading the manifest
         """
         super().__init__(boot_set)
-        path = self._boot_set.get('path', None)
+        try:
+            path = self._boot_set['path']
+        except KeyError as exc:
+            raise BootImageError(f"Boot set is missing required 'path' field: {boot_set}") from exc
         etag = self._boot_set.get('etag', None)
         self.boot_artifacts = S3BootArtifacts(path, etag)
         self.artifact_summary = {}


### PR DESCRIPTION
The only functional change is that an exception is now raised if a boot set is missing the required `path` field. I think with the checks we have in other places, we should never hit that part of this code anyway, but if we do, we should fail on it.

The rest of this is purely improving the type annotations.