### PR TITLE
CASMCMS-9330: Print new logging level as string rather than integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.30.13] - 2025-03-20
+
 ### Changed
 - CASMCMS-9274: Prevent [`SNYK-PYTHON-WERKZEUG-6808933`](https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933) from causing builds to fail.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Changed
 - CASMCMS-9274: Prevent [`SNYK-PYTHON-WERKZEUG-6808933`](https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933) from causing builds to fail.
 
 ### Dependencies
 - Pin Alpine version in release branch
+
+### Fixed
+- CASMCMS-9330: Print new logging level as string rather than integer
 
 ## [2.30.12] - 2025-02-05
 ### Fixed

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -145,11 +145,11 @@ def update_log_level(new_level_str):
     current_level = LOGGER.getEffectiveLevel()
     if current_level != new_level:
         LOGGER.log(current_level, 'Changing logging level from %s to %s',
-                   logging.getLevelName(current_level), new_level)
+                   logging.getLevelName(current_level), logging.getLevelName(new_level))
         logger = logging.getLogger()
         logger.setLevel(new_level)
         LOGGER.log(new_level, 'Logging level changed from %s to %s',
-                   logging.getLevelName(current_level), new_level)
+                   logging.getLevelName(current_level), logging.getLevelName(new_level))
 
 
 def check_v2_logging_level():


### PR DESCRIPTION
CSM 1.6 backport of https://github.com/Cray-HPE/bos/pull/463