### PR TITLE
CASMCMS-9351: Fix logging bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-8666: Remove `name` field from `/sessiontemplatetemplate` response.
 - CASMCMS-7902: Check size before loading image manifest to avoid OOM issues.
 
+### Fixed
+- CASMCMS-9351: Fixed two logging bugs:
+  - When updating log level, BOS operators were logging the new log level as its
+    integer value, rather than its string value.
+  - The server was not properly updating its log level when it changed, because it
+    runs in separate processes.
+
 ## [2.37.2] - 2025-04-09
 
 ### Fixed

--- a/src/bos/common/utils.py
+++ b/src/bos/common/utils.py
@@ -27,6 +27,7 @@ from contextlib import nullcontext, AbstractContextManager
 import copy
 import datetime
 from functools import partial
+import logging
 import re
 import traceback
 from typing import Unpack
@@ -38,6 +39,8 @@ import requests_retry_session as rrs
 
 from bos.common.types.components import ComponentRecord
 
+LOGGER = logging.getLogger(__name__)
+
 PROTOCOL = 'http'
 TIME_DURATION_PATTERN = re.compile(r"^(\d+?)(\D+?)$", re.M | re.S)
 
@@ -47,6 +50,30 @@ class InvalidDurationTimestamp(Exception):
     Raised by duration_to_timedelta if it is asked to parse a timestamp
     that does not fit its expected pattern
     """
+
+
+def update_log_level(new_level_str: str) -> None:
+    """
+    If the current logging level does not match the specified new level,
+    then call do_update_log_level to update it
+    """
+    new_level_str = new_level_str.upper()
+    new_level_int = logging.getLevelName(new_level_str)
+    current_level_int = LOGGER.getEffectiveLevel()
+    if current_level_int != new_level_int:
+        do_update_log_level(current_level_int, new_level_int, new_level_str)
+
+
+def do_update_log_level(current_level_int: int, new_level_int: int, new_level_str: str) -> None:
+    """
+    Change the logging level of the current process to the specified new level
+    """
+    current_level_str = logging.getLevelName(current_level_int)
+    LOGGER.log(current_level_int, 'Changing logging level from %s to %s',
+               current_level_str, new_level_str)
+    logging.getLogger().setLevel(new_level_int)
+    LOGGER.log(new_level_int, 'Logging level changed from %s to %s',
+               current_level_str, new_level_str)
 
 
 # Common date and timestamps functions so that timezones and formats are handled consistently.

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -45,7 +45,7 @@ from bos.common.clients.cfs import CFSClient
 from bos.common.clients.hsm import HSMClient
 from bos.common.clients.ims import IMSClient
 from bos.common.clients.pcs import PCSClient
-from bos.common.utils import exc_type_msg
+from bos.common.utils import exc_type_msg, update_log_level
 from bos.common.types.components import ComponentRecord
 from bos.common.values import Status
 from bos.operators.filters import BOSQuery, DesiredConfigurationSetInCFS, HSMState
@@ -397,15 +397,7 @@ def _update_log_level() -> None:
     try:
         if not options.logging_level:
             return
-        new_level = logging.getLevelName(options.logging_level.upper())
-        current_level = LOGGER.getEffectiveLevel()
-        if current_level != new_level:
-            LOGGER.log(current_level, 'Changing logging level from %s to %s',
-                       logging.getLevelName(current_level), new_level)
-            logger = logging.getLogger()
-            logger.setLevel(new_level)
-            LOGGER.log(new_level, 'Logging level changed from %s to %s',
-                       logging.getLevelName(current_level), new_level)
+        update_log_level(options.logging_level)
     except Exception as e:
         LOGGER.error('Error updating logging level: %s', exc_type_msg(e))
 

--- a/src/bos/server/__main__.py
+++ b/src/bos/server/__main__.py
@@ -29,7 +29,7 @@ import os
 
 import connexion
 
-from bos.server.controllers.v2 import options
+from bos.server import options
 from bos.server.encoder import JSONEncoder
 
 LOGGER = logging.getLogger(__name__)

--- a/src/bos/server/controllers/v2/base.py
+++ b/src/bos/server/controllers/v2/base.py
@@ -29,6 +29,7 @@ import yaml
 from bos.common.utils import exc_type_msg
 from bos.server.controllers.utils import url_for
 from bos.server.models import Version, Link
+from bos.server.options import update_server_log_level
 
 LOGGER = logging.getLogger(__name__)
 
@@ -63,10 +64,16 @@ def calc_version(details: bool) -> Version:
 
 
 def get_v2() -> tuple[Version, Literal[200]]:
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("GET /v2 invoked get_v2")
     return calc_version(details=True), 200
 
 
 def get_version_v2() -> tuple[Version, Literal[200]]:
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("GET /v2/version invoked get_version_v2")
     return calc_version(details=True), 200

--- a/src/bos/server/controllers/v2/boot_set/ims.py
+++ b/src/bos/server/controllers/v2/boot_set/ims.py
@@ -29,7 +29,7 @@ from bos.common.clients.ims import (get_arch_from_image_data,
 from bos.common.clients.s3 import S3Url
 from bos.common.types.general import JsonDict
 from bos.common.utils import exc_type_msg
-from bos.server.controllers.v2.options import OptionsData
+from bos.server.options import OptionsData
 
 from .defs import DEFAULT_ARCH
 from .exceptions import BootSetArchMismatch, BootSetError, BootSetWarning, \

--- a/src/bos/server/controllers/v2/boot_set/sanitize.py
+++ b/src/bos/server/controllers/v2/boot_set/sanitize.py
@@ -24,7 +24,7 @@
 
 from bos.common.utils import exc_type_msg
 from bos.common.types.templates import BootSet, SessionTemplate, remove_empty_cfs_field
-from bos.server.controllers.v2.options import OptionsData
+from bos.server.options import OptionsData
 from bos.server.utils import canonize_xname
 
 from .artifacts import validate_boot_artifacts

--- a/src/bos/server/controllers/v2/boot_set/validate.py
+++ b/src/bos/server/controllers/v2/boot_set/validate.py
@@ -26,7 +26,7 @@ from functools import partial
 
 from bos.common.utils import exc_type_msg
 from bos.common.types.general import JsonDict
-from bos.server.controllers.v2.options import OptionsData
+from bos.server.options import OptionsData
 
 from .artifacts import validate_boot_artifacts
 from .defs import HARDWARE_SPECIFIER_FIELDS, LOGGER, BootSetStatus

--- a/src/bos/server/controllers/v2/components.py
+++ b/src/bos/server/controllers/v2/components.py
@@ -39,8 +39,9 @@ from bos.common.utils import components_by_id, exc_type_msg, get_current_timesta
 from bos.common.values import Phase, Action, Status, EMPTY_STAGED_STATE, EMPTY_BOOT_ARTIFACTS
 from bos.server import redis_db_utils as dbutils
 from bos.server.controllers.utils import _400_bad_request, _404_resource_not_found
-from bos.server.controllers.v2.options import get_v2_options_data
+from bos.server.options import get_v2_options_data
 from bos.server.dbs.boot_artifacts import get_boot_artifacts, BssTokenUnknown
+from bos.server.options import update_server_log_level
 from bos.server.utils import get_request_json
 
 LOGGER = logging.getLogger(__name__)
@@ -63,6 +64,9 @@ def get_v2_components(
 
     Allows filtering using a comma separated list of ids.
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug(
         "GET /v2/components invoked get_v2_components with ids=%s enabled=%s session=%s "
         "staged_session=%s phase=%s status=%s start_after_id=%s page_size=%d", ids,
@@ -226,6 +230,9 @@ def _calculate_status(data: ComponentRecord) -> str:
 @dbutils.redis_error_handler
 def put_v2_components() -> tuple[list[ComponentRecord], Literal[200]] | CxResponse:
     """Used by the PUT /components API operation"""
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("PUT /v2/components invoked put_v2_components")
     try:
         data = cast(list[ComponentRecord], get_request_json())
@@ -249,6 +256,9 @@ def put_v2_components() -> tuple[list[ComponentRecord], Literal[200]] | CxRespon
 @dbutils.redis_error_handler
 def patch_v2_components() -> tuple[list[ComponentRecord], Literal[200]] | CxResponse:
     """Used by the PATCH /components API operation"""
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("PATCH /v2/components invoked patch_v2_components")
     try:
         data = get_request_json()
@@ -371,6 +381,9 @@ def _get_invalid_comp_id_for_tenant(comp_id_list: Iterable[str], tenant: str | N
 @dbutils.redis_error_handler
 def get_v2_component(component_id: str) -> tuple[ComponentRecord, Literal[200]] | CxResponse:
     """Used by the GET /components/{component_id} API operation"""
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("GET /v2/components/%s invoked get_v2_component",
                  component_id)
     if not is_valid_tenant_component(component_id, get_tenant_from_header()):
@@ -389,6 +402,9 @@ def get_v2_component(component_id: str) -> tuple[ComponentRecord, Literal[200]] 
 @dbutils.redis_error_handler
 def put_v2_component(component_id: str) -> tuple[ComponentRecord, Literal[200]] | CxResponse:
     """Used by the PUT /components/{component_id} API operation"""
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("PUT /v2/components/%s invoked put_v2_component",
                  component_id)
     try:
@@ -408,6 +424,9 @@ def put_v2_component(component_id: str) -> tuple[ComponentRecord, Literal[200]] 
 @dbutils.redis_error_handler
 def patch_v2_component(component_id: str) -> tuple[ComponentRecord, Literal[200]] | CxResponse:
     """Used by the PATCH /components/{component_id} API operation"""
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("PATCH /v2/components/%s invoked patch_v2_component",
                  component_id)
     try:
@@ -461,6 +480,9 @@ def _validate_actual_state_change_is_allowed(current_data: ComponentRecord) -> b
 @dbutils.redis_error_handler
 def delete_v2_component(component_id: str) -> tuple[None, Literal[204]] | CxResponse:
     """Used by the DELETE /components/{component_id} API operation"""
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("DELETE /v2/components/%s invoked delete_v2_component",
                  component_id)
     if not is_valid_tenant_component(component_id, get_tenant_from_header()):
@@ -479,6 +501,9 @@ def delete_v2_component(component_id: str) -> tuple[None, Literal[204]] | CxResp
 @dbutils.redis_error_handler
 def post_v2_apply_staged() -> tuple[JsonDict, Literal[200]] | CxResponse:
     """Used by the POST /applystaged API operation"""
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("POST /v2/applystaged invoked post_v2_apply_staged")
     try:
         data = get_request_json()

--- a/src/bos/server/controllers/v2/healthz.py
+++ b/src/bos/server/controllers/v2/healthz.py
@@ -26,6 +26,7 @@ from typing import Literal
 
 from bos.common.utils import exc_type_msg
 from bos.server.models.healthz import Healthz
+from bos.server.options import update_server_log_level
 from bos.server import redis_db_utils
 
 DB = redis_db_utils.OptionsDBWrapper()
@@ -53,6 +54,9 @@ def get_v2_healthz() -> tuple[Healthz, Literal[200]]:
 
     :rtype: Healthz
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("GET /v2/healthz invoked get_v2_healthz")
     return Healthz(
         db_status=_get_db_status(),

--- a/src/bos/server/controllers/v2/options.py
+++ b/src/bos/server/controllers/v2/options.py
@@ -22,113 +22,35 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 import logging
-import threading
-import time
-from typing import Literal, NoReturn, cast
+from typing import Literal, cast
 
 from connexion.lifecycle import ConnexionResponse
 
-from bos.common.options import DEFAULTS, OptionsCache
-from bos.common.types.general import JsonDict
-from bos.common.types.options import is_option_name, OptionsDict
+from bos.common.types.options import OptionsDict
 from bos.common.utils import exc_type_msg
 from bos.server import redis_db_utils as dbutils
 from bos.server.controllers.utils import _400_bad_request
+from bos.server.options import DB, get_options, update_server_log_level
 from bos.server.utils import get_request_json
 
 LOGGER = logging.getLogger(__name__)
-DB = dbutils.OptionsDBWrapper()
-
-
-class OptionsData(OptionsCache):
-    """
-    Handler for reading configuration options from the BOS DB
-
-    This caches the options so that frequent use of these options do not all
-    result in DB calls.
-    """
-
-    def _get_options(self) -> OptionsDict:
-        """Retrieves the current options from the BOS DB"""
-        LOGGER.debug("Retrieving options data from BOS DB")
-        try:
-            return _get_v2_options()
-        except Exception as err:
-            LOGGER.error("Error retrieving BOS options: %s", exc_type_msg(err))
-        return {}
-
-
-def _init() -> None:
-    # Start log level updater
-    log_level_updater = threading.Thread(target=check_v2_logging_level,
-                                         args=())
-    log_level_updater.start()
-
-    # Cleanup old options
-    while True:
-        try:
-            data = DB.get_options()
-            break
-        except dbutils.NotFoundInDB:
-            # No old options to clean up
-            return
-        except Exception as err:
-            LOGGER.info('Database is not yet available (%s)',
-                        exc_type_msg(err))
-            time.sleep(1)
-    if not data:
-        # No old options to clean up
-        return
-    data = _clean_options_data(data)
-    DB.put_options(data)
-
 
 @dbutils.redis_error_handler
 def get_v2_options() -> tuple[OptionsDict, Literal[200]]:
     """Used by the GET /options API operation"""
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("GET /v2/options invoked get_v2_options")
-    return _get_v2_options(), 200
-
-
-def _get_v2_options() -> OptionsDict:
-    """
-    Helper function for get_v2_options function and OptionsData class
-    """
-    data = get_v2_options_data()
-    return _clean_options_data(data)
-
-
-def _clean_options_data(data: JsonDict) -> OptionsDict:
-    """Removes keys that are not in the options spec"""
-    return { key: value for key, value in data.items() if is_option_name(key) }
-
-
-def get_v2_options_data() -> OptionsDict:
-    try:
-        option_data = DB.get_options()
-    except dbutils.NotFoundInDB:
-        option_data = None
-    return _check_defaults(option_data)
-
-
-def _check_defaults(data: OptionsDict | None) -> OptionsDict:
-    """Adds defaults to the options data if they don't exist"""
-    put = False
-    if not data:
-        data = {}
-        put = True
-    for key, default_value in DEFAULTS.items():
-        if key not in data:
-            data[key] = default_value
-            put = True
-    if put:
-        DB.put_options(data)
-    return data
+    return get_options(), 200
 
 
 @dbutils.redis_error_handler
 def patch_v2_options() -> tuple[OptionsDict, Literal[200]] | ConnexionResponse:
     """Used by the PATCH /options API operation"""
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("PATCH /v2/options invoked patch_v2_options")
     try:
         patch_data = cast(OptionsDict, get_request_json())
