### PR TITLE
CASMCMS-9392: Resolve mypy concerns around BootImageMetaDataFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9392: Change type annotation of `BootImageMetaDataFactory` to reflect the only actual
+  type it can current return, to resolve `mypy` concerns.
+
 ## [2.41.0] - 2025-04-28
 
 ### Changed

--- a/src/bos/operators/utils/boot_image_metadata/factory.py
+++ b/src/bos/operators/utils/boot_image_metadata/factory.py
@@ -24,7 +24,6 @@
 import logging
 
 from bos.common.types.templates import BootSet
-from bos.operators.utils.boot_image_metadata import BootImageMetaData
 from bos.operators.utils.boot_image_metadata.s3_boot_image_metadata import S3BootImageMetaData
 
 LOGGER = logging.getLogger(__name__)
@@ -45,7 +44,14 @@ class BootImageMetaDataFactory:
     def __init__(self, boot_set: BootSet):
         self.boot_set = boot_set
 
-    def __call__(self) -> BootImageMetaData:
+    def __call__(self) -> S3BootImageMetaData:
+        """
+        Technically, this method could return any BootImageMetaData subclass.
+        However, right now S3 is the only one that is supported.
+        So as a practical matter, this method always returns S3BootImageMetadata.
+        If we ever add additional supported types, the type annotation for this
+        method will need to be enhanced.
+        """
         path_type = self.boot_set.get('type', None)
         if not path_type:
             raise BootImageMetaDataUnknown(


### PR DESCRIPTION
The fact that the `BootImageMetaDataFactory` return type was the `BootImageMetaData` superclass was causing `mypy` distress, because all of the calls were assuming that the type they got back was `S3BootImageMetaData`. This is because at the moment, that is the only type of boot image metadata that BOS supports. The code was written at a time when it was envisioned that BOS may eventually support multiple types of boot artifacts (I assume), but so far that has not come to pass.

Eventually it would make sense to just simplify this entirely and re-write this part of the code to just have the one type, and get rid of the whole factory idea. But for now, to get type checking working, we can just modify the factory type annotation to reflect the only type of object it can currently return. 

No functionality changes here -- just the return type annotation of one method.