### PR TITLE
CASMCMS-9428: Change component phase and action fields to enumerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 = Refactor a couple huge methods in the status operator to make the code more digestible
 - Minor refactoring of power on operator to resolve pylint complexity complaints
 - CASMCMS-9426: Allow session template patches to omit the `boot_sets` field
+- CASMCMS-9428: Change component `phase` and `action` fields to enumerated string types; refactor
+  operators to take advantage of the changed `action` field type.
 
 ## [2.43.0] - 2025-05-07
 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -783,9 +783,7 @@ components:
         last_updated:
           $ref: '#/components/schemas/V2ComponentLastUpdated'
         action:
-          type: string
-          description: A description of the most recent operator/action to impact the Component.
-          maxLength: 1024
+          $ref: '#/components/schemas/V2ComponentAction'
         failed:
           type: boolean
           description: Denotes if the last action failed to accomplish its task
@@ -811,10 +809,14 @@ components:
           minimum: 0
           maximum: 1048576
       additionalProperties: false
+    V2ComponentAction:
+        type: string
+        description: A description of the most recent operator/action to impact the Component.
+        enum: ['actual_state_cleanup', 'apply_staged', 'newly_discovered', 'powering_off_forcefully', 'powering_off_gracefully', 'powering_on', 'session_setup']
     V2ComponentPhase:
       type: string
       description: The current phase of the Component in the boot process.
-      maxLength: 128
+      enum: ['configuring', 'powering_off', 'powering_on', '']
     V2ComponentStatus:
       description: Status information for the Component
       type: object

--- a/src/bos/common/types/components.py
+++ b/src/bos/common/types/components.py
@@ -28,11 +28,20 @@ Type annotation definitions for BOS components
 import copy
 from typing import Literal, Required, TypedDict, cast, get_args
 
+#/components/schemas/V2ComponentPhase
+ComponentPhaseStr = Literal['powering_on', 'powering_off', 'configuring', '']
+
+COMPONENT_PHASE_STR: frozenset[ComponentPhaseStr] = frozenset(get_args(ComponentPhaseStr))
+
+ComponentStatusStr = Literal['power_on_pending', 'power_on_called', 'power_off_pending',
+                          'power_off_gracefully_called', 'power_off_forcefully_called',
+                          'configuring', 'stable', 'failed', 'on_hold']
+
 class ComponentStatus(TypedDict, total=False):
     """
     #/components/schemas/V2ComponentStatus
     """
-    phase: str
+    phase: ComponentPhaseStr
     status: str
     status_override: str
 
@@ -45,11 +54,15 @@ class BootArtifacts(TypedDict, total=False):
     initrd: Required[str]
     timestamp: str
 
+ComponentActionStr = Literal['actual_state_cleanup', 'apply_staged', 'newly_discovered',
+                             'powering_off_forcefully', 'powering_off_gracefully', 'powering_on',
+                             'session_setup']
+
 class ComponentLastAction(TypedDict, total=False):
     """
     #/components/schemas/V2ComponentLastAction
     """
-    action: str
+    action: ComponentActionStr
     failed: bool
     last_updated: str
 
@@ -218,7 +231,7 @@ class GetComponentsFilter(TypedDict, total=False):
     session: str
     staged_session: str
     enabled: bool
-    phase: str
+    phase: ComponentPhaseStr
     status: str
     start_after_id: str
     page_size: int

--- a/src/bos/common/values.py
+++ b/src/bos/common/values.py
@@ -26,20 +26,13 @@
 BOS values used by both server and operators
 """
 
-from typing import Literal
-
 from bos.common.types.components import (BootArtifacts,
+                                         ComponentActionStr,
                                          ComponentActualState,
                                          ComponentDesiredState,
-                                         ComponentStagedState)
-
-
-ComponentActionStr = Literal['powering_on', 'powering_off_gracefully', 'powering_off_forcefully',
-                          'apply_staged', 'session_setup', 'newly_discovered']
-ComponentPhaseStr = Literal['powering_on', 'powering_off', 'configuring', '']
-ComponentStatusStr = Literal['power_on_pending', 'power_on_called', 'power_off_pending',
-                          'power_off_gracefully_called', 'power_off_forcefully_called',
-                          'configuring', 'stable', 'failed', 'on_hold']
+                                         ComponentPhaseStr,
+                                         ComponentStagedState,
+                                         ComponentStatusStr)
 
 # Phases
 class Phase:
@@ -51,12 +44,13 @@ class Phase:
 
 # Actions
 class Action:
-    power_on: ComponentActionStr = "powering_on"
-    power_off_gracefully: ComponentActionStr = "powering_off_gracefully"
-    power_off_forcefully: ComponentActionStr = "powering_off_forcefully"
+    actual_state_cleanup: ComponentActionStr = "actual_state_cleanup"
     apply_staged: ComponentActionStr = "apply_staged"
-    session_setup: ComponentActionStr = "session_setup"
     newly_discovered: ComponentActionStr = "newly_discovered"
+    power_off_forcefully: ComponentActionStr = "powering_off_forcefully"
+    power_off_gracefully: ComponentActionStr = "powering_off_gracefully"
+    power_on: ComponentActionStr = "powering_on"
+    session_setup: ComponentActionStr = "session_setup"
 
 
 # Status

--- a/src/bos/operators/actual_state_cleanup.py
+++ b/src/bos/operators/actual_state_cleanup.py
@@ -32,15 +32,15 @@ import logging
 from bos.common.clients.bos.options import options
 from bos.common.utils import duration_to_timedelta
 from bos.common.types.components import ComponentRecord
-from bos.common.values import EMPTY_ACTUAL_STATE
-from bos.operators.base import BaseOperator, main
+from bos.common.values import Action, EMPTY_ACTUAL_STATE
+from bos.operators.base import BaseActionOperator, main
 from bos.operators.filters import ActualStateAge, ActualBootStateIsSet
 from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
 
-class ActualStateCleanupOperator(BaseOperator):
+class ActualStateCleanupOperator(BaseActionOperator):
     """
     The ActualStateCleanupOperator is responsible for identifying components that have
     an expired actual state set (from boot artifacts). Typically this can happen when
