### PR TITLE
CASMCMS-7902: Check size before loading image manifest to avoid errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - CASMCMS-8666: Remove `name` field from `/sessiontemplatetemplate` response.
+- CASMCMS-7902: Check size before loading image manifest to avoid OOM issues.
 
 ## [2.37.1] - 2025-04-09
 


### PR DESCRIPTION
This adds code to BOS that mirrors what IMS does when processing manifest files -- if the file is bigger than 1M, it gives an error, rather than trying to use it. This avoids problems like OOM issues. This is only likely to occur if someone has made a mistake with their S3 artifacts, but fortunately the safeguard is very simple and does not involve any additional S3 calls, so the overhead is low.

I tested this on mug and verified that it properly rejected such manifests.