### PR TITLE
CASMCMS-9296: Improve Python type annotations in rootfs modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - CASMCMS-9294: Improve Python type annotations, focused on DB modules
 - CASMCMS-9295: Improve Python type annotations in `boot_image_metadata` modules
+- CASMCMS-9296: Improve Python type annotations in `rootfs` modules
 
 ## [2.35.1] - 2025-03-20
 

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -34,13 +34,15 @@ from bos.common.clients.hsm import Inventory
 from bos.common.clients.s3 import S3Object, S3ObjectNotFound
 from bos.common.tenant_utils import get_tenant_component_set, InvalidTenantException
 from bos.common.types.components import ComponentRecord
+from bos.common.types.templates import BootSet
 from bos.common.utils import exc_type_msg
 from bos.common.values import Action, EMPTY_ACTUAL_STATE, EMPTY_DESIRED_STATE, EMPTY_STAGED_STATE
 from bos.operators.base import BaseOperator, main, chunk_components
 from bos.operators.filters import HSMState
 from bos.operators.session_completion import mark_session_complete
+from bos.operators.utils.boot_image_metadata import BootImageArtifactSummary
 from bos.operators.utils.boot_image_metadata.factory import BootImageMetaDataFactory
-from bos.operators.utils.rootfs.factory import ProviderFactory
+from bos.operators.utils.rootfs.factory import get_provider
 
 LOGGER = logging.getLogger(__name__)
 
@@ -383,7 +385,7 @@ class Session:
             boot_set)
         return state
 
-    def _get_configuration_from_boot_set(self, boot_set: dict):
+    def _get_configuration_from_boot_set(self, boot_set: BootSet):
         """
         An abstraction method for determining the configuration to use
         in the event for any given <boot set> within a session. Boot Sets
@@ -400,7 +402,7 @@ class Session:
         # Otherwise, we take the configuration value from the session template itself
         return self.template.get('cfs', {}).get('configuration', '')
 
-    def assemble_kernel_boot_parameters(self, boot_set, artifact_info):
+    def assemble_kernel_boot_parameters(self, boot_set: BootSet, artifact_info: BootImageArtifactSummary):
         """
         Assemble the kernel boot parameters that we want to set in the
         Boot Script Service (BSS).
@@ -462,8 +464,7 @@ class Session:
             boot_param_pieces.append(boot_set.get('kernel_parameters'))
 
         # Append special parameters for the rootfs and Node Memory Dump
-        pf = ProviderFactory(boot_set, artifact_info)
-        provider = pf()
+        provider = get_provider(boot_set, artifact_info)
         rootfs_parameters = str(provider)
         if rootfs_parameters:
             boot_param_pieces.append(rootfs_parameters)

