### PR TITLE
CASMCMS-9390/CASMCMS-9394: Fix type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9393: Fix type annotations for sessiontemplatetemplate endpoint controller
 - CASMCMS-9395: Fix type annotations for sessions controller
 - CASMCMS-9390: Fix type annotations for server options
+- CASMCMS-9394: Fix type annotations for operators
 
 ## [2.41.0] - 2025-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9391: Clean up type annotations in BOS server migration code (and fix minor bugs identified by mypy).
 - CASMCMS-9393: Fix type annotations for sessiontemplatetemplate endpoint controller
 - CASMCMS-9395: Fix type annotations for sessions controller
+- CASMCMS-9390: Fix type annotations for server options
 
 ## [2.41.0] - 2025-04-28
 

--- a/src/bos/common/options.py
+++ b/src/bos/common/options.py
@@ -173,7 +173,7 @@ class OptionsCache(DefaultOptions, ABC):
     result in network/DB calls.
     """
 
-    def __init__(self, update_on_create: bool = True):
+    def __init__(self, update_on_create: bool = True) -> None:
         super().__init__()
         if update_on_create:
             self.update()

--- a/src/bos/common/types/components.py
+++ b/src/bos/common/types/components.py
@@ -53,13 +53,12 @@ class ComponentLastAction(TypedDict, total=False):
     failed: bool
     last_updated: str
 
-class ComponentEventStats(TypedDict, total=False):
-    """
-    #/components/schemas/V2ComponentEventStats
-    """
-    power_on_attempts: int
-    power_off_graceful_attempts: int
-    power_off_forceful_attempts: int
+ComponentEventStatsAttemptFields = Literal['power_on_attempts',
+                                           'power_off_graceful_attempts',
+                                           'power_off_forceful_attempts']
+
+# #/components/schemas/V2ComponentEventStats
+type ComponentEventStats = dict[ComponentEventStatsAttemptFields, int]
 
 class BaseComponentState(TypedDict, total=False):
     """

--- a/src/bos/operators/actual_state_cleanup.py
+++ b/src/bos/operators/actual_state_cleanup.py
@@ -30,6 +30,7 @@ from bos.common.types.components import ComponentRecord
 from bos.common.values import EMPTY_ACTUAL_STATE
 from bos.operators.base import BaseOperator, main
 from bos.operators.filters import ActualStateAge, ActualBootStateIsSet
+from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -47,12 +48,12 @@ class ActualStateCleanupOperator(BaseOperator):
     """
 
     @property
-    def name(self):
+    def name(self) -> str:
         return 'Actual State Cleanup Operator'
 
     # Filters
     @property
-    def filters(self):
+    def filters(self) -> list[BaseFilter]:
         return [
             self.BOSQuery(),
             ActualBootStateIsSet(),

--- a/src/bos/operators/configuration.py
+++ b/src/bos/operators/configuration.py
@@ -23,9 +23,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 import logging
+from typing import Literal
 
+from bos.common.types.components import ComponentRecord
 from bos.common.values import Status
 from bos.operators.base import BaseOperator, main
+from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +41,7 @@ class ConfigurationOperator(BaseOperator):
     """
 
     @property
-    def name(self):
+    def name(self) -> Literal[""]:
         # The Configuration step can take place at any time before power-on.
         # This step is therefore outside the normal boot flow and the name is
         # left empty so this step is not recorded to the component data.
@@ -46,13 +49,13 @@ class ConfigurationOperator(BaseOperator):
 
     # Filters
     @property
-    def filters(self):
+    def filters(self) -> list[BaseFilter]:
         return [
             self.BOSQuery(enabled=True, status=Status.configuring),
             self.DesiredConfigurationSetInCFS(negate=True)
         ]
 
-    def _act(self, components):
+    def _act(self, components: list[ComponentRecord]) -> list[ComponentRecord]:
         if components:
             self.client.cfs.components.set_cfs(components, enabled=True)
         return components

