### PR TITLE
CASMCMS-9413: Add explicit annotations for S3 methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - CASMCMS-9407: Refactored session setup operator to resolve type annotation issues
-- CASMCMS-9412: Enable more thorough `mypy` checks at build time
+- CASMCMS-9412:
+  - Enable more thorough `mypy` checks at build time
+  - CASMCMS-9413: Add explicit annotations for S3 methods
 
 ### Dependencies
 - Updated to openapi-generator-cli v7.13.0


### PR DESCRIPTION
There are 3 BOS methods which return objects that come from the `boto3`/`botocore` modules. Currently, the return types for these methods is not explicitly annotated, because this is not possible to do using usual methods. The types in question are classes which do not exist at the time that type checking is done. There are stubs modules that allow `mypy` to infer the types, but it will still complain about methods that are not explicitly annotated. We could just suppress those errors, but it's possible to do the explicit type annotation. It just requires some care be taken, to avoid using things that are not present when the code is actually run in production. This PR adds in the explicit type annotations, but uses a `TYPE_CHECKING` conditional to ensure that the extra stuff is only done when we're actually type checking. Otherwise, it defaults to something that will have no effect at runtime.

(this is based on advice from the `boto3-stubs` maintainers)