### PR TITLE
CASMCMS-9432: Update API spec examples to use SBPS instead of CPS/DVS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve performance of BOS component queries that specify IDs or a tenant
+- CASMCMS-9432: Update API spec examples to use SBPS instead of CPS/DVS
 
 ## [2.44.1] - 2025-05-19
 

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -155,7 +155,7 @@ components:
     BootSetRootfsProvider:
       type: string
       description: The root file system provider.
-      example: "cpss3"
+      example: "sbps"
       minLength: 1
       maxLength: 511
     BootSetRootfsProviderPassthrough:
@@ -164,7 +164,7 @@ components:
         The root file system provider passthrough.
         These are additional kernel parameters that will be appended to
         the 'rootfs=<protocol>' kernel parameter
-      example: "dvs:api-gw-service-nmn.local:300:nmn0"
+      example: "sbps:v1:iqn.2023-06.csm.iscsi:_sbps-hsn._tcp.my-system.my-site-domain:300"
       maxLength: 4096
     BootSetType:
       type: string


### PR DESCRIPTION
CPS/DVS are removed in CSM 1.7, replaced by SBPS. This PR updates the BOS API spec to change the CPS/DVS examples to instead use SBPS. This only modifies example values in the spec -- it has no impact on the service at runtime.

The values were taken from the example values used on [the SBPS setup page in docs-csm](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/boot_orchestration/Create_a_Session_Template_to_Boot_Compute_Nodes_with_SBPS.md)