@@ -136,31 +58,9 @@ def patch_v2_options() -> tuple[OptionsDict, Literal[200]] | ConnexionResponse:
         LOGGER.error("Error parsing PATCH request data: %s", exc_type_msg(err))
         return _400_bad_request(f"Error parsing the data provided: {err}")
 
-    options = get_v2_options_data()
+    options = get_options()
     options.update(patch_data)
     DB.put_options(options)
+    if "logging_level" in patch_data:
+        update_server_log_level()
     return options, 200
-
-
-def update_log_level(new_level_str: str) -> None:
-    new_level = logging.getLevelName(new_level_str.upper())
-    current_level = LOGGER.getEffectiveLevel()
-    if current_level != new_level:
-        LOGGER.log(current_level, 'Changing logging level from %s to %s',
-                   logging.getLevelName(current_level), logging.getLevelName(new_level))
-        logger = logging.getLogger()
-        logger.setLevel(new_level)
-        LOGGER.log(new_level, 'Logging level changed from %s to %s',
-                   logging.getLevelName(current_level), logging.getLevelName(new_level))
-
-
-def check_v2_logging_level() -> NoReturn:
-    while True:
-        try:
-            data = get_v2_options_data()
-            if 'logging_level' in data:
-                update_log_level(data['logging_level'])
-        except Exception as err:
-            LOGGER.debug("Error checking or updating log level: %s",
-                         exc_type_msg(err))
-        time.sleep(5)

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -45,10 +45,11 @@ from bos.server import redis_db_utils as dbutils
 from bos.server.controllers.utils import _400_bad_request, _404_tenanted_resource_not_found
 from bos.server.controllers.v2.boot_set import BootSetStatus, validate_boot_sets
 from bos.server.controllers.v2.components import get_v2_components_data