--- a/src/bos/operators/utils/rootfs/__init__.py
+++ b/src/bos/operators/utils/rootfs/__init__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,71 +26,3 @@ Created on Apr 29, 2019
 
 @author: jsl
 '''
-
-import logging
-
-LOGGER = logging.getLogger(__name__)
-
-
-class ProviderNotImplemented(Exception):
-    """
-    Raised when a user requests a Provider Provisioning mechanism that isn't yet supported
-    """
-
-
-class RootfsProvider:
-    PROTOCOL = None
-    DELIMITER = ':'
-    """
-    This class is intended to be inherited by various kinds of root Provider provisioning
-    mechanisms.
-    """
-
-    def __init__(self, boot_set, artifact_info):
-        """
-        Given an bootset, extrapolate the required boot parameter value.
-        """
-        self.boot_set = boot_set
-        self.artifact_info = artifact_info
-
-    def __str__(self):
-        """
-        The value to add to the 'root=' kernel boot parameter.
-        """
-        fields = []
-        if self.PROTOCOL:
-            fields.append(self.PROTOCOL)
-
-        if self.provider_field:
-            fields.append(self.provider_field)
-        else:
-            fields.append("")
-
-        if self.provider_field_id:
-            fields.append(self.provider_field_id)
-        else:
-            fields.append("")
-
-        rootfs_provider_passthrough = self.boot_set.get(
-            'rootfs_provider_passthrough', None)
-        if rootfs_provider_passthrough:
-            fields.append(rootfs_provider_passthrough)
-
-        stripped_fields = [field for field in fields if field]
-        return f"root={self.DELIMITER.join(fields)}" if stripped_fields else ''
-
-    @property
-    def provider_field(self):
-        return None
-
-    @property
-    def provider_field_id(self):
-        return None
-
-    @property
-    def nmd_field(self):
-        """
-        The value to add to the kernel boot parameters for Node Memory Dump (NMD)
-        parameter.
-        """
-        return None

--- a/src/bos/operators/utils/rootfs/cpss3_provider.py
+++ b/src/bos/operators/utils/rootfs/cpss3_provider.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,14 +22,17 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 '''
-Provisioning mechanism unique to the ContentProjectionService; this is software
-that is often installed as part of Cray CME images in both standard, enhanced
-and premium offerings; the underlying implementation of CPS may be handled by
-another protocol (iSCSI or DVS) depending on the product.
+Provisioning mechanism unique to the ContentProjectionService
 '''
 
-from .baserootfs import BaseRootfsProvider
+from .rootfs_provider_with_artifact_info import RootfsProviderWithArtifactInfo
 
 
-class CPSS3Provider(BaseRootfsProvider):
+class CPSS3Provider(RootfsProviderWithArtifactInfo):
+    '''
+    Provisioning mechanism unique to the ContentProjectionService; this is software
+    that is often installed as part of Cray CME images in both standard, enhanced
+    and premium offerings; the underlying implementation of CPS may be handled by
+    another protocol (iSCSI or DVS) depending on the product.
+    '''
     PROTOCOL = 'craycps-s3'

--- a/src/bos/operators/utils/rootfs/rootfs_provider.py
+++ b/src/bos/operators/utils/rootfs/rootfs_provider.py
@@ -1,0 +1,89 @@
+#
+# MIT License
+#
+# (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+'''
+Created on Apr 29, 2019
+
+@author: jsl
+'''
+
+from bos.common.types.templates import BootSet
+from bos.operators.utils.boot_image_metadata import BootImageArtifactSummary
+
+class RootfsProvider:
+    """
+    This class is intended to be inherited by various kinds of root Provider provisioning
+    mechanisms.
+    """
+
+    PROTOCOL: str | None = None
+    DELIMITER: str = ':'
+
+    def __init__(self, boot_set: BootSet, artifact_info: BootImageArtifactSummary) -> None:
+        """
+        Given an bootset, extrapolate the required boot parameter value.
+        """
+        self.boot_set = boot_set
+        self.artifact_info = artifact_info
+
+    def __str__(self) -> str:
+        """
+        The value to add to the 'root=' kernel boot parameter.
+        """
+        fields = []
+        if self.PROTOCOL:
+            fields.append(self.PROTOCOL)
+
+        if self.provider_field:
+            fields.append(self.provider_field)
+        else:
+            fields.append("")
+
+        if self.provider_field_id:
+            fields.append(self.provider_field_id)
+        else:
+            fields.append("")
+
+        rootfs_provider_passthrough = self.boot_set.get(
+            'rootfs_provider_passthrough', None)
+        if rootfs_provider_passthrough:
+            fields.append(rootfs_provider_passthrough)
+
+        stripped_fields = [field for field in fields if field]
+        return f"root={self.DELIMITER.join(fields)}" if any(fields) else ''
+
+    @property
+    def provider_field(self) -> str | None:
+        return None
+
+    @property
+    def provider_field_id(self) -> str | None:
+        return None
+
+    @property
+    def nmd_field(self) -> str | None:
+        """
+        The value to add to the kernel boot parameters for Node Memory Dump (NMD)
+        parameter.
+        """
+        return None

--- a/src/bos/operators/utils/rootfs/rootfs_provider_with_artifact_info.py
+++ b/src/bos/operators/utils/rootfs/rootfs_provider_with_artifact_info.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,26 +23,26 @@
 #
 '''
 Provisioning mechanism, base class
-The assumption is the artifact info contains information about the rootfs.
 '''
 
-from . import RootfsProvider
+from .rootfs_provider import RootfsProvider
 
 
-class BaseRootfsProvider(RootfsProvider):
-
-    PROTOCOL = None
+class RootfsProviderWithArtifactInfo(RootfsProvider):
+    """
+    The assumption is the artifact info contains information about the rootfs.
+    """
 
     @property
-    def provider_field(self):
+    def provider_field(self) -> str:
         return self.artifact_info['rootfs']
 
     @property
-    def provider_field_id(self):
+    def provider_field_id(self) -> str:
         return self.artifact_info['rootfs_etag']
 
     @property
-    def nmd_field(self):
+    def nmd_field(self) -> str:
         """
         The value to add to the kernel boot parameters for Node Memory Dump (NMD)
         parameter.

--- a/src/bos/operators/utils/rootfs/sbps_provider.py
+++ b/src/bos/operators/utils/rootfs/sbps_provider.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,8 +25,12 @@
 Provisioning mechanism using the Scalable Boot Provisioning Service
 '''
 
-from .baserootfs import BaseRootfsProvider
+from .rootfs_provider_with_artifact_info import RootfsProviderWithArtifactInfo
 
 
-class SBPSProvider(BaseRootfsProvider):
+class SBPSProvider(RootfsProviderWithArtifactInfo):
+    '''
+    Provisioning mechanism using the Scalable Boot Provisioning Service
+    '''
+
     PROTOCOL = 'sbps-s3'


### PR DESCRIPTION
Next up in the continuing type annotation saga, the rootfs modules. The only thing to note here is that I did away with the `ProviderFactory` class. Its logic was slick, and gave the advantage that to implement a new provider, the factory class did not need to be modified. But it was harder to follow its logic, and made it harder for tools like mypy to figure out what it would be returning. I replaced it with a function that does hard-code the (two) different supported rootfs providers. It adds minimal overhead when adding/removing supported rootfs providers, and makes the logic much more obvious (to both humans and mypy).