### PR TITLE
CASMCMS-9357: Make compact_response_text more efficient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9357: Made compact_response_text more memory efficient by using iterators. Made
+  it more processor efficient by converting it into a class with a __str__ method, so that
+  when it is used with logging functions, its code does not get executed unless the associated
+  log entry is actually going to be recorded.
+
 ## [2.38.1] - 2025-04-11
 
 ### Fixed


### PR DESCRIPTION
Recently while working on other BOS tickets, I added some additional debug logging statements, and on mug I noticed that this resulted in some OOM errors for some operator pods. mug does have more nodes than we have ever tested in the field, and so it is unsurprising that some of the API responses it receives are larger than normal. But we use the `compact_response_text` function to reduce the size of this data when we log it. And interestingly, the OOM issues only happened when I added the calls to log the responses -- the responses were being handled fine otherwise. This caused me to look closer at compact_response_text, and I realized it was inefficient in two ways.

First, the primary cause of the OOM issues is that it is very memory inefficient. It starts by calling the `split` function on the response text, which returns a gigantic list of strings. It then calls `strip()` on each of these strings and stores the result in another list, which it then calls `join` on. 

Second, it occurred to me that in the ordinary course of execution, debug logging is not enabled, and we pretty much only ever log this kind of data at the debug level. So all of the processing done in this function is wasted when we are not doing debug logging. But because of how we are calling the logging functions, the work is all done before we find out it isn't needed.

This PR addresses both issues.

For the first issue, I realized that everything being done could instead be replaced by iterators/generators, so that it wouldn't need to create these massive intermediate objects.

For the second issue, I realized we could change it from a function to a class. The class would take the same argument as the function (the response string), but we would move all of the work into the `__str__` method of the class. This is what Python ends up calling when you need to format it as a string. But because of how Python logging works, as long as you use the lazy evaluation style of string formatting, this `__str__` method will never get called except when we are actually logging the result. (This is why Python linters generally scold you for not using f-strings except when it comes to logging, where it scolds you for not using lazy string evaluation)

I tested this on bug and it works beautifully.