### PR TITLE
CASMCMS-9346: Improve type annotations for BOS components controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9346: Improved type annotations for BOS components controller
+
 ## [2.39.0] - 2025-04-14
 
 ### Changed

--- a/src/bos/common/types/components.py
+++ b/src/bos/common/types/components.py
@@ -36,18 +36,13 @@ class ComponentStatus(TypedDict, total=False):
     status: str
     status_override: str
 
-class BootArtifacts(TypedDict, total=True):
+class BootArtifacts(TypedDict, total=False):
     """
     #/components/schemas/V2BootArtifacts
     """
-    kernel: str
-    kernel_parameters: str
-    initrd: str
-
-class TimestampedBootArtifacts(BootArtifacts, TypedDict, total=True):
-    """
-    When storing the boot artifacts in the database, there is an additional timestamp field
-    """
+    kernel: Required[str]
+    kernel_parameters: Required[str]
+    initrd: Required[str]
     timestamp: str
 
 class ComponentLastAction(TypedDict, total=False):
@@ -168,6 +163,9 @@ def update_component_record(
     # Make a copy, to avoid changing new_record in place
     # Cast it as ComponentData, since that will just have the effect of making the 'id' field optional
     new_record_copy = cast(ComponentData, copy.deepcopy(new_record))
+
+    # Pop the 'id' field, if present
+    new_record_copy.pop("id", None)
 
     # Merge the state dicts -- this is not done in a loop because mypy gets confused keeping track
     # of string literal values in loops

--- a/src/bos/server/dbs/boot_artifacts.py
+++ b/src/bos/server/dbs/boot_artifacts.py
@@ -23,7 +23,7 @@
 #
 import logging
 
-from bos.common.types.components import TimestampedBootArtifacts
+from bos.common.types.components import BootArtifacts
 from bos.common.utils import get_current_timestamp
 from bos.server.redis_db_utils import BootArtifactsDBWrapper, NotFoundInDB
 
@@ -51,16 +51,11 @@ def record_boot_artifacts(token: str, kernel: str, kernel_parameters: str,
         "Logging BSS token and boot artifacts: token='%s' kernel='%s' "
         "kernel_parameters='%s' initrd='%s'", token, kernel, kernel_parameters,
         initrd)
-    TOKENS_DB.put(
-        token, {
-            "kernel": kernel,
-            "kernel_parameters": kernel_parameters,
-            "initrd": initrd,
-            "timestamp": get_current_timestamp()
-        })
+    boot_artifacts = BootArtifacts(kernel=kernel, kernel_parameters=kernel_parameters, initrd=initrd, timestamp=get_current_timestamp())
+    TOKENS_DB.put(token, boot_artifacts)
 
 
-def get_boot_artifacts(token: str) -> TimestampedBootArtifacts:
+def get_boot_artifacts(token: str) -> BootArtifacts:
     """
     Get the boot artifacts associated with a BSS token.
 

--- a/src/bos/server/redis_db_utils/boot_artifacts_dbwrapper.py
+++ b/src/bos/server/redis_db_utils/boot_artifacts_dbwrapper.py
@@ -27,22 +27,22 @@ BootArtifactsDBWrapper class
 
 from typing import cast
 
-from bos.common.types.components import TimestampedBootArtifacts
+from bos.common.types.components import BootArtifacts
 from bos.common.types.general import JsonDict
 
 from .dbwrapper import DBWrapper
 from .defs import Databases
 
-class BootArtifactsDBWrapper(DBWrapper[TimestampedBootArtifacts]):
+class BootArtifactsDBWrapper(DBWrapper[BootArtifacts]):
     """
     Boot artifacts database wrapper
     """
 
     _Database = Databases.BSS_TOKENS_BOOT_ARTIFACTS
 
-    def _jsondict_to_bosdata(self, key: str, jsondict: JsonDict, /) -> TimestampedBootArtifacts:
+    def _jsondict_to_bosdata(self, key: str, jsondict: JsonDict, /) -> BootArtifacts:
         """
         Eventually this should probably actually make sure that the record being returned is in the
         correct format. But for now, we'll just satisfy mypy
         """
-        return cast(TimestampedBootArtifacts, jsondict)
+        return cast(BootArtifacts, jsondict)

--- a/src/bos/server/redis_db_utils/dbwrapper.py
+++ b/src/bos/server/redis_db_utils/dbwrapper.py
@@ -194,10 +194,10 @@ class DBWrapper(SpecificDatabase, Generic[DataT], ABC):
         """
         return dict(self.iter_items_raw())
 
-    def get_all_filtered(self,
-                         filter_func: Callable[[DataT], DataT | None], *,
+    def get_all_filtered[OutDataT](self,
+                         filter_func: Callable[[DataT], OutDataT | None], *,
                          start_after_key: str | None = None,
-                         page_size: int = 0) -> list[DataT]:
+                         page_size: int = 0) -> list[OutDataT]:
         """
         Get an array of data for all keys after passing them through the specified filter
         (discarding any for which the filter returns None)

--- a/src/bos/server/redis_db_utils/defs.py
+++ b/src/bos/server/redis_db_utils/defs.py
@@ -28,7 +28,7 @@ Definitions for redis_db_utils modules
 from enum import IntEnum
 from typing import TypeVar
 
-from bos.common.types.components import ComponentRecord, TimestampedBootArtifacts
+from bos.common.types.components import BootArtifacts, ComponentRecord
 from bos.common.types.options import OptionsDict
 from bos.common.types.sessions import Session
 from bos.common.types.session_extended_status import SessionExtendedStatus
@@ -49,4 +49,5 @@ DB_HOST = 'cray-bos-db'
 DB_PORT = 6379
 
 # The decoded data formats for the different BOS databases
-BosDataRecord = TypeVar("BosDataRecord", ComponentRecord, OptionsDict, Session, SessionExtendedStatus, SessionTemplate, TimestampedBootArtifacts)
+BosDataRecord = TypeVar("BosDataRecord", BootArtifacts, ComponentRecord, OptionsDict,
+                        Session, SessionExtendedStatus, SessionTemplate)


### PR DESCRIPTION
Modify the V2 controller code for components endpoints to make better use of type annotations.
Also minor refactoring and linting of same.
As part of this, I slightly adjusted the boot artifacts `TypedDict`s, to stop distinguishing between those with and without timestamp fields. Because of how `mypy` handles `TypedDict`s, you can't just have one inherit from another, making an optional parent class field to be required in the child class (which is what ideally we should do with boot artifacts and the timestamp field). See https://github.com/python/mypy/issues/7435