--- a/src/bos/operators/discovery.py
+++ b/src/bos/operators/discovery.py
@@ -28,6 +28,7 @@ from copy import copy
 from bos.common.types.components import ComponentRecord
 from bos.common.values import Action, EMPTY_ACTUAL_STATE, EMPTY_DESIRED_STATE
 from bos.operators.base import BaseOperator, main
+from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -56,13 +57,13 @@ class DiscoveryOperator(BaseOperator):
     frequency_option = "discovery_frequency"
 
     @property
-    def name(self):
+    def name(self) -> str:
         return "Discovery"
 
     # This operator overrides _run and does not use "filters" or "_act", but they are defined here
     # because they are abstract methods in the base class and must be implemented.
     @property
-    def filters(self):
+    def filters(self) -> list[BaseFilter]:
         return []
 
     def _act(self, components: list[ComponentRecord]) -> list[ComponentRecord]:

--- a/src/bos/operators/power_off_forceful.py
+++ b/src/bos/operators/power_off_forceful.py
@@ -25,9 +25,11 @@
 import logging
 
 from bos.common.clients.bos.options import options
+from bos.common.types.components import ComponentRecord
 from bos.common.values import Action, Status
 from bos.operators.base import BaseOperator, main
 from bos.operators.filters import TimeSinceLastAction
+from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,12 +44,12 @@ class ForcefulPowerOffOperator(BaseOperator):
     retry_attempt_field = "power_off_forceful_attempts"
 
     @property
-    def name(self):
+    def name(self) -> str:
         return Action.power_off_forcefully
 
     # Filters
     @property
