### PR TITLE
CASMCMS-8666: Remove name field from /sessiontemplatetemplate response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-8666: Remove `name` field from `/sessiontemplatetemplate` response.
+
 ## [2.37.0] - 2025-04-07
 
 ### Added

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -63,8 +63,7 @@ EXAMPLE_SESSION_TEMPLATE = {
     "cfs": {
         "configuration": "default-sessiontemplate-cfs-config"
     },
-    "enable_cfs": True,
-    "name": "name-your-template"
+    "enable_cfs": True
 }
 
 


### PR DESCRIPTION
The `/sessiontemplatetemplate` endpoint was added because people wanted a way to get a skeleton template that they could edit in order to create their own session template. When creating a session template, the `name` is not specified as part of the request body -- it is specified as part of the path (or in the case of the CLI, it is specified using a separate argument). In either case, the user would need to manually delete that field from their request body, otherwise the create will fail. So it makes more sense not to include that field in the output. That's what this PR does.

Note that this change does not violate the API schema, because the `name` field is listed as read only, but not as required.