### PR TITLE
CASMCMS-9385: Resolve mypy complaints in HSM and IMS clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- CASMCMS-9383: tenant_utils: Resolve mypy type complaints
+- CASMCMS-9382: Resolve mypy type complaints
+  - CASMCMS-9383: tenant_utils
+  - CASMCMS-9385: HSM and IMS clients
 
 ## [2.40.0] - 2025-04-23
 

--- a/src/bos/common/clients/hsm/base.py
+++ b/src/bos/common/clients/hsm/base.py
@@ -23,13 +23,14 @@
 #
 from abc import ABC
 from json import JSONDecodeError
+from typing import cast
 
 from requests.exceptions import HTTPError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from urllib3.exceptions import MaxRetryError
 
 from bos.common.clients.endpoints import ApiResponseError, BaseEndpoint, RequestsMethod
-from bos.common.types.general import JsonData
+from bos.common.types.general import JsonData, JsonDict
 from bos.common.utils import PROTOCOL
 
 from .exceptions import HWStateManagerException
@@ -38,7 +39,7 @@ SERVICE_NAME = 'cray-smd'
 ENDPOINT = f"{PROTOCOL}://{SERVICE_NAME}/hsm/v2"
 
 
-class BaseHsmEndpoint(BaseEndpoint, ABC):
+class BaseHsmEndpoint[ListDataT](BaseEndpoint, ABC):
     """
     This base class provides generic access to the HSM API.
     The individual endpoint needs to be overridden for a specific endpoint.
@@ -57,5 +58,7 @@ class BaseHsmEndpoint(BaseEndpoint, ABC):
                 JSONDecodeError, MaxRetryError) as err:
             raise HWStateManagerException(err) from err
 
-    def list(self, params=None):
-        return self.get(params=params)
+    def get_list(
+        self, params: JsonDict|None=None
+    ) -> ListDataT:
+        return cast(ListDataT, self.get(params=params))

--- a/src/bos/common/clients/hsm/groups.py
+++ b/src/bos/common/clients/hsm/groups.py
@@ -21,8 +21,10 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
 from .base import BaseHsmEndpoint
+from .types import Group
 
 
-class GroupsEndpoint(BaseHsmEndpoint):
+class GroupsEndpoint(BaseHsmEndpoint[list[Group]]):
     ENDPOINT = 'groups'

--- a/src/bos/common/clients/hsm/inventory.py
+++ b/src/bos/common/clients/hsm/inventory.py
@@ -49,7 +49,7 @@ class Inventory:
     @property
     def groups(self):
         if self._groups is None:
-            data = self.hsm_client.groups.list()
+            data = self.hsm_client.groups.get_list()
             groups = {}
             for group in data:
                 groups[group['label']] = set(
@@ -60,7 +60,7 @@ class Inventory:
     @property
     def partitions(self):
         if self._partitions is None:
-            data = self.hsm_client.partitions.list()
+            data = self.hsm_client.partitions.get_list()
             partitions = {}
             for partition in data:
                 partitions[partition['name']] = set(
@@ -74,7 +74,7 @@ class Inventory:
             params = {}
             if self._partition:
                 params['partition'] = self._partition
-            data = self.hsm_client.state_components.list(params=params)
+            data = self.hsm_client.state_components.get_list(params=params)
             roles = defaultdict(set)
             for component in data['Components']:
                 role = ''

--- a/src/bos/common/clients/hsm/partitions.py
+++ b/src/bos/common/clients/hsm/partitions.py
@@ -21,8 +21,10 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
 from .base import BaseHsmEndpoint
+from .types import Partition
 
 
-class PartitionsEndpoint(BaseHsmEndpoint):
+class PartitionsEndpoint(BaseHsmEndpoint[list[Partition]]):
     ENDPOINT = 'partitions'

--- a/src/bos/common/clients/hsm/types.py
+++ b/src/bos/common/clients/hsm/types.py
@@ -1,0 +1,86 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from typing import Required, TypedDict
+
+
+class Members(TypedDict, total=False):
+    """
+    https://github.com/Cray-HPE/hms-smd/blob/master/api/swagger_v2.yaml
+    '#/definitions/Members.1.0.0'
+    """
+    ids: list[str]
+
+
+class Group(TypedDict, total=False):
+    """
+    https://github.com/Cray-HPE/hms-smd/blob/master/api/swagger_v2.yaml
+    '#/definitions/Group.1.0.0:'
+    """
+    label: Required[str]
+    description: str
+    tags: list[str]
+    exclusiveGroup: str
+    members: Members
+
+
+class Partition(TypedDict, total=False):
+    """
+    https://github.com/Cray-HPE/hms-smd/blob/master/api/swagger_v2.yaml
+    '#/definitions/Partition.1.0.0:'
+    """
+    name: Required[str]
+    description: str
+    tags: list[str]
+    members: Members
+
+
+class StateComponentData(TypedDict, total=False):
+    """
+    https://github.com/Cray-HPE/hms-smd/blob/master/api/swagger_v2.yaml
+    '#/definitions/Component.1.0.0_Component'
+    """
+    ID: str
+    Type: str
+    State: str
+    Flag: str
+    Enabled: bool
+    SoftwareStatus: str
+    Role: str
+    SubRole: str
+    NID: int
+    Subtype: str
+    NetType: str
+    Arch: str
+    Class: str
+    ReservationDisabled: bool
+    Locked: bool
+
+
+class StateComponentsDataArray(TypedDict, total=False):
+    """
+    https://github.com/Cray-HPE/hms-smd/blob/master/api/swagger_v2.yaml
+    '#/definitions/ComponentArray_ComponentArray'
+    """
+    Components: list[StateComponentData]

--- a/src/bos/common/clients/ims/utils.py
+++ b/src/bos/common/clients/ims/utils.py
@@ -33,9 +33,12 @@ def get_ims_id_from_s3_url(s3_url: S3Url) -> str | None:
     If the s3_url matches the expected format of an IMS image path, then return the IMS image ID.
     Otherwise return None.
     """
+    match = IMS_S3_KEY_RE_PROG.match(s3_url.key)
+    if match is None:
+        return None
     try:
-        return IMS_S3_KEY_RE_PROG.match(s3_url.key).group(1)
-    except (AttributeError, IndexError):
+        return match.group(1)
+    except IndexError:
         return None
 
 


### PR DESCRIPTION
HSM client: This PR creates some `TypedDict`s to represent the data that is returned from HSM API calls, and adds some `cast` calls to tell `mypy` that this is what the responses are.

IMS client: Just changed how some regex pattern matching is done to be more precise. Instead of relying on an exception being raised when there is no match found, this explicitly verifies whether or not there was a match. This placates mypy.