@@ -52,9 +52,7 @@ class ActualStateCleanupOperator(BaseOperator):
     zero the actual booted state record when the configured TTL has expired.
     """
 
-    @property
-    def name(self) -> str:
-        return 'Actual State Cleanup Operator'
+    action = Action.actual_state_cleanup
 
     # Filters
     @property

--- a/src/bos/operators/configuration.py
+++ b/src/bos/operators/configuration.py
@@ -28,7 +28,6 @@ BOS component configuration operator
 """
 
 import logging
-from typing import Literal
 
 from bos.common.types.components import ComponentRecord
 from bos.common.values import Status
@@ -43,14 +42,11 @@ class ConfigurationOperator(BaseOperator):
     The Configure Operator sets the desired configuration in CFS if:
     - Enabled in the BOS database and the current phase is configuring
     - DesiredConfiguration != SetConfiguration
-    """
 
-    @property
-    def name(self) -> Literal[""]:
-        # The Configuration step can take place at any time before power-on.
-        # This step is therefore outside the normal boot flow and the name is
-        # left empty so this step is not recorded to the component data.
-        return ''
+    The Configuration step can take place at any time before power-on.
+    Because this step is therefore outside the normal boot flow, it does not
+    inherit from BaseActionOperator, so it is not recorded to the component data.
+    """
 
     # Filters
     @property

--- a/src/bos/operators/power_off_forceful.py
+++ b/src/bos/operators/power_off_forceful.py
@@ -32,25 +32,22 @@ import logging
 from bos.common.clients.bos.options import options
 from bos.common.types.components import ComponentRecord
 from bos.common.values import Action, Status
-from bos.operators.base import BaseOperator, main
+from bos.operators.base import BaseActionOperator, main
 from bos.operators.filters import TimeSinceLastAction
 from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
 
-class ForcefulPowerOffOperator(BaseOperator):
+class ForcefulPowerOffOperator(BaseActionOperator):
     """
     The Forceful Power-Off Operator tells pcs to power-off nodes if:
     - Enabled in the BOS database and the status is power_off_gracefully of power_off_forcefully
     - Enabled in HSM
     """
 
+    action = Action.power_off_forcefully
     retry_attempt_field = "power_off_forceful_attempts"
-
-    @property
-    def name(self) -> str:
-        return Action.power_off_forcefully
 
     # Filters
     @property

--- a/src/bos/operators/power_off_graceful.py
+++ b/src/bos/operators/power_off_graceful.py
@@ -31,23 +31,20 @@ import logging
 
 from bos.common.types.components import ComponentRecord
 from bos.common.values import Action, Status
-from bos.operators.base import BaseOperator, main
+from bos.operators.base import BaseActionOperator, main
 from bos.operators.filters.base import BaseFilter
 
 LOGGER = logging.getLogger(__name__)
 
 
-class GracefulPowerOffOperator(BaseOperator):
+class GracefulPowerOffOperator(BaseActionOperator):
     """
     - Enabled in the BOS database and the status is power_off_pending
     - Enabled in HSM
     """
 
+    action = Action.power_off_gracefully
     retry_attempt_field = "power_off_graceful_attempts"
-
-    @property
-    def name(self) -> str:
-        return Action.power_off_gracefully
 
     # Filters
     @property

--- a/src/bos/operators/power_on.py
+++ b/src/bos/operators/power_on.py
@@ -39,7 +39,7 @@ from bos.common.utils import (exc_type_msg,
                               using_sbps_check_kernel_parameters,
                               components_by_id)
 from bos.common.values import Action, Status
