### PR TITLE
CASMCMS-9393: Fix type annotations for sessiontemplatetemplate endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9392: Change type annotation of `BootImageMetaDataFactory` to reflect the only actual
   type it can current return, to resolve `mypy` concerns.
 - CASMCMS-9391: Clean up type annotations in BOS server migration code (and fix minor bugs identified by mypy).
+- CASMCMS-9393: Fix type annotations for sessiontemplatetemplate endpoint controller
 
 ## [2.41.0] - 2025-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type it can current return, to resolve `mypy` concerns.
 - CASMCMS-9391: Clean up type annotations in BOS server migration code (and fix minor bugs identified by mypy).
 - CASMCMS-9393: Fix type annotations for sessiontemplatetemplate endpoint controller
+- CASMCMS-9395: Fix type annotations for sessions controller
 
 ## [2.41.0] - 2025-04-28
 

--- a/src/bos/common/types/templates.py
+++ b/src/bos/common/types/templates.py
@@ -95,7 +95,7 @@ class SessionTemplate(TypedDict, total=False):
     description: str
     enable_cfs: bool
     links: list[Link]
-    name: Required[str]
+    name: str
     tenant: str | None
 
 def _update_boot_sets(record: dict[str, BootSet], new_record_copy: dict[str, BootSet]) -> None:

--- a/src/bos/server/controllers/v2/boot_set/validate.py
+++ b/src/bos/server/controllers/v2/boot_set/validate.py
@@ -26,6 +26,7 @@ from functools import partial
 
 from bos.common.utils import exc_type_msg
 from bos.common.types.general import JsonDict
+from bos.common.types.sessions import SessionOperation
 from bos.common.types.templates import BootSet, SessionTemplate
 from bos.common.types.templates import BOOT_SET_HARDWARE_SPECIFIER_FIELDS as HARDWARE_SPECIFIER_FIELDS
 from bos.server.options import OptionsData
@@ -38,7 +39,7 @@ from .ims import validate_ims_boot_image
 
 def validate_boot_sets(
         session_template: SessionTemplate,
-        operation: str,
+        operation: SessionOperation,
         template_name: str,
         options_data: OptionsData | None=None) -> tuple[BootSetStatus, str]:
     """

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -255,11 +255,10 @@ def validate_v2_sessiontemplate(
     # Otherwise it should be a tuple of data and 200 status code
     data, _ = response
 
-    # We assume boot because it and reboot are the most demanding from a validation
+    # We assume operation boot because it and reboot are the most demanding from a validation
     # standpoint.
-    operation = "boot"
+    _error_code, msg = validate_boot_sets(data, "boot", session_template_id)
 
-    _error_code, msg = validate_boot_sets(data, operation, session_template_id)
     # We return 200 because the request itself was successful even if the session template
     # is invalid.
     return msg, 200

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -29,7 +29,9 @@ from connexion.lifecycle import ConnexionResponse as CxResponse
 
 from bos.common.tenant_utils import (get_tenant_from_header,
                                      reject_invalid_tenant)
-from bos.common.types.templates import (SessionTemplate,
+from bos.common.types.templates import (BootSet,
+                                        SessionTemplate,
+                                        SessionTemplateCfsParameters,
                                         remove_empty_cfs_field,
                                         update_template_record)
 from bos.common.utils import exc_type_msg
@@ -43,30 +45,22 @@ from .boot_set import validate_boot_sets, validate_sanitize_boot_sets
 LOGGER = logging.getLogger(__name__)
 DB = dbutils.SessionTemplateDBWrapper()
 
-EXAMPLE_BOOT_SET = {
-    "type": "s3",
-    "etag": "boot-image-s3-etag",
-    "kernel_parameters": "your-kernel-parameters",
-    "cfs": {
-        "configuration": "bootset-specific-cfs-override"
-    },
-    "node_list": ["xname1", "xname2", "xname3"],
-    "path": "s3://boot-images/boot-image-ims-id/manifest.json",
-    "rootfs_provider": "cpss3",
-    "rootfs_provider_passthrough":
-    "dvs:api-gw-service-nmn.local:300:hsn0,nmn0:0"
-}
+EXAMPLE_BOOT_SET = BootSet(
+    type="s3",
+    etag="boot-image-s3-etag",
+    kernel_parameters="your-kernel-parameters",
+    cfs=SessionTemplateCfsParameters(configuration="bootset-specific-cfs-override"),
+    node_list=["xname1", "xname2", "xname3"],
+    path="s3://boot-images/boot-image-ims-id/manifest.json",
+    rootfs_provider="cpss3",
+    rootfs_provider_passthrough="dvs:api-gw-service-nmn.local:300:hsn0,nmn0:0",
+)
 
-EXAMPLE_SESSION_TEMPLATE = {
-    "boot_sets": {
-        "name_your_boot_set": EXAMPLE_BOOT_SET
-    },
-    "cfs": {
-        "configuration": "default-sessiontemplate-cfs-config"
-    },
-    "enable_cfs": True
-}
-
+EXAMPLE_SESSION_TEMPLATE = SessionTemplate(
+    boot_sets={"name_your_boot_set": EXAMPLE_BOOT_SET},
+    cfs=SessionTemplateCfsParameters(configuration="default-sessiontemplate-cfs-config"),
+    enable_cfs=True
+)
 
 @reject_invalid_tenant
 @dbutils.redis_error_handler


### PR DESCRIPTION
This cleans up some type annotations around the sessiontemplatetemplate endpoint, to resolve a complaint `mypy` was making. Specifically, it modifies the `SessionTemplate` `TypedDict` to match the API schema, and then it explicitly uses the relevant `TypedDict` structures when constructing the return data for this endpoint.

There is no functional change here -- just type annotation cleanup.