### PR TITLE
CASMCMS-8843: Remove locked HSM nodes when starting session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-8843: Filter out locked nodes when starting a session; improve logging around node lists in same
+
 ## [2.46.1] - 2025-06-06
 
 ### Dependencies

--- a/src/bos/common/clients/hsm/client.py
+++ b/src/bos/common/clients/hsm/client.py
@@ -26,12 +26,14 @@ from dataclasses import dataclass
 from bos.common.clients.api_client_with_timeout_option import APIClientWithTimeoutOption
 
 from .groups import GroupsEndpoint
+from .locks import LocksEndpoint
 from .partitions import PartitionsEndpoint
 from .state_components import StateComponentsEndpoint
 
 @dataclass
 class HsmEndpoints:
     groups: GroupsEndpoint | None = None
+    locks: LocksEndpoint | None = None
     partitions: PartitionsEndpoint | None = None
     state_components: StateComponentsEndpoint | None = None
 
@@ -49,6 +51,12 @@ class HSMClient(APIClientWithTimeoutOption[HsmEndpoints]):
         if self._endpoints.groups is None:
             self._endpoints.groups = GroupsEndpoint(self.requests_session)
         return self._endpoints.groups
+
+    @property
+    def locks(self) -> LocksEndpoint:
+        if self._endpoints.locks is None:
+            self._endpoints.locks = LocksEndpoint(self.requests_session)
+        return self._endpoints.locks
 
     @property
     def partitions(self) -> PartitionsEndpoint:

--- a/src/bos/common/clients/hsm/locks.py
+++ b/src/bos/common/clients/hsm/locks.py
@@ -1,0 +1,61 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from typing import Literal, TypedDict
+
+from .base import BaseHsmEndpoint
+from .types import LocksComponentsDataArray
+
+
+class LocksGetListParams(TypedDict, total=True):
+    """
+    Other params are supported in the API spec, but we only define here the ones we care about
+    """
+    # Other types are supported, but we always query for Nodes
+    type: Literal['Node']
+    # Similarly, we always query for locked nodes
+    locked: Literal[True]
+
+
+def _locks_get_list_params() -> LocksGetListParams:
+    """
+    Return the parameters we use when listing locked nodes
+    """
+    return LocksGetListParams(type="Node", locked=True)
+
+
+class LocksEndpoint(BaseHsmEndpoint[LocksGetListParams, LocksComponentsDataArray]):
+    ENDPOINT = 'locks/status'
+
+    def get_locked_nodes(self) -> set[str]:
+        """
+        Returns the set of xname strings of all locked nodes
+        """
+        lock_comps_data_array = self.get_list(params=_locks_get_list_params())
+
+        try:
+            components = lock_comps_data_array["Components"]
+        except KeyError:
+            return set()
+        return { component["ID"] for component in components if "ID" in component }

--- a/src/bos/common/clients/hsm/types.py
+++ b/src/bos/common/clients/hsm/types.py
@@ -84,3 +84,27 @@ class StateComponentsDataArray(TypedDict, total=False):
     '#/definitions/ComponentArray_ComponentArray'
     """
     Components: list[StateComponentData]
+
+
+class ComponentStatus(TypedDict, total=False):
+    """
+    https://github.com/Cray-HPE/hms-smd/blob/master/api/swagger_v2.yaml
+    '#/definitions/ComponentStatus.1.0.0'
+    """
+    ID: str
+    Locked: bool
+    Reserved: bool
+    CreatedTime: str
+    ExpirationTime: str
+    ReservationDisabled: bool
+
+
+class LocksComponentsDataArray(TypedDict, total=False):
+    """
+    https://github.com/Cray-HPE/hms-smd/blob/master/api/swagger_v2.yaml
+    '#/definitions/AdminStatusCheck_Response.1.0.0'
+    """
+    Components: list[ComponentStatus]
+    # The way that BOS queries for locks, this field should never actually be used, since it never
+    # queries for specific xnames
+    NotFound: list[str]

--- a/src/bos/operators/filters/filters.py
+++ b/src/bos/operators/filters/filters.py
@@ -133,6 +133,12 @@ class HSMState(IDFilter):
             if component.get('Arch', 'Unknown') in arch
         ]
 
+    def filter_for_unlocked(self, nodes: set[str]) -> set[str]:
+        """
+        Query HSM for the list of locked nodes, and return all specified nodes that are not locked
+        """
+        return nodes - self.hsm_client.locks.get_locked_nodes()
+
 
 class TimeSinceLastAction(LocalFilter):
     """ Returns all components whose last actions was over some time ago """


### PR DESCRIPTION
Add code to remove nodes that are locked in HSM when creating a BOS session, to make it more obvious when this is done. I tested this on mug.

I also slightly changed the order in which nodes are filtered during session setup, to try to whittle down the list before making API calls that specify the node list (to try and keep such calls smaller).