### PR TITLE
CASMCMS-9383: tenant_utils: Resolve mypy complaints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9383: tenant_utils: Resolve mypy type complaints
+
 ## [2.40.0] - 2025-04-23
 
 ### Added


### PR DESCRIPTION
`mypy` was reporting a bunch of errors inside the `get_tenant_component_set` function, because of uncertainty around the types that may be encountered in the response from TAPMS. This just adds explicit type annotations to reflect the format we expect the TAPMS response to have,