### PR TITLE
CASMCMS-9353: Improve exception logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it more processor efficient by converting it into a class with a __str__ method, so that
   when it is used with logging functions, its code does not get executed unless the associated
   log entry is actually going to be recorded.
+- CASMCMS-9353: Improve exception logging
 
 ## [2.38.1] - 2025-04-11
 

--- a/src/bos/common/clients/endpoints/base_generic_endpoint.py
+++ b/src/bos/common/clients/endpoints/base_generic_endpoint.py
@@ -26,6 +26,8 @@ import logging
 
 import requests
 
+from bos.common.utils import compact_response_text
+
 from .defs import RequestData, RequestsMethod
 from .exceptions import ApiResponseError
 from .request_error_handler import BaseRequestErrorHandler, RequestErrorHandler
@@ -93,6 +95,8 @@ class BaseGenericEndpoint[RequestReturnT](ABC):
                  **kwargs) -> RequestReturnT:
         """Make API request"""
         with method(url, **kwargs) as response:
+            LOGGER.debug("Response status code=%d, reason=%s, body=%s", response.status_code,
+                 response.reason, compact_response_text(response.text))
             if not response.ok:
                 raise ApiResponseError(response=response)
             return cls.format_response(response)

--- a/src/bos/operators/base.py
+++ b/src/bos/operators/base.py
@@ -180,7 +180,7 @@ class BaseOperator(ABC):
                     self._client = _client
                     self._run()
             except Exception as e:
-                LOGGER.exception('Unhandled exception detected: %s', e)
+                LOGGER.exception('Unhandled exception detected: %s', exc_type_msg(e))
             finally:
                 # We have exited the context manager, so make sure to reset the client
                 # value for this operator
@@ -193,7 +193,7 @@ class BaseOperator(ABC):
                     time.sleep(sleep_time)
             except Exception as e:
                 LOGGER.exception(
-                    'Unhandled exception getting polling frequency: %s', e)
+                    'Unhandled exception getting polling frequency: %s', exc_type_msg(e))
                 time.sleep(
                     5
                 )  # A small sleep for when exceptions getting the polling frequency
@@ -247,7 +247,7 @@ class BaseOperator(ABC):
         except Exception as e:
             LOGGER.error(
                 "An unhandled exception was caught while trying to act on components: %s",
-                e,
+                exc_type_msg(e),
                 exc_info=True)
             for component in components:
                 component["error"] = str(e)

--- a/src/bos/operators/filters/base.py
+++ b/src/bos/operators/filters/base.py
@@ -26,6 +26,7 @@ from abc import ABC, abstractmethod
 import logging
 
 from bos.common.types.components import ComponentRecord
+from bos.common.utils import exc_type_msg
 
 LOGGER = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ class BaseFilter[T](ABC):
             if components or self.INITIAL:
                 results = self.filter_components(components)
         except Exception as e:
-            LOGGER.exception(e)
+            LOGGER.exception(exc_type_msg(e))
         LOGGER.debug('%s filter found the following components: %s', type(self).__name__,
                      ','.join(self.component_list_to_id_list(results)))
         return results

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -75,25 +75,25 @@ class PowerOnOperator(BaseOperator):
         try:
             self._tag_images(boot_artifacts, components)
         except Exception as e:
-            raise Exception(f"Error encountered tagging images {e}.") from e
+            raise Exception(f"Error encountered tagging images {exc_type_msg(e)}.") from e
         try:
             self._set_bss(boot_artifacts, bos_sessions=sessions)
         except Exception as e:
             raise Exception(
-                f"Error encountered setting BSS information: {e}") from e
+                f"Error encountered setting BSS information: {exc_type_msg(e)}") from e
         try:
             self.client.cfs.components.set_cfs(components,
                                                enabled=False,
                                                clear_state=True)
         except Exception as e:
             raise Exception(
-                f"Error encountered setting CFS information: {e}") from e
+                f"Error encountered setting CFS information: {exc_type_msg(e)}") from e
         component_ids = [component['id'] for component in components]
         try:
             self.client.pcs.transitions.power_on(component_ids)
         except Exception as e:
             raise Exception(
-                f"Error encountered calling CAPMC to power on: {e}") from e
+                f"Error encountered calling CAPMC to power on: {exc_type_msg(e)}") from e
         return components
 
     def _sort_components_by_boot_artifacts(
@@ -278,7 +278,7 @@ class PowerOnOperator(BaseOperator):
                                                  "true")
             except Exception as e:
                 self._record_component_errors(my_components_by_id, image_id_to_nodes[image],
-                                              str(e))
+                                              exc_type_msg(e))
 
     def _record_component_errors(self, my_components_by_id: dict[str, ComponentRecord],
                                  component_set: set[str], err_msg: str) -> None:

--- a/src/bos/operators/session_setup.py
+++ b/src/bos/operators/session_setup.py
@@ -144,6 +144,7 @@ class Session:
             if not all_component_ids:
                 raise SessionSetupException("No nodes were found to act upon.")
         except Exception as err:
+            self._log(LOGGER.debug, exc_type_msg(err))
             raise SessionSetupException(err) from err
         # No exception raised by previous block
         self._log(LOGGER.info, 'Found %d components that require updates',

--- a/src/bos/server/controllers/v2/boot_set/ims.py
+++ b/src/bos/server/controllers/v2/boot_set/ims.py
@@ -21,6 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+import logging
 
 from bos.common.clients.ims import (get_arch_from_image_data,
                                     get_ims_id_from_s3_url,
@@ -34,6 +35,10 @@ from bos.server.options import OptionsData
 from .defs import DEFAULT_ARCH
 from .exceptions import BootSetArchMismatch, BootSetError, BootSetWarning, \
                         CannotValidateBootSetArch, NonImsImage
+
+
+LOGGER = logging.getLogger(__name__)
+
 
 # Mapping from BOS boot set arch values to expected IMS image arch values
 # Omits BOS Other value, since there is no corresponding IMS image arch value
@@ -64,6 +69,7 @@ def validate_ims_boot_image(bs: JsonDict, options_data: OptionsData) -> None:
             raise BootSetError(str(err)) from err
         raise BootSetWarning(str(err)) from err
     except Exception as err:
+        LOGGER.debug(exc_type_msg(err))
         if options_data.ims_errors_fatal:
             raise BootSetError(exc_type_msg(err)) from err
         if bs_arch != 'Other':
@@ -81,6 +87,7 @@ def validate_ims_boot_image(bs: JsonDict, options_data: OptionsData) -> None:
         ims_image_arch = get_arch_from_image_data(image_data)
     except Exception as err:
         # This most likely indicates that the IMS image data we got wasn't even a dict
+        LOGGER.debug(exc_type_msg(err))
         if options_data.ims_errors_fatal:
             raise BootSetError(exc_type_msg(err)) from err
         raise BootSetWarning(str(err)) from err

--- a/src/bos/server/redis_db_utils/redis_error_handler.py
+++ b/src/bos/server/redis_db_utils/redis_error_handler.py
@@ -33,6 +33,8 @@ from typing import ParamSpec, TypeVar
 import connexion
 import redis
 
+from bos.common.utils import exc_type_msg
+
 LOGGER = logging.getLogger(__name__)
 
 P = ParamSpec('P')
@@ -50,7 +52,7 @@ def redis_error_handler(func: Callable[P, R]) -> Callable[P, R]:
                 del kwargs['body']
             return func(*args, **kwargs)
         except redis.exceptions.ConnectionError as e:
-            LOGGER.error('Unable to connect to the Redis database: %s', e)
+            LOGGER.error('Unable to connect to the Redis database: %s', exc_type_msg(e))
             return connexion.problem(
                 status=503,
                 title='Unable to connect to the Redis database',


### PR DESCRIPTION
When debugging [CASMTRIAGE-8072](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8072) it was discovered that when the session setup operator received a 404, it did not log all of the relevant information included with the exception (in this case, the item which was not found). This made debugging more challenging. See that ticket for full context.

That ticket was found on CSM 1.5, and some parts of that problem have already been addressed in CSM 1.7. This PR makes a few tweaks to the BOS server and operator logging to help capture problems when debugging. I have tested it on mug.