### PR TITLE
CASMCMS-9407: Refactor session setup operator to resolve type annotation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9407: Refactored session setup operator to resolve type annotation issues
+
 ## [2.42.0] - 2025-05-01
 
 ### Changed


### PR DESCRIPTION
This fixes the type annotation issues in the session setup operator.

Some just required the usual explicit annotation of variables, to let `mypy` know what is intended. But typing the code as-is was going to be complicated because of the fact that the same class was used for both staged and regular sessions. I realized that it was only a very small number of places where the behavior was actually different, so I moved the bulk of the existing code into an abstract base class, and then created two concrete child classes -- one for handling regular sessions, and one for handling staged sessions. This dramatically simplified the type annotation, and actually also simplified the code itself, since it removed the previous "if staged" conditionals that were peppered through the class.

Ultimately the underlying code logic is unchanged.


