### PR TITLE
CASMCMS-9339: Make more precise type annotations for session create and patch requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 - CASMCMS-9331: When a requested item is missing from a BOS DB, signal this by raising an
   exception instead of returning None.
+- CASMCMS-9339: Make more precise type annotations for session create and patch requests
 
 ### Dependencies
 - Bump redis Python client version from 5.0 to 5.2

--- a/src/bos/common/types/sessions.py
+++ b/src/bos/common/types/sessions.py
@@ -26,7 +26,6 @@
 Type annotation definitions for BOS sessions
 """
 
-import copy
 from typing import Literal, Required, TypedDict
 
 from .general import BosDataRecord
@@ -58,20 +57,30 @@ class Session(BosDataRecord, total=False):
     template_name: Required[str]
     tenant: str | None
 
-def update_session_record(record: Session, new_record: Session) -> None:
+class SessionCreate(TypedDict, total=False):
     """
-    Patch 'record' in-place with the data from 'new_record'.
+    #/components/schemas/V2SessionCreate
     """
-    # Make a copy, to avoid changing new_record in place
-    new_record_copy = copy.deepcopy(new_record)
+    include_disabled: bool
+    limit: str
+    name: str
+    operation: Required[SessionOperation]
+    stage: bool
+    template_name: Required[str]
 
-    # First, merge the status sub-dict
-    if "status" in new_record_copy:
-        if "status" in record:
-            record["status"].update(new_record_copy["status"])
-            new_record_copy["status"] = record["status"]
-        else:
-            record["status"] = new_record_copy["status"]
+class SessionUpdate(TypedDict, total=False):
+    """
+    #/components/schemas/V2SessionUpdate
+    """
+    components: str
+    status: SessionStatus
 
-    # The remaining fields can be merged the old-fashioned way
-    record.update(new_record_copy)
+def update_session_record(record: Session, patch_data: SessionUpdate) -> None:
+    """
+    Patch 'record' in-place with the data from 'patch_data'.
+    """
+    if "status" in patch_data:
+        record["status"].update(patch_data["status"])
+
+    if "components" in patch_data:
+        record["components"] = patch_data["components"]


### PR DESCRIPTION
Create type annotations for the schemas used to create and patch sessions. Modify the function used to patch sessions to use the patch request type, rather than a generic session, to reflect what is actually allowed by the API. 