-from bos.server.controllers.v2.options import OptionsData
+from bos.server.options import OptionsData
 from bos.server.controllers.v2.sessiontemplates import get_v2_sessiontemplate
 from bos.server.models.v2_session import V2Session as Session  # noqa: E501
 from bos.server.models.v2_session_create import V2SessionCreate as SessionCreate  # noqa: E501
+from bos.server.options import update_server_log_level
 from bos.server.utils import get_request_json, ParsingException
 
 LOGGER = logging.getLogger(__name__)
@@ -69,6 +70,9 @@ def post_v2_session() -> tuple[SessionRecordT, Literal[201]] | CxResponse:  # no
 
     :rtype: Session
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("POST /v2/sessions invoked post_v2_session")
     # -- Validation --
     try:
@@ -161,6 +165,9 @@ def patch_v2_session(session_id: str) -> tuple[SessionRecordT, Literal[200]] | C
     Returns:
       Session Dictionary, Status Code
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("PATCH /v2/sessions/%s invoked patch_v2_session", session_id)
     try:
         patch_data = cast(SessionUpdateT, get_request_json())
@@ -197,6 +204,9 @@ def get_v2_session(
     Return:
       Session Dictionary, Status Code
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("GET /v2/sessions/%s invoked get_v2_session", session_id)
     tenant = get_tenant_from_header()
     try:
@@ -215,6 +225,9 @@ def get_v2_sessions(min_age: str | None=None, max_age: str | None=None,
 
     List all sessions
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug(
         "GET /v2/sessions invoked get_v2_sessions with min_age=%s max_age=%s status=%s",
         min_age, max_age, status)
@@ -233,6 +246,9 @@ def delete_v2_session(
 
     Delete the session by session id
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("DELETE /v2/sessions/%s invoked delete_v2_session",
                  session_id)
     tenant = get_tenant_from_header()
@@ -250,6 +266,9 @@ def delete_v2_session(
 def delete_v2_sessions(
         min_age: str | None=None, max_age: str | None=None,
         status: str | None=None) -> tuple[None, Literal[204]] | CxResponse:  # noqa: E501
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug(
         "DELETE /v2/sessions invoked delete_v2_sessions with min_age=%s max_age=%s status=%s",
         min_age, max_age, status)
@@ -293,6 +312,9 @@ def get_v2_session_status(
     Return:
       Session Status Dictionary, Status Code
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("GET /v2/sessions/status/%s invoked get_v2_session_status",
                  session_id)
     tenant = get_tenant_from_header()
@@ -323,6 +345,9 @@ def save_v2_session_status(
     Return:
       Session Status Dictionary, Status Code
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("POST /v2/sessions/status/%s invoked save_v2_session_status",
                  session_id)
     tenant = get_tenant_from_header()

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -35,6 +35,7 @@ from bos.common.types.templates import (SessionTemplate,
 from bos.common.utils import exc_type_msg
 from bos.server import redis_db_utils as dbutils
 from bos.server.controllers.utils import _400_bad_request, _404_tenanted_resource_not_found
+from bos.server.options import update_server_log_level
 from bos.server.schema import validator
 from bos.server.utils import get_request_json
 from .boot_set import validate_boot_sets, validate_sanitize_boot_sets
@@ -76,6 +77,9 @@ def put_v2_sessiontemplate(
 
     Creates a new session template. # noqa: E501
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("PUT /v2/sessiontemplates/%s invoked put_v2_sessiontemplate",
                  session_template_id)
     try:
@@ -106,6 +110,9 @@ def get_v2_sessiontemplates() -> tuple[list[SessionTemplate], Literal[200]]:  # 
 
     List all sessiontemplates
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("GET /v2/sessiontemplates invoked get_v2_sessiontemplates")
     tenant=get_tenant_from_header()
     if tenant:
@@ -128,6 +135,9 @@ def get_v2_sessiontemplate(
 
     Get the session template by session template ID
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug("GET /v2/sessiontemplates/%s invoked get_v2_sessiontemplate",
                  session_template_id)
     tenant = get_tenant_from_header()
@@ -143,13 +153,15 @@ def get_v2_sessiontemplate(
     return template, 200
 
 
-@dbutils.redis_error_handler
 def get_v2_sessiontemplatetemplate() -> tuple[SessionTemplate, Literal[200]]:
     """
     GET /v2/sessiontemplatetemplate
 
     Get the example session template
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug(
         "GET /v2/sessiontemplatetemplate invoked get_v2_sessiontemplatetemplate"
     )
@@ -163,6 +175,9 @@ def delete_v2_sessiontemplate(session_template_id: str) -> tuple[None, Literal[2
 
     Delete the session template by session template ID
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug(
         "DELETE /v2/sessiontemplates/%s invoked delete_v2_sessiontemplate",
         session_template_id)
@@ -188,6 +203,9 @@ def patch_v2_sessiontemplate(
 
     Patch the session template by session template ID
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug(
         "PATCH /v2/sessiontemplates/%s invoked patch_v2_sessiontemplate",
         session_template_id)
@@ -229,6 +247,9 @@ def validate_v2_sessiontemplate(
     Validate a V2 session template. Look for missing elements or errors that would prevent
     a session from being launched using this template.
     """
+    # For all entry points into the server, first refresh options and update log level if needed
+    update_server_log_level()
+
     LOGGER.debug(
         "GET /v2/sessiontemplatesvalid/%s invoked validate_v2_sessiontemplate",
         session_template_id)

--- a/src/bos/server/options.py
+++ b/src/bos/server/options.py
@@ -1,0 +1,169 @@
+#
+# MIT License
+#
+# (C) Copyright 2019, 2021-2022, 2024-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+import logging
+import threading
+import time
+
+from bos.common.options import DEFAULTS, OptionsCache
+from bos.common.types.general import JsonDict
+from bos.common.types.options import OptionsDict, is_option_name
+from bos.common.utils import exc_type_msg, do_update_log_level
+import bos.server.redis_db_utils as dbutils
+
+LOGGER = logging.getLogger(__name__)
+
+LogLevelUpdateLock = threading.Lock()
+
+DB = dbutils.OptionsDBWrapper()
+
+class OptionsData(OptionsCache):
+    """
+    Handler for reading configuration options from the BOS DB
+
+    This caches the options so that frequent use of these options do not all
+    result in DB calls.
+    """
+
+    _create_lock = threading.Lock()
+
+    def __new__(cls):
+        """This override makes the class a singleton"""
+        if not hasattr(cls, 'instance'):
+            # Make sure that no other thread has beaten us to the punch
+            with cls._create_lock:
+                if not hasattr(cls, 'instance'):
+                    new_instance = super().__new__(cls)
+                    new_instance.__init__(_initialize=True)
+                    # Only assign to cls.instance after all work has been done, to ensure
+                    # no other threads access it prematurely
+                    cls.instance = new_instance
+        return cls.instance
+
+    def __init__(self, _initialize: bool=False):
+        """
+        We only want this singleton to be initialized once
+        """
+        if _initialize:
+            super().__init__()
+
+    def _get_options(self) -> OptionsDict:
+        """Retrieves the current options from the BOS DB"""
+        LOGGER.debug("Retrieving options data from BOS DB")
+        try:
+            return get_options()
+        except Exception as err:
+            LOGGER.error("Error retrieving BOS options: %s", exc_type_msg(err))
+        # Continue using current option values
+        return self.options
+
+
+def _cleanup_old_options() -> None:
+    """
+    Cleanup old options
+    """
+    while True:
+        try:
+            data = DB.get_options()
+            break
+        except dbutils.NotFoundInDB:
+            # No old options to clean up
+            return
+        except Exception as err:
+            LOGGER.info('Database is not yet available (%s)',
+                        exc_type_msg(err))
+            time.sleep(1)
+    if not data:
+        # No old options to clean up
+        return
+    data = remove_invalid_keys(data)
+    DB.put_options(data)
+
+
+def _init() -> None:
+    """
+    Called by bos.server.__main__ on server startup
+    """
+    _cleanup_old_options()
+    update_server_log_level()
+
+
+def remove_invalid_keys(data: JsonDict) -> OptionsDict:
+    """Removes keys that are not in the options spec"""
+    return { key: value for key, value in data.items() if is_option_name(key) }
+
+
+def get_options() -> OptionsDict:
+    """
+    Helper function for OptionsData class
+    """
+    data = get_v2_options_data()
+    return remove_invalid_keys(data)
+
+
+def get_v2_options_data() -> OptionsDict:
+    """
+    Load the options from the BOS database, and then fill in
+    default values
+    """
+    try:
+        option_data = DB.get_options()
+    except dbutils.NotFoundInDB:
+        option_data = None
+    return _check_defaults(option_data)
+
+
+def _check_defaults(data: OptionsDict | None) -> OptionsDict:
+    """Adds defaults to the options data if they don't exist"""
+    put = False
+    if not data:
+        data = {}
+        put = True
+    for key, default_value in DEFAULTS.items():
+        if key not in data:
+            data[key] = default_value
+            put = True
+    if put:
+        DB.put_options(data)
+    return data
+
+
+def update_server_log_level() -> None:
+    """
+    Refresh BOS options and update the log level for this process, if needed
+    """
+    options_data.update()
+    desired_level_str = options_data.logging_level.upper()
+    desired_level_int = logging.getLevelName(desired_level_str)
+    current_level_int = LOGGER.getEffectiveLevel()
+    if current_level_int == desired_level_int:
+        # No update needed
+        return
+    # Take a lock to prevent multiple threads from doing this
+    with LogLevelUpdateLock:
+        if current_level_int != desired_level_int:
+            do_update_log_level(current_level_int, desired_level_int, desired_level_str)
+
+
+# Other server code which needs to read BOS options should import and use this dict
+options_data = OptionsData()


### PR DESCRIPTION
This PR fixes two logging bugs in BOS.

The first one is minor, and is very similar to the bug fixed by [CASMCMS-9330](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9330). When the BOS operators detect a new logging level and change it, the log messages they write specify the new log level as an integer, not as a string. This PR corrects that.

The second issue is a bigger deal, but has actually been present in BOS for a long time. Specifically, the BOS server does not update its logging level dynamically. It thinks that it does -- it starts up a thread that periodically checks it and updates it. However, that thread is started by BOS in the main server startup code. The problem is, that code only starts up the thread in one of the BOS processes in any given pod. But BOS is multiprocess, and no such thread is started for most of the BOS processes. If you look at the BOS server pod logs after changing the log level, you will only see one set of messages reporting the log level change, even though there are multiple BOS server processes. So for most BOS server processes, they will continue to use whatever the BOS log level was at the time that the server started. And you can tell this is happening by running BOS requests which should generate specific log messages, and verifying that they do not show up if the expected log level is one that would not have been logged at the time the server started.

Because the BOS server code entry points are through endpoint functions, this PR adds calls to all of the endpoints, to check the log level. This means that we don't have a background process updating the log level needlessly. I have tested on mug and verified that with this change, the log level changes are correctly propagated for all server processes.

The PR touches a lot of files, but mostly because:
1. I refactored some of the code that was currently in the options endpoint controller, moving it to bos.server.options, requiring a bunch of imports to be updated to point to the new location.
2. I had to add the `update_server_log_level` call to the front of each endpoint function. I considered doing this with a decorator, but it didn't seem like that offered a lot of benefit -- either way, it's one new line of code per function.
3. I consolidated some common "log update" code from the operator side and the server side, to avoid cases like the first bug in this ticket, where a problem is fixed in one place but not the other

As part of the refactoring, I also made the OptionsData class a singleton, to mirror what is done for [the corresponding CFS class](https://github.com/Cray-HPE/config-framework-service/blob/acbee532fab89a1455f7795ee0fc12297f3796b9/src/server/cray/cfs/api/controllers/options.py#L138), to make its initialization thread safe.
