### PR TITLE
CASMCMS-9414: Create helper types for sessions and component type annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9412:
   - Enable more thorough `mypy` checks at build time
   - CASMCMS-9413: Add explicit annotations for S3 methods
+  - CASMCMS-9414: Create helper types for sessions and component type annotation
 
 ### Dependencies
 - Updated to openapi-generator-cli v7.13.0

--- a/src/bos/common/types/components.py
+++ b/src/bos/common/types/components.py
@@ -223,3 +223,22 @@ class ApplyStagedStatus(TypedDict, total=False):
     failed: list[str]
     ignored: list[str]
     succeeded: list[str]
+
+class GetComponentsFilter(TypedDict, total=False):
+    """
+    Filters that can be specified when doing a GET to /v2/components
+    """
+    ids: str
+    session: str
+    staged_session: str
+    enabled: bool
+    phase: str
+    status: str
+    start_after_id: str
+    page_size: int
+
+class ComponentBulkUpdateParams(TypedDict, total=False):
+    """
+    Parameters that can be specified when doing a bulk component patch
+    """
+    skip_bad_ids: bool

--- a/src/bos/common/types/sessions.py
+++ b/src/bos/common/types/sessions.py
@@ -82,3 +82,14 @@ def update_session_record(record: Session, patch_data: SessionUpdate) -> None:
 
     if "components" in patch_data:
         record["components"] = patch_data["components"]
+
+class SessionFilter(TypedDict, total=False):
+    """
+    The parameters that can be passed into BOS session endpoints that allow filtering
+    #/components/parameters/V2SessionsMaxAgeQueryParam
+    #/components/parameters/V2SessionsMinAgeQueryParam
+    #/components/parameters/V2SessionsStatusQueryParam
+    """
+    min_age: str
+    max_age: str
+    status: SessionStatusLabel

--- a/src/bos/common/values.py
+++ b/src/bos/common/values.py
@@ -22,40 +22,50 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+from typing import Literal
+
 from bos.common.types.components import (BootArtifacts,
                                          ComponentActualState,
                                          ComponentDesiredState,
                                          ComponentStagedState)
 
+
+ComponentActionStr = Literal['powering_on', 'powering_off_gracefully', 'powering_off_forcefully',
+                          'apply_staged', 'session_setup', 'newly_discovered']
+ComponentPhaseStr = Literal['powering_on', 'powering_off', 'configuring', '']
+ComponentStatusStr = Literal['power_on_pending', 'power_on_called', 'power_off_pending',
+                          'power_off_gracefully_called', 'power_off_forcefully_called',
+                          'configuring', 'stable', 'failed', 'on_hold']
+
 # Phases
 class Phase:
-    powering_on = "powering_on"
-    powering_off = "powering_off"
-    configuring = "configuring"
-    none = ""
+    powering_on: ComponentPhaseStr = "powering_on"
+    powering_off: ComponentPhaseStr = "powering_off"
+    configuring: ComponentPhaseStr = "configuring"
+    none: ComponentPhaseStr = ""
 
 
 # Actions
 class Action:
-    power_on = "powering_on"
-    power_off_gracefully = "powering_off_gracefully"
-    power_off_forcefully = "powering_off_forcefully"
-    apply_staged = "apply_staged"
-    session_setup = "session_setup"
-    newly_discovered = "newly_discovered"
+    power_on: ComponentActionStr = "powering_on"
+    power_off_gracefully: ComponentActionStr = "powering_off_gracefully"
+    power_off_forcefully: ComponentActionStr = "powering_off_forcefully"
+    apply_staged: ComponentActionStr = "apply_staged"
+    session_setup: ComponentActionStr = "session_setup"
+    newly_discovered: ComponentActionStr = "newly_discovered"
 
 
 # Status
 class Status:
-    power_on_pending = "power_on_pending"
-    power_on_called = "power_on_called"
-    power_off_pending = "power_off_pending"
-    power_off_gracefully_called = "power_off_gracefully_called"
-    power_off_forcefully_called = "power_off_forcefully_called"
-    configuring = "configuring"
-    stable = "stable"
-    failed = "failed"
-    on_hold = "on_hold"
+    power_on_pending: ComponentStatusStr = "power_on_pending"
+    power_on_called: ComponentStatusStr = "power_on_called"
+    power_off_pending: ComponentStatusStr = "power_off_pending"
+    power_off_gracefully_called: ComponentStatusStr = "power_off_gracefully_called"
+    power_off_forcefully_called: ComponentStatusStr = "power_off_forcefully_called"
+    configuring: ComponentStatusStr = "configuring"
+    stable: ComponentStatusStr = "stable"
+    failed: ComponentStatusStr = "failed"
+    on_hold: ComponentStatusStr = "on_hold"
 
 
 EMPTY_BOOT_ARTIFACTS: BootArtifacts = {


### PR DESCRIPTION
This just defines a few new types that I will be using in an upcoming PR to clean up the remaining type annotation issues relating to components and sessions. This PR itself just adds the definitions, but doesn't modify the other code to use them yet.