### PR TITLE
CASMCMS-9415: Refactor dbwrapper to resolve type annotation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enable more thorough `mypy` checks at build time
   - CASMCMS-9413: Add explicit annotations for S3 methods
   - CASMCMS-9414: Create helper types for sessions and component type annotation
+  - CASMCMS-9415: Refactor `dbwrapper` to resolve type annotation issues
 
 ### Dependencies
 - Updated to openapi-generator-cli v7.13.0


### PR DESCRIPTION
It turns out that `mypy` has a little trouble with inferring type information in some cases when `partialmethod` is used, particularly in combination with `overload`. This PR refactors `dbwrapper` to avoid this problematic combination. The result has the same execution logic as before, but in a way that doesn't make `mypy` sad.