### PR TITLE
CASMCMS-8131: Removed disable_components_on_completion option due to lack of use and lack of testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- CASMCMS-8131: Removed `disable_components_on_completion` option due to lack of use and lack of testing.
+
 ## [2.47.0] - 2025-06-11
 
 ### Changed

--- a/api/openapi.yaml.in
+++ b/api/openapi.yaml.in
@@ -1024,11 +1024,6 @@ components:
           example: 1
           minimum: 0
           maximum: 1048576
-        disable_components_on_completion:
-          type: boolean
-          description: |
-            If true, when a Session has brought a Component to its desired state, that Component will be marked as disabled in BOS.
-            If false, BOS will continue to maintain the state of the nodes declaratively, even after a Session finishes.
         discovery_frequency:
           type: integer
           description: How frequently the BOS discovery agent syncs new Components from HSM (in seconds)

--- a/src/bos/common/options.py
+++ b/src/bos/common/options.py
@@ -43,7 +43,6 @@ DEFAULTS: OptionsDict = {
     'clear_stage': False,
     'component_actual_state_ttl': "4h",
     'default_retry_policy': 3,
-    'disable_components_on_completion': True,
     'discovery_frequency': 300,
     'hsm_read_timeout': 20,
     'ims_errors_fatal': False,
@@ -99,10 +98,6 @@ class BaseOptions(ABC):
     @property
     def default_retry_policy(self) -> int:
         return int(self.get_option('default_retry_policy'))
-
-    @property
-    def disable_components_on_completion(self) -> bool:
-        return bool(self.get_option('disable_components_on_completion'))
 
     @property
     def discovery_frequency(self) -> int:

--- a/src/bos/common/types/options.py
+++ b/src/bos/common/types/options.py
@@ -41,7 +41,6 @@ OptionName = Literal[
     'clear_stage',
     'component_actual_state_ttl',
     'default_retry_policy',
-    'disable_components_on_completion',
     'discovery_frequency',
     'hsm_read_timeout',
     'ims_errors_fatal',
@@ -80,7 +79,6 @@ class OptionsDict(TypedDict, total=False):
     clear_stage: bool
     component_actual_state_ttl: str
     default_retry_policy: int
-    disable_components_on_completion: bool
     discovery_frequency: int
     hsm_read_timeout: int
     ims_errors_fatal: bool

--- a/src/bos/operators/status.py
+++ b/src/bos/operators/status.py
@@ -280,7 +280,7 @@ def _updated_component(comp: ComponentRecord, new_status: _StatusData) -> Compon
     update = _check_phase(new_status.phase, comp, updated_component)
     if new_status.override != comp.get('status', ComponentStatus()).get('status_override', ''):
         update = True
-    if new_status.disable and options.disable_components_on_completion:
+    if new_status.disable:
         updated_component['enabled'] = False
         update = True
     if new_status.error and new_status.error != comp.get('error', ''):


### PR DESCRIPTION
This removes the `disable_components_on_completion` option from the code and from the spec file. It changes the single place in the code where it is used, so it follows the behavior it would have if the option was set to true (the default before).

I'll also have follow-on PRs to docs and craycli.