### PR TITLE
CASMCMS-9391: Clean up type annotations in BOS server migration code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - CASMCMS-9392: Change type annotation of `BootImageMetaDataFactory` to reflect the only actual
   type it can current return, to resolve `mypy` concerns.
+- CASMCMS-9391: Clean up type annotations in BOS server migration code (and fix minor bugs identified by mypy).
 
 ## [2.41.0] - 2025-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9392: Change type annotation of `BootImageMetaDataFactory` to reflect the only actual
   type it can current return, to resolve `mypy` concerns.
 - CASMCMS-9391: Clean up type annotations in BOS server migration code (and fix minor bugs identified by mypy).
+- CASMCMS-9393: Fix type annotations for sessiontemplatetemplate endpoint controller
+- CASMCMS-9395: Fix type annotations for sessions controller
 
 ## [2.41.0] - 2025-04-28
 

--- a/src/bos/common/types/templates.py
+++ b/src/bos/common/types/templates.py
@@ -95,7 +95,7 @@ class SessionTemplate(TypedDict, total=False):
     description: str
     enable_cfs: bool
     links: list[Link]
-    name: Required[str]
+    name: str
     tenant: str | None
 
 def _update_boot_sets(record: dict[str, BootSet], new_record_copy: dict[str, BootSet]) -> None:

--- a/src/bos/server/controllers/v2/boot_set/validate.py
+++ b/src/bos/server/controllers/v2/boot_set/validate.py
@@ -26,6 +26,7 @@ from functools import partial
 
 from bos.common.utils import exc_type_msg
 from bos.common.types.general import JsonDict
+from bos.common.types.sessions import SessionOperation
 from bos.common.types.templates import BootSet, SessionTemplate
 from bos.common.types.templates import BOOT_SET_HARDWARE_SPECIFIER_FIELDS as HARDWARE_SPECIFIER_FIELDS
 from bos.server.options import OptionsData
@@ -38,7 +39,7 @@ from .ims import validate_ims_boot_image
 
 def validate_boot_sets(
         session_template: SessionTemplate,
-        operation: str,
+        operation: SessionOperation,
         template_name: str,
         options_data: OptionsData | None=None) -> tuple[BootSetStatus, str]:
     """


### PR DESCRIPTION
The BOS server migration code (which runs when BOS is updated) had some errors, which this PR cleans up. Most of them were purely type annotation errors. For example, when the migration code was annotated, the DB keys were all typed as either strings or bytes. But when we did the database rework, we ended up ensuring that they would always be strings by the time the migration code was looking at them. There was also a case where a function was annotated as returning a string in the case of an error, but it really just raised an exception in that case, and always returned None.

mypy also did identify one bug in the migration code, albeit one which only impacted a log message. A call to `delete_template` mistakenly included the template data in a field intended for an error message (or None). This is the kind of error which mypy is meant to find, because it noticed that the argument type did not match what was expected. This PR cleans that up, so that it passes None instead (which is what we wanted in this case).

Finally, this PR does add some additional explicit type checking in the server migration code. mypy identified a couple of cases where we were assuming certain data types. This PR adds explicit checks around those, so that we can raise meaningful validation errors if we encounter unexpected types, rather than a less obvious Python exception when we try to do something like call a dict method on a string object.