### PR TITLE
CASMCMS-9340: Improve efficiency by using Redis mget/mset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CASMCMS-9340: Created Redis DB wrapper methods to allow reading/writing multiple entries in
+  a single call; updated components controller to make use of this.
+
 ### Changes
 - CASMCMS-9331: When a requested item is missing from a BOS DB, signal this by raising an
   exception instead of returning None.

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -241,7 +241,7 @@ def put_v2_components() -> tuple[list[ComponentRecord], Literal[200]] | CxRespon
     for comp_id in components:
         components[comp_id] = _set_auto_fields(components[comp_id])
 
-    _mput(components)
+    DB.mput(components)
     return list(components.values()), 200
 
 
@@ -289,7 +289,7 @@ def patch_v2_components_list(
         LOGGER.error("Error patching component data: %s", exc_type_msg(err))
         return _400_bad_request(f"Error patching the data provided: {err}")
 
-    _mput(components)
+    DB.mput(components)
     return list(components.values()), 200
 
 
@@ -334,7 +334,7 @@ def patch_v2_components_dict(data: JsonDict) -> tuple[list[ComponentRecord],
         LOGGER.error("Error patching component data: %s", exc_type_msg(err))
         return _400_bad_request(f"Error patching the data provided: {err}")
 
-    _mput(components)
+    DB.mput(components)
     return list(components.values()), 200
 
 
@@ -346,7 +346,7 @@ def _load_comps_from_id_list(id_list: list[str]) -> dict[str, ComponentRecord]:
         raise KeyError(invalid_comp_id)
 
     try:
-        return { comp_id: DB.get(comp_id) for comp_id in id_list }
+        return DB.mget(id_list)
     except dbutils.NotFoundInDB as exc:
         raise KeyError(exc.key) from exc
 
@@ -510,14 +510,6 @@ def post_v2_apply_staged() -> tuple[JsonDict, Literal[200]] | CxResponse:
         return _400_bad_request(f"Error parsing the data provided: {err}")
 
     return response, 200
-
-
-def _mput(components_by_id: dict[str, ComponentRecord]) -> None:
-    """
-    Add all components to the DB
-    """
-    for component_id, component_data in components_by_id.items():
-        DB.put(component_id, component_data)
 
 
 def _apply_tenant_limit(component_list: list[str]) -> tuple[list[str], list[str]]:

--- a/src/bos/server/redis_db_utils/tenant_aware_dbwrapper.py
+++ b/src/bos/server/redis_db_utils/tenant_aware_dbwrapper.py
@@ -57,3 +57,8 @@ class TenantAwareDBWrapper[DataT: BosDataRecord](DBWrapper[DataT], ABC):
     def tenanted_delete(self, name: str, tenant: str | None, /) -> None:
         """Deletes data from the database."""
         return self.delete(get_tenant_aware_key(name, tenant))
+
+    def tenanted_mput(self, name_tenant_data_map: dict[tuple[str, str|None], DataT], /) -> None:
+        """Put data in to the database, replacing any old data."""
+        self.mput({ get_tenant_aware_key(*name_tenant_tuple): data
+                    for name_tenant_tuple, data in name_tenant_data_map.items() })


### PR DESCRIPTION
For some operations, BOS does a series of reads/writes for numerous single database entries, instead of combining these into a single call. The biggest impact is when update component states. This PR adds two new methods to the database wrapper -- `mget` and `mput`, which use the `mget` and `mset` Redis calls. This PR modifies the components controller to use these in places where it previously was doing things one entry at a time.

The logic does not change outside of this consolidation.