-    def filters(self):
+    def filters(self) -> list[BaseFilter]:
         return [
             self.BOSQuery(enabled=True,
                           status=','.join([
@@ -58,7 +60,7 @@ class ForcefulPowerOffOperator(BaseOperator):
             self.HSMState(),
         ]
 
-    def _act(self, components):
+    def _act(self, components: list[ComponentRecord]) -> list[ComponentRecord]:
         if components:
             component_ids = [component['id'] for component in components]
             self.client.pcs.transitions.force_off(nodes=component_ids)

--- a/src/bos/operators/power_off_graceful.py
+++ b/src/bos/operators/power_off_graceful.py
@@ -26,6 +26,7 @@ import logging
 
 from bos.common.values import Action, Status
 from bos.operators.base import BaseOperator, main
+from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,12 +40,12 @@ class GracefulPowerOffOperator(BaseOperator):
     retry_attempt_field = "power_off_graceful_attempts"
 
     @property
-    def name(self):
+    def name(self) -> str:
         return Action.power_off_gracefully
 
     # Filters
     @property
-    def filters(self):
+    def filters(self) -> list[BaseFilter]:
         return [
             self.BOSQuery(enabled=True, status=Status.power_off_pending),
             self.HSMState(),

--- a/src/bos/operators/session_cleanup.py
+++ b/src/bos/operators/session_cleanup.py
@@ -26,7 +26,9 @@ import logging
 import re
 
 from bos.common.clients.bos.options import options
+from bos.common.types.components import ComponentRecord
 from bos.operators.base import BaseOperator, main
+from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -38,11 +40,11 @@ class SessionCleanupOperator(BaseOperator):
     """
 
     @property
-    def name(self):
+    def name(self) -> str:
         return 'SessionCleanup'
 
     @property
-    def disabled(self):
+    def disabled(self) -> bool:
         """
         When users set the cleanup time to 0, no cleanup behavior is desired.
         """
@@ -53,10 +55,10 @@ class SessionCleanupOperator(BaseOperator):
     # This operator overrides _run and does not use "filters" or "_act", but they are defined here
     # because they are abstract methods in the base class and must be implemented.
     @property
-    def filters(self):
+    def filters(self) -> list[BaseFilter]:
         return []
 
-    def _act(self, components):
+    def _act(self, components: list[ComponentRecord]) -> list[ComponentRecord]:
         return components
 
     def _run(self) -> None:

--- a/src/bos/operators/session_completion.py
+++ b/src/bos/operators/session_completion.py
@@ -25,8 +25,11 @@
 import logging
 
 from bos.common.clients.bos import BOSClient
+from bos.common.types.components import ComponentRecord
+from bos.common.types.sessions import Session
 from bos.common.utils import get_current_timestamp
 from bos.operators.base import BaseOperator, main
+from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -38,16 +41,16 @@ class SessionCompletionOperator(BaseOperator):
     """
 
     @property
-    def name(self):
+    def name(self) -> str:
         return 'SessionCompletion'
 
     # This operator overrides _run and does not use "filters" or "_act", but they are defined here
     # because they are abstract methods in the base class and must be implemented.
     @property
-    def filters(self):
+    def filters(self) -> list[BaseFilter]:
         return []
 
-    def _act(self, components):
+    def _act(self, components: list[ComponentRecord]) -> list[ComponentRecord]:
         return components
 
     def _run(self) -> None:
@@ -60,10 +63,10 @@ class SessionCompletionOperator(BaseOperator):
                                       tenant=session.get("tenant"),
                                       bos_client=self.client.bos)
 
-    def _get_incomplete_sessions(self):
+    def _get_incomplete_sessions(self) -> list[Session]:
         return self.client.bos.sessions.get_sessions(status='running')
 
-    def _get_incomplete_components(self, session_id):
+    def _get_incomplete_components(self, session_id) -> list[ComponentRecord]:
         components = self.client.bos.components.get_components(
             session=session_id, enabled=True)
         components += self.client.bos.components.get_components(

--- a/src/bos/operators/status.py
+++ b/src/bos/operators/status.py
@@ -23,6 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 import logging
+from typing import Literal
 
 from bos.common.clients.bos.options import options
 from bos.common.types.components import ComponentRecord
@@ -33,6 +34,7 @@ from bos.operators.filters import (BootArtifactStatesMatch,
                                    DesiredConfigurationIsNone,
                                    LastActionIs,
                                    TimeSinceLastAction)
+from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +45,7 @@ class StatusOperator(BaseOperator):
     Also disables stable components if necessary and sets some status overrides.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # Reuse filter code
         self.desired_boot_state_is_off = DesiredBootStateIsOff().component_match
@@ -55,21 +57,21 @@ class StatusOperator(BaseOperator):
         self.power_on_wait_time_elapsed = TimeSinceLastAction(
             seconds=options.max_power_on_wait_time).component_match
 
-    def desired_configuration_set_in_cfs(self, *args, **kwargs):
+    def desired_configuration_set_in_cfs(self, *args, **kwargs) -> bool:
         """
         Shortcut to DesiredConfigurationSetInCFS._match method
         """
         return self.DesiredConfigurationSetInCFS().component_match(*args, **kwargs)
 
     @property
-    def name(self):
+    def name(self) -> Literal[""]:
         """ Unused for the status operator """
         return ''
 
     # This operator overrides _run and does not use "filters" or "_act", but they are defined here
     # because they are abstract methods in the base class and must be implemented.
     @property
-    def filters(self):
+    def filters(self) -> list[BaseFilter]:
         return []
 
     def _act(self, components: list[ComponentRecord]) -> list[ComponentRecord]:


### PR DESCRIPTION
## CASMCMS-9390: Fix type annotations for server options

* Simplified the `_check_defaults` logic (in such a way that it also calms down poor `mypy`).
* Used `dict` `copy` method to copy a `dict` instead of calling `dict` with the old `dict` as the argument, as the latter confused `mypy`.
* Otherwise, just added in missing type annotations or necessary `cast` calls

## CASMCMS-9394: Fix type annotations for operators

This adds annotations to a bunch of operator methods and variables which lack them.
It also redefines the component event stats type, to handle how the operators store a class variable with a field name from that structure.
As always, some `cast`s were added to keep `mypy` happy.
This doesn't completely finish the type annotation work for the operators, but this PR had grown large enough that I thought it best to stop it here, and begin another one to continue that work.