### PR TITLE
CASMCMS-9390: Fix type annotations for server options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9391: Clean up type annotations in BOS server migration code (and fix minor bugs identified by mypy).
 - CASMCMS-9393: Fix type annotations for sessiontemplatetemplate endpoint controller
 - CASMCMS-9395: Fix type annotations for sessions controller
+- CASMCMS-9390: Fix type annotations for server options
 
 ## [2.41.0] - 2025-04-28
 

--- a/src/bos/common/options.py
+++ b/src/bos/common/options.py
@@ -173,7 +173,7 @@ class OptionsCache(DefaultOptions, ABC):
     result in network/DB calls.
     """
 
-    def __init__(self, update_on_create: bool = True):
+    def __init__(self, update_on_create: bool = True) -> None:
         super().__init__()
         if update_on_create:
             self.update()


### PR DESCRIPTION
* Simplified the `_check_defaults` logic (in such a way that it also calms down poor `mypy`).
* Used `dict` `copy` method to copy a `dict` instead of calling `dict` with the old `dict` as the argument, as the latter confused `mypy`.
* Otherwise, just added in missing type annotations or necessary `cast` calls