### PR TITLE
CASMCMS-9395: Fix type annotations for sessions controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type it can current return, to resolve `mypy` concerns.
 - CASMCMS-9391: Clean up type annotations in BOS server migration code (and fix minor bugs identified by mypy).
 - CASMCMS-9393: Fix type annotations for sessiontemplatetemplate endpoint controller
+- CASMCMS-9395: Fix type annotations for sessions controller
 
 ## [2.41.0] - 2025-04-28
 

--- a/src/bos/server/controllers/v2/boot_set/validate.py
+++ b/src/bos/server/controllers/v2/boot_set/validate.py
@@ -26,6 +26,7 @@ from functools import partial
 
 from bos.common.utils import exc_type_msg
 from bos.common.types.general import JsonDict
+from bos.common.types.sessions import SessionOperation
 from bos.common.types.templates import BootSet, SessionTemplate
 from bos.common.types.templates import BOOT_SET_HARDWARE_SPECIFIER_FIELDS as HARDWARE_SPECIFIER_FIELDS
 from bos.server.options import OptionsData
@@ -38,7 +39,7 @@ from .ims import validate_ims_boot_image
 
 def validate_boot_sets(
         session_template: SessionTemplate,
-        operation: str,
+        operation: SessionOperation,
         template_name: str,
         options_data: OptionsData | None=None) -> tuple[BootSetStatus, str]:
     """

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -255,11 +255,10 @@ def validate_v2_sessiontemplate(
     # Otherwise it should be a tuple of data and 200 status code
     data, _ = response
 
-    # We assume boot because it and reboot are the most demanding from a validation
+    # We assume operation boot because it and reboot are the most demanding from a validation
     # standpoint.
-    operation = "boot"
+    _error_code, msg = validate_boot_sets(data, "boot", session_template_id)
 
-    _error_code, msg = validate_boot_sets(data, operation, session_template_id)
     # We return 200 because the request itself was successful even if the session template
     # is invalid.
     return msg, 200


### PR DESCRIPTION
This PR resolves `mypy` complaints related to the sessions controller. Most of this just involves using `cast` to convey type information that `mypy` cannot automatically infer. This PR also moves a somewhat unwieldy conditional into its own helper function, mainly for readability of the code.