### PR TITLE
CASMCMS-9412: Update Jenkinsfile to make failed mypy checks fail the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CASMCMS-9416: Resolve type annotation issues in `server/options.py`
   - CASMCMS-9417: Resolve type annotation issues in session status operator
   - CASMCMS-9418: Resolve type annotation issues in BOS client, HSM client, and filters
+  - Update Jenkinsfile to make failed `mypy` checks fail the build
 
 ### Dependencies
 - Updated to openapi-generator-cli v7.13.0

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -136,8 +136,7 @@ pipeline {
                             sh "make image_build_base"
                         }
                         sh "make image_build_mypy"
-                        // For now, do not fail on mypy failures
-                        sh "make image_run_mypy || true"
+                        sh "make image_run_mypy"
                     }
                 }
                 stage('Chart') {


### PR DESCRIPTION
As the description says, this PR just makes it so that if `mypy` fails, the build fails, to ensure that we don't add new code which is not type safe.