### PR TITLE
CASMCMS-9362: Refactor components bulk patch functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - CASMCMS-9346: Improved type annotations for BOS components controller
+- CASMCMS-9362: Refactor components bulk patch functions
 
 ## [2.39.0] - 2025-04-14
 

--- a/src/bos/server/controllers/utils.py
+++ b/src/bos/server/controllers/utils.py
@@ -32,6 +32,28 @@ import flask
 LOGGER = logging.getLogger(__name__)
 
 
+class BadRequest(Exception):
+    """
+    Generic error to use for problems with API requests
+    """
+
+
+class ResourceNotFound(Exception):
+    """
+    A resource needed for an API request was not found.
+    """
+
+    RESOURCE_TYPE: str = "Resource"
+
+    def __init__(self, resource_id: str):
+        self._resource_id = resource_id
+        super().__init__(f"{self.RESOURCE_TYPE} not found: {resource_id}")
+
+    @property
+    def resource_id(self) -> str:
+        return self._resource_id
+
+
 def url_for(endpoint: str, **values) -> str:
     """Calculate the URL for an endpoint
 


### PR DESCRIPTION
The fix for [CASMCMS-9355](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9355) is going to require some changes to the procedure used for bulk component updates. Trying to do that the way the functions currently work is going to result in a mess. This PR refactors the bulk component patch functions. It doesn't change the current behavior (beyond perhaps the exact wording of some log and error messages), but it will make the changes needed for CASMCMS-9355 much easier and cleaner.

Basically, this PR moves the actual patching itself into the main bulk patch function. The two main child functions are now responsible for providing the parent function with the current component data, and the patch data for those components. Missing components are now signaled by a specific new exception being raised. This is important, because CASMCMS-9355 deals with how such cases are handled.