### PR TITLE
CASMCMS-9330: Print new logging level as string rather than integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.35.1] - 2025-03-20
+
 ### Fixed
 - CASMCMS-9330: Print new logging level as string rather than integer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CASMCMS-9330: Print new logging level as string rather than integer
+
 ## [2.35.0] - 2025-03-13
 
 ### Changed

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -149,11 +149,11 @@ def update_log_level(new_level_str: str) -> None:
     current_level = LOGGER.getEffectiveLevel()
     if current_level != new_level:
         LOGGER.log(current_level, 'Changing logging level from %s to %s',
-                   logging.getLevelName(current_level), new_level)
+                   logging.getLevelName(current_level), logging.getLevelName(new_level))
         logger = logging.getLogger()
         logger.setLevel(new_level)
         LOGGER.log(new_level, 'Logging level changed from %s to %s',
-                   logging.getLevelName(current_level), new_level)
+                   logging.getLevelName(current_level), logging.getLevelName(new_level))
 
 
 def check_v2_logging_level() -> NoReturn:


### PR DESCRIPTION
I noticed that the BOS logs now contain messages like this:

```
DEBUG:bos.server.controllers.v2.options:Logging level changed from INFO to 10
```

Where they previously looked like this:

```
DEBUG:bos.server.controllers.v2.options:Logging level changed from INFO to DEBUG
```

This impacts both CSM 1.6 and CSM 1.7, but not earlier. I figured out the change that caused it, and this reverts it back to the way it was. I have tested this on wasp and confirmed that it works.

CSM 1.6 backport:
https://github.com/Cray-HPE/bos/pull/464