### PR TITLE
CASMCMS-9433: Update sessiontemplatetemplate endpoint to use SBPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve performance of BOS component queries that specify IDs or a tenant
 - CASMCMS-9432: Update API spec examples to use SBPS instead of CPS/DVS
+- CASMCMS-9433: Update `sessiontemplatetemplate` endpoint to use SBPS instead of CPS/DVS
 
 ## [2.44.1] - 2025-05-19
 

--- a/src/bos/server/controllers/v2/sessiontemplates.py
+++ b/src/bos/server/controllers/v2/sessiontemplates.py
@@ -53,8 +53,8 @@ EXAMPLE_BOOT_SET = BootSet(
     cfs=SessionTemplateCfsParameters(configuration="bootset-specific-cfs-override"),
     node_list=["xname1", "xname2", "xname3"],
     path="s3://boot-images/boot-image-ims-id/manifest.json",
-    rootfs_provider="cpss3",
-    rootfs_provider_passthrough="dvs:api-gw-service-nmn.local:300:hsn0,nmn0:0",
+    rootfs_provider="sbps",
+    rootfs_provider_passthrough="sbps:v1:iqn.2023-06.csm.iscsi:_sbps-hsn._tcp.my-system.my-site-domain:300",
 )
 
 EXAMPLE_SESSION_TEMPLATE = SessionTemplate(


### PR DESCRIPTION
CPS/DVS are removed in CSM 1.7. The example session template returned by the `sessiontemplatetemplate` endpoint specifies CPS/DVS in its boot set. This PR updates the example data it returns so that it uses SBPS instead. The values were taken from the example values used on [the SBPS setup page in docs-csm](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/boot_orchestration/Create_a_Session_Template_to_Boot_Compute_Nodes_with_SBPS.md)