### PR TITLE
CASMCMS-9426: Allow session template patches to omit the boot_sets field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 = Refactor a couple huge methods in the status operator to make the code more digestible
 - Minor refactoring of power on operator to resolve pylint complexity complaints
+- CASMCMS-9426: Allow session template patches to omit the `boot_sets` field
 
 ## [2.43.0] - 2025-05-07
 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -387,6 +387,29 @@ components:
           $ref: '#/components/schemas/LinkListReadOnly'
       additionalProperties: false
       required: [ boot_sets ]
+    V2SessionTemplatePatch:
+      type: object
+      description: Data to update an existing Session Template record.
+      properties:
+        description:
+          $ref: '#/components/schemas/SessionTemplateDescription'
+        enable_cfs:
+          $ref: '#/components/schemas/EnableCfs'
+        cfs:
+          $ref: '#/components/schemas/V2CfsParameters'
+        boot_sets:
+          type: object
+          description: |
+            Mapping from Boot Set names to Boot Sets.
+
+            * Boot Set names must be 1-127 characters in length.
+            * Boot Set names must use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Boot Set names must begin and end with a letter or digit.
+          minProperties: 1
+          maxProperties: 127
+          additionalProperties:
+            $ref: '#/components/schemas/V2BootSet'
+      additionalProperties: false
     V2SessionTemplateValidation:
       description: |
         Message describing errors or incompleteness in a Session Template.
@@ -1575,7 +1598,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/V2SessionTemplate'
+              $ref: '#/components/schemas/V2SessionTemplatePatch'
       responses:
         200:
           $ref: '#/components/responses/V2SessionTemplateDetails'

--- a/src/bos/common/types/templates.py
+++ b/src/bos/common/types/templates.py
@@ -86,17 +86,25 @@ def _update_boot_set(record: BootSet, new_record_copy: BootSet) -> None:
     # The remaining fields can be merged the old-fashioned way
     record.update(new_record_copy)
 
-class SessionTemplate(TypedDict, total=False):
+class BaseSessionTemplate(TypedDict, total=False):
+    cfs: SessionTemplateCfsParameters
+    description: str
+    enable_cfs: bool
+
+class SessionTemplate(BaseSessionTemplate, total=False):
     """
     #/components/schemas/V2SessionTemplate
     """
     boot_sets: Required[dict[str, BootSet]]
-    cfs: SessionTemplateCfsParameters
-    description: str
-    enable_cfs: bool
     links: list[Link]
     name: str
     tenant: str | None
+
+class SessionTemplatePatch(BaseSessionTemplate, total=False):
+    """
+    #/components/schemas/V2SessionTemplatePatch
+    """
+    boot_sets: dict[str, BootSet]
 
 def _update_boot_sets(record: dict[str, BootSet], new_record_copy: dict[str, BootSet]) -> None:
     """
@@ -110,13 +118,13 @@ def _update_boot_sets(record: dict[str, BootSet], new_record_copy: dict[str, Boo
         else:
             record[new_bs_name] = new_bs_record
 
-def update_template_record(record: SessionTemplate, new_record: SessionTemplate) -> None:
+def update_template_record(record: SessionTemplate, patch_data: SessionTemplatePatch) -> None:
     """
     This is used to patch session template data.
-    The session template 'record' is patched in-place with the data from 'new_record'.
+    The session template 'record' is patched in-place with the data from 'patch_data'.
     """
-    # Make a copy, to avoid changing new_record in place
-    new_record_copy = copy.deepcopy(new_record)
+    # Make a copy, to avoid changing patch_data in place
+    new_record_copy = copy.deepcopy(patch_data)
 
     if "cfs" in new_record_copy:
         new_cfs_data = new_record_copy.pop("cfs")

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -32,6 +32,7 @@ from bos.common.tenant_utils import (get_tenant_from_header,
 from bos.common.types.templates import (BootSet,
                                         SessionTemplate,
                                         SessionTemplateCfsParameters,
+                                        SessionTemplatePatch,
                                         remove_empty_cfs_field,
                                         update_template_record)
 from bos.common.utils import exc_type_msg
@@ -215,7 +216,7 @@ def patch_v2_sessiontemplate(
         return _404_template_not_found(resource_id=session_template_id, tenant=tenant)
 
     try:
-        template_patch_data = cast(SessionTemplate, get_request_json())
+        template_patch_data = cast(SessionTemplatePatch, get_request_json())
     except Exception as err:
         LOGGER.error("Error parsing PATCH '%s' request data: %s",
                      session_template_id, exc_type_msg(err))


### PR DESCRIPTION
Currently, the API spec uses the same schema definition for the body of session template PUT and PATCH requests. This schema has the boot set field as required, because new session templates are useless without it. However, when patching a template, it should not be required, since there are other fields that may be modified.

This PR updates the API spec to create a separate schema for session template patching, adds an associated datatype in the BOS typing library, and updates the relevant code to use it. The actual code is mostly unchanged, beyond using the new data type.

I have tested this on mug and verified that it now allows me to patch without having to include the boot sets.