### PR TITLE
CASMCMS-9381: Add skip_bad_ids parameter to bulk components patch endopoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - CASMCMS-9346: Improved type annotations for BOS components controller
 - CASMCMS-9362: Refactor components bulk patch functions
+- CASMCMS-9355: Use new `skip_bad_ids` parameter in session setup operator, to gracefully
+  handle the case where bad IDs are included in the session.
 
 ## [2.39.0] - 2025-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CASMCMS-9381: Add `skip_bad_ids` parameter to bulk components patch endpoint.
+
 ### Changed
 - CASMCMS-9346: Improved type annotations for BOS components controller
 - CASMCMS-9362: Refactor components bulk patch functions

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1845,6 +1845,19 @@ paths:
           $ref: '#/components/responses/BadRequest'
     patch:
       summary: Update a collection of Components
+      parameters:
+        - name: skip_bad_ids
+          schema:
+            type: boolean
+            default: false
+          in: query
+          description: |-
+            If false, if the patch request explicitly lists a BOS component ID that
+            does not exist, it will be considered a fatal error. The patch operation
+            will fail and return a 404 status.
+            If true, the patch request will skip any IDs that do not exist, and
+            patch the remaining items. The response will only include the components
+            that were actually updated.
       description: Update the state for a collection of Components in the BOS database
       tags:
         - v2

--- a/src/bos/common/clients/bos/base.py
+++ b/src/bos/common/clients/bos/base.py
@@ -61,9 +61,12 @@ class BaseBosNonTenantAwareEndpoint(BaseBosEndpoint, ABC):
         """Update information for a single BOS item"""
         return self.patch(uri=item_id, json=data)
 
-    def update_items(self, data):
+    def update_items(self, data, **params):
         """Update information for multiple BOS items"""
-        return self.patch(json=data)
+        kwargs = { "json": data }
+        if params:
+            kwargs["params"] = params
+        return self.patch(**kwargs)
 
     def put_items(self, data):
         """Put information for multiple BOS Items"""
@@ -100,11 +103,13 @@ class BaseBosTenantAwareEndpoint(BaseBosEndpoint, ABC):
             kwargs["headers"] = get_new_tenant_header(tenant)
         return self.patch(**kwargs)
 
-    def update_items(self, tenant, data):
+    def update_items(self, tenant, data, **params):
         """Update information for multiple BOS items"""
         kwargs = { "json": data }
         if tenant:
             kwargs["headers"] = get_new_tenant_header(tenant)
+        if params:
+            kwargs["params"] = params
         return self.patch(**kwargs)
 
     def post_item(self, item_id, tenant, data=None):

--- a/src/bos/common/clients/bos/components.py
+++ b/src/bos/common/clients/bos/components.py
@@ -52,8 +52,9 @@ class ComponentEndpoint(BaseBosNonTenantAwareEndpoint):
     def update_component(self, component_id, data):
         return self.update_item(component_id, data)
 
-    def update_components(self, data):
-        return self.update_items(data)
+    def update_components(self, data, skip_bad_ids: bool | None=None):
+        params = {} if skip_bad_ids is None else { "skip_bad_ids": skip_bad_ids }
+        return self.update_items(data, **params)
 
     def put_components(self, data):
         return self.put_items(data)

--- a/src/bos/server/redis_db_utils/dbwrapper.py
+++ b/src/bos/server/redis_db_utils/dbwrapper.py
@@ -233,6 +233,14 @@ class DBWrapper(SpecificDatabase, Generic[DataT], ABC):
                 raise NotFoundInDB(db=self.db, key=key_sublist[none_index])
         return { key: self._load_bosdata(key, data) for key, data in zip(keys, raw_data_list) }
 
+    def mget_skip_bad_keys(self, keys: Iterable[str], /) -> dict[str, DataT]:
+        """
+        Returns a mapping from the specified keys to the corresponding BOS data records.
+        Omits from the mapping any keys which do not exist in the DB.
+        """
+        raw_data_list: list[Any] = cast(list[Any], self.client.mget(keys))
+        return { key: self._load_bosdata(key, data) for key, data in zip(keys, raw_data_list) if data is not None }
+
     def mput(self, key_data_map: dict[str, DataT] | dict[str, JsonDict], /) -> None:
         """
         JSON-encode all data and then write each item to the database under its respective key


### PR DESCRIPTION
The problem being solved with [CASMCMS-9355](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9355) is that it is possible for the session setup operator to process a session and come up with a list of invalid component IDs that it should include. When it attempts to patch those components in BOS, the fact that some of them do not exist causes the patch request to fail, which breaks the session setup operator.

The simplest solution is to have BOS treat such components the same way it does for other cases (like the component being disabled in HSM) -- just to filter it out and not include it in the session. Doing this inside the operator itself is the natural thought, but it turns out to be easier to just make this part of the patch operation. Especially on larger scale systems, this will be much more efficient.

This PR adds a new option that can be specified when doing a patch component update -- `skip_bad_ids`. This defaults to False, which preserves the current behavior, and thus retains backward compatibility.

If this option is specified, then the bulk PATCH will basically pretend that the invalid IDs were not specified in the first place. It will only patch the remaining IDs (if any).

Currently I do not plan to expose this new option to the CLI, because the use case for it is not something that I think is likely to be useful at the command line. That said, it would be easy enough for us to add later, if requested.

This PR only adds the new option to the endpoint, but does not modify anything to use it. That last piece will come in the PR for CASMCMS-9355 itself.