### PR TITLE
CASMCMS-9355: Update session setup operator to gracefully handle invalid components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - CASMCMS-9346: Improved type annotations for BOS components controller
 - CASMCMS-9362: Refactor components bulk patch functions
+- CASMCMS-9355: Use new `skip_bad_ids` parameter in session setup operator, to gracefully
+  handle the case where bad IDs are included in the session.
 
 ## [2.39.0] - 2025-04-14
 

--- a/src/bos/common/clients/bos/base.py
+++ b/src/bos/common/clients/bos/base.py
@@ -61,9 +61,12 @@ class BaseBosNonTenantAwareEndpoint(BaseBosEndpoint, ABC):
         """Update information for a single BOS item"""
         return self.patch(uri=item_id, json=data)
 
-    def update_items(self, data):
+    def update_items(self, data, **params):
         """Update information for multiple BOS items"""
-        return self.patch(json=data)
+        kwargs = { "json": data }
+        if params:
+            kwargs["params"] = params
+        return self.patch(**kwargs)
 
     def put_items(self, data):
         """Put information for multiple BOS Items"""
@@ -100,11 +103,13 @@ class BaseBosTenantAwareEndpoint(BaseBosEndpoint, ABC):
             kwargs["headers"] = get_new_tenant_header(tenant)
         return self.patch(**kwargs)
 
-    def update_items(self, tenant, data):
+    def update_items(self, tenant, data, **params):
         """Update information for multiple BOS items"""
         kwargs = { "json": data }
         if tenant:
             kwargs["headers"] = get_new_tenant_header(tenant)
+        if params:
+            kwargs["params"] = params
         return self.patch(**kwargs)
 
     def post_item(self, item_id, tenant, data=None):

--- a/src/bos/common/clients/bos/components.py
+++ b/src/bos/common/clients/bos/components.py
@@ -52,8 +52,9 @@ class ComponentEndpoint(BaseBosNonTenantAwareEndpoint):
     def update_component(self, component_id, data):
         return self.update_item(component_id, data)
 
-    def update_components(self, data):
-        return self.update_items(data)
+    def update_components(self, data, skip_bad_ids: bool | None=None):
+        params = {} if skip_bad_ids is None else { "skip_bad_ids": skip_bad_ids }
+        return self.update_items(data, **params)
 
     def put_components(self, data):
         return self.put_items(data)


### PR DESCRIPTION
The `skip_bad_ids` parameter for bulk component patching is added with https://github.com/Cray-HPE/bos/pull/493.

With that in place, this PR modifies the session setup operator to make use of it.

Without this PR, if the session setup operator finds a session that includes invalid components, the attempt to patch the component fails, and it breaks the operator. See [CASMCMS-9355](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9355) for full details.

One might argue this should have been filtered out earlier, when the session was created, but unfortunately this is not possible. In the case where this bug was found, the issue was that the session template included an HSM group, and that group included invalid IDs. While it would be possible to validate that when the session is created (and this may be desirable), it does not completely prevent the problem. This is because the HSM group could be changed after the session is first created, and thus it would still be possible for the setup operator to encounter this.

This PR instead just filters out the bad components during the patch operation, essentially just like the session setup operator already does for other invalid components (like ones that are disabled in HSM, or ones that have the wrong hardware architecture). In those cases, the overall session does not fail, it just does not include those components. This PR makes it do the same thing for invalid components -- the patch operation is now called with the new `skip_bad_ids` parameter set to True, and this results in any invalid components being automatically omitted from the patch. And the session setup operator need only look at the response from the patch operation to figure out which components were actually patched (and thus, which ones are actually part of the session).