### PR TITLE
CASMCMS-9418: Resolve type annotation issues in BOS client, HSM client, and filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CASMCMS-9415: Refactor `dbwrapper` to resolve type annotation issues
   - CASMCMS-9416: Resolve type annotation issues in `server/options.py`
   - CASMCMS-9417: Resolve type annotation issues in session status operator
+  - CASMCMS-9418: Resolve type annotation issues in BOS client, HSM client, and filters
 
 ### Dependencies
 - Updated to openapi-generator-cli v7.13.0

--- a/src/bos/common/clients/bos/session_templates.py
+++ b/src/bos/common/clients/bos/session_templates.py
@@ -23,22 +23,15 @@
 #
 import logging
 
-from .base import BaseBosTenantAwareEndpoint
+from bos.common.types.templates import SessionTemplate
+
+from .base import BaseBosGetItemEndpoint
 
 LOGGER = logging.getLogger(__name__)
 
 
-class SessionTemplateEndpoint(BaseBosTenantAwareEndpoint):
+class SessionTemplateEndpoint(BaseBosGetItemEndpoint[SessionTemplate]):
     ENDPOINT = 'sessiontemplates'
 
-    def get_session_template(self, session_template_id, tenant):
+    def get_session_template(self, session_template_id: str, tenant: str | None) -> SessionTemplate:
         return self.get_item(session_template_id, tenant)
-
-    def get_session_templates(self, **kwargs):
-        return self.get_items(**kwargs)
-
-    def update_session_template(self, session_template_id, tenant, data):
-        return self.update_item(session_template_id, tenant, data)
-
-    def update_session_templates(self, data):
-        raise Exception("Session templates don't support a bulk update")

--- a/src/bos/common/clients/bos/sessions.py
+++ b/src/bos/common/clients/bos/sessions.py
@@ -22,30 +22,44 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 import logging
+from typing import Unpack
 
-from .base import BaseBosTenantAwareEndpoint
+from bos.common.types.sessions import Session, SessionFilter, SessionUpdate
+
+from .base import (BaseBosGetItemEndpoint,
+                   BaseBosGetItemsEndpoint,
+                   BaseBosUpdateItemEndpoint,
+                   BaseBosPostItemEndpoint,
+                   BaseBosDeleteItemsEndpoint)
 
 LOGGER = logging.getLogger(__name__)
 
 
-class SessionEndpoint(BaseBosTenantAwareEndpoint):
-    ENDPOINT = __name__.lower().rsplit('.', maxsplit=1)[-1]
+class SessionEndpoint(
+    BaseBosGetItemEndpoint[Session],
+    BaseBosGetItemsEndpoint[SessionFilter, Session],
+    BaseBosUpdateItemEndpoint[SessionUpdate, Session],
+    BaseBosPostItemEndpoint[None, Session],
+    BaseBosDeleteItemsEndpoint[SessionFilter]
+):
+    ENDPOINT = 'sessions'
 
-    def get_session(self, session_id, tenant):
+    def get_session(self, session_id: str, tenant: str | None) -> Session:
         return self.get_item(session_id, tenant)
 
-    def get_sessions(self, **kwargs):
-        return self.get_items(**kwargs)
+    def get_sessions(self, tenant: str | None=None,
+                     **params: Unpack[SessionFilter]) -> list[Session]:
+        return self.get_items(tenant=tenant, params=params)
 
-    def update_session(self, session_id, tenant, data):
+    def update_session(self, session_id: str, tenant: str | None, data: SessionUpdate) -> Session:
         return self.update_item(session_id, tenant, data)
 
-    def delete_sessions(self, **kwargs):
-        return self.delete_items(**kwargs)
+    def delete_sessions(self, tenant: str | None=None, **params: Unpack[SessionFilter]) -> None:
+        self.delete_items(tenant=tenant, params=params)
 
-    def post_session_status(self, session_id, tenant):
+    def post_session_status(self, session_id: str, tenant: str | None) -> Session:
         """
         Post information for a single BOS Session status.
         This basically saves the BOS Session status to the database.
         """
-        return self.post_item(f'{session_id}/status', tenant)
+        return self.post_item(f'{session_id}/status', tenant, None)

--- a/src/bos/common/clients/endpoints/defs.py
+++ b/src/bos/common/clients/endpoints/defs.py
@@ -21,13 +21,29 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager
-from typing import Any, NamedTuple
+from typing import NamedTuple, TypedDict
 
 import requests
 
 type RequestsMethod = Callable[..., AbstractContextManager[requests.Response]]
+
+
+class RequestOptions(TypedDict, total=False):
+    """
+    Kwargs definition for BaseGenericEndpoint _request method
+    These are passed into the requests module request methods.
+
+    This is not intended to list all of the supported arguments for the requests
+    module methods -- only the ones that BOS uses. And even for those, these
+    definitions will only cover the ways in which BOS uses them.
+    """
+    params: Mapping[str,object]|None
+    json: object
+    headers: Mapping[str,object]|None
+    verify: bool
+
 
 class RequestData(NamedTuple):
     """
@@ -37,4 +53,4 @@ class RequestData(NamedTuple):
     """
     method_name: str
     url: str
-    request_options: dict[str, Any]
+    request_options: RequestOptions

--- a/src/bos/common/clients/hsm/groups.py
+++ b/src/bos/common/clients/hsm/groups.py
@@ -26,5 +26,5 @@ from .base import BaseHsmEndpoint
 from .types import Group
 
 
-class GroupsEndpoint(BaseHsmEndpoint[list[Group]]):
+class GroupsEndpoint(BaseHsmEndpoint[None, list[Group]]):
     ENDPOINT = 'groups'

--- a/src/bos/common/clients/hsm/partitions.py
+++ b/src/bos/common/clients/hsm/partitions.py
@@ -26,5 +26,5 @@ from .base import BaseHsmEndpoint
 from .types import Partition
 
 
-class PartitionsEndpoint(BaseHsmEndpoint[list[Partition]]):
+class PartitionsEndpoint(BaseHsmEndpoint[None, list[Partition]]):
     ENDPOINT = 'partitions'

--- a/src/bos/common/clients/hsm/state_components.py
+++ b/src/bos/common/clients/hsm/state_components.py
@@ -23,7 +23,7 @@
 #
 
 import logging
-from typing import cast
+from typing import cast, TypedDict
 
 from bos.common.utils import exc_type_msg
 
@@ -34,7 +34,11 @@ from .types import StateComponentsDataArray
 LOGGER = logging.getLogger(__name__)
 
 
-class StateComponentsEndpoint(BaseHsmEndpoint[StateComponentsDataArray]):
+class StateComponentsGetListParams(TypedDict, total=False):
+    partition: str
+
+
+class StateComponentsEndpoint(BaseHsmEndpoint[StateComponentsGetListParams, StateComponentsDataArray]):
     ENDPOINT = 'State/Components'
 
     def read_all_node_xnames(self) -> set[str]:


### PR DESCRIPTION
This PR does a refactoring of the base generic API client, the BOS client, and the HSM client, to resolve the remaining mypy issues they had. It also fixes type issues in the filters code used by the operators.

The core logic is unchanged. The size of the PR is just a reflection of how many parts of BOS import this code, and needed their type annotations updated accordingly.

With this PR in place, the `mypy` check gives BOS a clean bill of health! The next PR will modify the Jenkinsfile to make the `mypy` check a gate to the builds, like we have with `pylint` currently.

I've also tested this code on mug and verified that it hasn't introduced some unforeseen bugs.