-from bos.operators.base import BaseOperator, main
+from bos.operators.base import BaseActionOperator, main
 from bos.operators.filters.base import BaseFilter
 from bos.server.dbs.boot_artifacts import record_boot_artifacts
 
@@ -49,18 +49,15 @@ LOGGER = logging.getLogger(__name__)
 type BootArtifactsTuple = tuple[str, str, str]
 type BootArtifactsToCompIds = defaultdict[BootArtifactsTuple, set[str]]
 
-class PowerOnOperator(BaseOperator):
+class PowerOnOperator(BaseActionOperator):
     """
     The Power-On Operator tells pcs to power-on nodes if:
     - Enabled in the BOS database and the status is power_on_pending
     - Enabled in HSM
     """
 
+    action = Action.power_on
     retry_attempt_field = "power_on_attempts"
-
-    @property
-    def name(self) -> str:
-        return Action.power_on
 
     # Filters
     @property

--- a/src/bos/operators/session_cleanup.py
+++ b/src/bos/operators/session_cleanup.py
@@ -45,10 +45,6 @@ class SessionCleanupOperator(BaseOperator):
     """
 
     @property
-    def name(self) -> str:
-        return 'SessionCleanup'
-
-    @property
     def disabled(self) -> bool:
         """
         When users set the cleanup time to 0, no cleanup behavior is desired.

--- a/src/bos/operators/session_completion.py
+++ b/src/bos/operators/session_completion.py
@@ -45,10 +45,6 @@ class SessionCompletionOperator(BaseOperator):
     that are part of the session have been disabled.
     """
 
-    @property
-    def name(self) -> str:
-        return 'SessionCompletion'
-
     # This operator overrides _run and does not use "filters" or "_act", but they are defined here
     # because they are abstract methods in the base class and must be implemented.
     @property

--- a/src/bos/operators/status.py
+++ b/src/bos/operators/status.py
@@ -90,11 +90,6 @@ class StatusOperator(BaseOperator):
         return self.DesiredConfigurationSetInCFS().component_match(component=component,
                                                                    cfs_component=cfs_component)
 
-    @property
-    def name(self) -> Literal[""]:
-        """ Unused for the status operator """
-        return ''
-
     # This operator overrides _run and does not use "filters" or "_act", but they are defined here
     # because they are abstract methods in the base class and must be implemented.
     @property

--- a/src/bos/server/controllers/v2/sessions.py
+++ b/src/bos/server/controllers/v2/sessions.py
@@ -34,7 +34,7 @@ from connexion.lifecycle import ConnexionResponse as CxResponse
 
 from bos.common.tenant_utils import (get_tenant_from_header,
                                      reject_invalid_tenant)
-from bos.common.types.components import ComponentRecord, ComponentStatus
+from bos.common.types.components import ComponentPhaseStr, ComponentRecord, ComponentStatus
 from bos.common.types.session_extended_status import (SessionExtendedStatus,
                                                       SessionExtendedStatusErrorComponents,
                                                       SessionExtendedStatusPhases,
@@ -409,6 +409,7 @@ def _matches_filter(data: SessionRecordT, tenant: str | None, min_start: datetim
             return None
     return data
 
+type _CompPhaseCounter = Counter[ComponentPhaseStr|None|Literal['failed', 'staged', 'successful']]
 
 def _get_v2_session_status(session_id: str, tenant_id: str | None,
                            session: SessionRecordT) -> SessionExtendedStatus:
@@ -417,7 +418,7 @@ def _get_v2_session_status(session_id: str, tenant_id: str | None,
                                                tenant=tenant_id)
     num_managed_components = len(components) + len(staged_components)
     if num_managed_components:
-        component_phase_counts = Counter([
+        component_phase_counts: _CompPhaseCounter = Counter([
             c.get('status', cast(ComponentStatus, {})).get('phase') for c in components
             if _component_enabled_and_not_on_hold(c)
         ])


### PR DESCRIPTION
BOS component fields `phase` and `action` both have a specific set of possible values, but the API spec currently just defines them as general string values. This means that someone could accidentally (or maliciously) do a component patch operation and set either of these fields to a value that BOS has no understanding of, and that we never test. There is no upside to this flexibility in the spec.

This PR modifies the API spec to define enumerations for each of these fields. It then modifies the server code accordingly, to ensure that those fields always contain those values.

I also did a refactoring of the operator classes, since they currently awkwardly use the `name` property to actually mean "new action field value", and also use it as a kind of boolean test for whether an operator updates that field when patching components. This PR instead explicitly makes an additional operator base class for those operators which do that kind of update. Those operators now inherit from that other base class. The `name` property is removed, because it was only being used for this purpose.

I tested these changes on mug, including using the updated `cmsdev` test tool with @kumarrahul04 's latest BOS additions.